### PR TITLE
Code Standards Enforcement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,184 @@
+# editorconfig.org
+
+# top-most EditorConfig file
 root = true
 
-end_of_line=crlf
-
-[*.{cs,vb}]
-indent_size = 4
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
 indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:refactoring
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:refactoring
+csharp_style_expression_bodied_constructors = true:refactoring
+csharp_style_expression_bodied_operators = true:refactoring
+csharp_style_expression_bodied_properties = true:refactoring
+csharp_style_expression_bodied_indexers = true:refactoring
+csharp_style_expression_bodied_accessors = true:refactoring
+csharp_style_expression_bodied_lambdas = true:refactoring
+csharp_style_expression_bodied_local_functions = true:refactoring
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
@@ -1,8 +1,9 @@
-﻿using MonoPoint = Microsoft.Xna.Framework.Point;
+﻿using System;
+using SadRogue.Primitives;
+using MonoPoint = Microsoft.Xna.Framework.Point;
 using SadRoguePoint = SadRogue.Primitives.Point;
-using System;
 
-namespace System.Numerics.Grid
+namespace SadRogue.Primitives
 {
     public static class SadRoguePointExtensions
     {
@@ -13,7 +14,7 @@ namespace System.Numerics.Grid
 
         public static SadRoguePoint Multiply(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
         public static SadRoguePoint Divide(this SadRoguePoint self, MonoPoint other)
-            => new SadRoguePoint((int)Math.Round(self. X / (double)other.X,MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         public static bool Equals(this SadRoguePoint self, MonoPoint other) => self.X == other.X && self.Y == other.Y;
     }
@@ -21,7 +22,6 @@ namespace System.Numerics.Grid
 
 namespace Microsoft.Xna.Framework
 {
-    using SadRogue.Primitives;
     public static class MonoPointExtensions
     {
         public static SadRoguePoint ToPoint(this MonoPoint self) => new SadRoguePoint(self.X, self.Y);

--- a/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using MonoRectangle = Microsoft.Xna.Framework.Rectangle;
 using SadRogueRectangle = SadRogue.Primitives.Rectangle;
 
-namespace System.Numerics.Grid
+namespace SadRogue.Primitives
 {
     public static class RectangleExtensions
     {

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using SadRogue.Primitives;
 using Xunit;
 using XUnit.ValueTuples;
-using SadRogue.Primitives;
-using System.Collections.Generic;
 
 namespace TheSadRogue.Primitives.UnitTests
 {
@@ -14,82 +14,80 @@ namespace TheSadRogue.Primitives.UnitTests
     public class DirectionTests
     {
         #region TestData
-        static public Direction[] ValidDirections = AdjacencyRule.EIGHT_WAY.DirectionsOfNeighborsClockwise().ToArray();
-        static public Direction[] AllDirections => ValidDirections.Append(Direction.NONE).ToArray();
-        static public Point[] TestPoints => new[] { new Point(1, 2), new Point(0, 0), new Point(-2, -5) };
-        static public IEnumerable<(Point, Direction)> CoordDirPairs => TestPoints.Combinate(AllDirections);
+        public static Direction[] ValidDirections = AdjacencyRule.EightWay.DirectionsOfNeighborsClockwise().ToArray();
+        public static Direction[] AllDirections => ValidDirections.Append(Direction.None).ToArray();
+        public static Point[] TestPoints => new[] { new Point(1, 2), new Point(0, 0), new Point(-2, -5) };
+        public static IEnumerable<(Point, Direction)> CoordDirPairs => TestPoints.Combinate(AllDirections);
 
-        static public IEnumerable<(Direction, int)> AddSubDirPairs => ValidDirections.Combinate(Enumerable.Range(0, 11));
+        public static IEnumerable<(Direction, int)> AddSubDirPairs => ValidDirections.Combinate(Enumerable.Range(0, 11));
 
-        static public IEnumerable<(Point, Point, Direction)> GetDirectionBasePairs =>
+        public static IEnumerable<(Point, Point, Direction)> GetDirectionBasePairs =>
             new (Point p1, Point p2, Direction d)[] {
-            ((0, 0), (0, 0), Direction.NONE),
-            ((0, 0), (0, 0) + Direction.UP, Direction.UP),
-            ((0, 0), (0, 0) + Direction.UP_RIGHT, Direction.UP_RIGHT),
-            ((0, 0), (0, 0) + Direction.RIGHT, Direction.RIGHT),
-            ((0, 0), (0, 0) + Direction.DOWN_RIGHT, Direction.DOWN_RIGHT),
-            ((0, 0), (0, 0) + Direction.DOWN, Direction.DOWN),
-            ((0, 0), (0, 0) + Direction.DOWN_LEFT, Direction.DOWN_LEFT),
-            ((0, 0), (0, 0) + Direction.LEFT, Direction.LEFT),
-            ((0, 0), (0, 0) + Direction.UP_LEFT, Direction.UP_LEFT)
+            ((0, 0), (0, 0), Direction.None),
+            ((0, 0), (0, 0) + Direction.Up, Direction.Up),
+            ((0, 0), (0, 0) + Direction.UpRight, Direction.UpRight),
+            ((0, 0), (0, 0) + Direction.Right, Direction.Right),
+            ((0, 0), (0, 0) + Direction.DownRight, Direction.DownRight),
+            ((0, 0), (0, 0) + Direction.Down, Direction.Down),
+            ((0, 0), (0, 0) + Direction.DownLeft, Direction.DownLeft),
+            ((0, 0), (0, 0) + Direction.Left, Direction.Left),
+            ((0, 0), (0, 0) + Direction.UpLeft, Direction.UpLeft)
         };
 
-        static public IEnumerable<(Point, Point, Direction)> GetCardinalDirectionBasePairs =>
+        public static IEnumerable<(Point, Point, Direction)> GetCardinalDirectionBasePairs =>
             new (Point p1, Point p2, Direction d)[] {
-            ((0, 0), (0, 0), Direction.NONE),
-            ((0, 0), (0, 0) + Direction.UP, Direction.UP),
-            ((0, 0), (0, 0) + Direction.UP_RIGHT, Direction.RIGHT),
-            ((0, 0), (0, 0) + Direction.RIGHT, Direction.RIGHT),
-            ((0, 0), (0, 0) + Direction.DOWN_RIGHT, Direction.DOWN),
-            ((0, 0), (0, 0) + Direction.DOWN, Direction.DOWN),
-            ((0, 0), (0, 0) + Direction.DOWN_LEFT, Direction.LEFT),
-            ((0, 0), (0, 0) + Direction.LEFT, Direction.LEFT),
-            ((0, 0), (0, 0) + Direction.UP_LEFT, Direction.UP)
+            ((0, 0), (0, 0), Direction.None),
+            ((0, 0), (0, 0) + Direction.Up, Direction.Up),
+            ((0, 0), (0, 0) + Direction.UpRight, Direction.Right),
+            ((0, 0), (0, 0) + Direction.Right, Direction.Right),
+            ((0, 0), (0, 0) + Direction.DownRight, Direction.Down),
+            ((0, 0), (0, 0) + Direction.Down, Direction.Down),
+            ((0, 0), (0, 0) + Direction.DownLeft, Direction.Left),
+            ((0, 0), (0, 0) + Direction.Left, Direction.Left),
+            ((0, 0), (0, 0) + Direction.UpLeft, Direction.Up)
         };
 
-        static public IEnumerable<(Point, Point, Direction)> GetDirectionPairs
+        public static IEnumerable<(Point, Point, Direction)> GetDirectionPairs
             => GetDirectionBasePairs.Concat(GetDirectionBasePairs.Select(i => (i.Item1 + 5, i.Item2 + 5, i.Item3)));
 
-        static public IEnumerable<(Point, Point, Direction)> GetCardinalDirectionPairs
+        public static IEnumerable<(Point, Point, Direction)> GetCardinalDirectionPairs
             => GetCardinalDirectionBasePairs.Concat(GetCardinalDirectionBasePairs.Select(i => (i.Item1 + 5, i.Item2 + 5, i.Item3)));
 
-        static public IEnumerable<(Direction.Types, Direction)> TypeDirectionConversion => TestUtils.Enumerable(
-            (Direction.Types.NONE, Direction.NONE),
-            (Direction.Types.UP, Direction.UP),
-            (Direction.Types.UP_RIGHT, Direction.UP_RIGHT),
-            (Direction.Types.RIGHT, Direction.RIGHT),
-            (Direction.Types.DOWN_RIGHT, Direction.DOWN_RIGHT),
-            (Direction.Types.DOWN, Direction.DOWN),
-            (Direction.Types.DOWN_LEFT, Direction.DOWN_LEFT),
-            (Direction.Types.LEFT, Direction.LEFT),
-            (Direction.Types.UP_LEFT, Direction.UP_LEFT)
+        public static IEnumerable<(Direction.Types, Direction)> TypeDirectionConversion => TestUtils.Enumerable(
+            (Direction.Types.None, Direction.None),
+            (Direction.Types.Up, Direction.Up),
+            (Direction.Types.UpRight, Direction.UpRight),
+            (Direction.Types.Right, Direction.Right),
+            (Direction.Types.DownRight, Direction.DownRight),
+            (Direction.Types.Down, Direction.Down),
+            (Direction.Types.DownLeft, Direction.DownLeft),
+            (Direction.Types.Left, Direction.Left),
+            (Direction.Types.UpLeft, Direction.UpLeft)
         );
 
-        static public IEnumerable<(Direction, Point, Point)> YIncreasesDeltaValues => TestUtils.Enumerable<(Direction, Point, Point)>(
-            (Direction.NONE, (0, 0), (0, 0)),
-            (Direction.UP, (0, -1), (0, 1)),
-            (Direction.UP_RIGHT, (1, -1), (1, 1)),
-            (Direction.RIGHT, (1, 0), (1, 0)),
-            (Direction.DOWN_RIGHT, (1, 1), (1, -1)),
-            (Direction.DOWN, (0, 1), (0, -1)),
-            (Direction.DOWN_LEFT, (-1, 1), (-1, -1)),
-            (Direction.LEFT, (-1, 0), (-1, 0)),
-            (Direction.UP_LEFT, (-1, -1), (-1, 1))
+        public static IEnumerable<(Direction, Point, Point)> YIncreasesDeltaValues => TestUtils.Enumerable<(Direction, Point, Point)>(
+            (Direction.None, (0, 0), (0, 0)),
+            (Direction.Up, (0, -1), (0, 1)),
+            (Direction.UpRight, (1, -1), (1, 1)),
+            (Direction.Right, (1, 0), (1, 0)),
+            (Direction.DownRight, (1, 1), (1, -1)),
+            (Direction.Down, (0, 1), (0, -1)),
+            (Direction.DownLeft, (-1, 1), (-1, -1)),
+            (Direction.Left, (-1, 0), (-1, 0)),
+            (Direction.UpLeft, (-1, -1), (-1, 1))
         );
 
-        static public IEnumerable<(Direction, bool)> IsCardinalPairs
-            => AdjacencyRule.CARDINALS.DirectionsOfNeighbors().Combinate(true.ToEnumerable())
-            .Concat(AdjacencyRule.DIAGONALS.DirectionsOfNeighbors().Combinate(false.ToEnumerable()))
-            .Append((Direction.NONE, false));
+        public static IEnumerable<(Direction, bool)> IsCardinalPairs
+            => AdjacencyRule.Cardinals.DirectionsOfNeighbors().Combinate(true.ToEnumerable())
+            .Concat(AdjacencyRule.Diagonals.DirectionsOfNeighbors().Combinate(false.ToEnumerable()))
+            .Append((Direction.None, false));
         #endregion
 
 
         [Fact]
-        public void NoneIsDefault()
-        {
+        public void NoneIsDefault() =>
             // This must be the case for optional Direction parameters as currently implemented in the library to function properly.
-            Assert.Equal(default, Direction.NONE);
-        }
+            Assert.Equal(default, Direction.None);
 
         #region Equality/Inequality
         [Theory]
@@ -98,7 +96,7 @@ namespace TheSadRogue.Primitives.UnitTests
         {
             Direction compareTo = dir;
             Assert.True(dir == compareTo);
-            Assert.False(dir == Direction.NONE);
+            Assert.False(dir == Direction.None);
 
             for (int i = 0; i < 7; i++)
             {
@@ -106,14 +104,16 @@ namespace TheSadRogue.Primitives.UnitTests
                 Assert.False(dir == compareTo);
             }
         }
-        
+
         [Fact]
         public void TestInvalidEquality()
         {
-            Direction none = Direction.NONE;
-            Assert.True(none == Direction.NONE);
-            foreach (var i in ValidDirections)
-                Assert.False(Direction.NONE == i);
+            Direction none = Direction.None;
+            Assert.True(none == Direction.None);
+            foreach (Direction i in ValidDirections)
+            {
+                Assert.False(Direction.None == i);
+            }
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace TheSadRogue.Primitives.UnitTests
         {
             Direction compareTo = dir;
             Assert.False(dir != compareTo);
-            Assert.True(dir != Direction.NONE);
+            Assert.True(dir != Direction.None);
 
             for (int i = 0; i < 7; i++)
             {
@@ -134,28 +134,32 @@ namespace TheSadRogue.Primitives.UnitTests
         [Fact]
         public void TestInvalidInequality()
         {
-            Direction none = Direction.NONE;
-            Assert.False(none != Direction.NONE);
-            foreach (var i in ValidDirections)
-                Assert.True(Direction.NONE != i);
+            Direction none = Direction.None;
+            Assert.False(none != Direction.None);
+            foreach (Direction i in ValidDirections)
+            {
+                Assert.True(Direction.None != i);
+            }
         }
 
         [Theory]
         [MemberDataEnumerable(nameof(AllDirections))]
         public void TestEqualityInqeualityOpposite(Direction compareDir)
         {
-            var dirs = AllDirections;
+            Direction[] dirs = AllDirections;
 
-            foreach (var dir in dirs)
+            foreach (Direction dir in dirs)
+            {
                 Assert.NotEqual(dir == compareDir, dir != compareDir);
+            }
         }
         [Theory]
         [MemberDataEnumerable(nameof(AllDirections))]
         public void TestEqualityEquivalence(Direction compareDir)
         {
-            var dirs = AllDirections;
+            Direction[] dirs = AllDirections;
 
-            foreach (var dir in dirs)
+            foreach (Direction dir in dirs)
             {
                 Assert.Equal(dir == compareDir, dir.Equals(compareDir));
                 Assert.Equal(dir == compareDir, dir.Equals((object)compareDir));
@@ -177,7 +181,7 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataTuple(nameof(AddSubDirPairs))]
         public void AddToDirection(Direction dir, int value)
         {
-            var dirs = ValidDirections;
+            Direction[] dirs = ValidDirections;
 
             int start = Array.FindIndex(dirs, x => x == dir);
             Assert.False(start == -1, "Could not find direction in valid directions list.");
@@ -190,7 +194,7 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataTuple(nameof(AddSubDirPairs))]
         public void SubFromDirection(Direction dir, int value)
         {
-            var dirs = ValidDirections;
+            Direction[] dirs = ValidDirections;
 
             int start = Array.FindIndex(dirs, x => x == dir);
             Assert.False(start == -1, "Could not find direction in valid directions list.");
@@ -198,7 +202,9 @@ namespace TheSadRogue.Primitives.UnitTests
             Direction res = dir - value;
             int index = start - (Math.Abs(value) % dirs.Length);
             if (index < 0)
+            {
                 index = dirs.Length + index;
+            }
 
             Assert.Equal(dirs[index], res);
         }
@@ -208,7 +214,7 @@ namespace TheSadRogue.Primitives.UnitTests
         public void IncrementValidDirection(Direction startingDir)
         {
             Direction oldDir = startingDir;
-            var dirs = ValidDirections;
+            Direction[] dirs = ValidDirections;
             int start = Array.FindIndex(dirs, x => x == startingDir);
             Assert.False(start == -1, "Couldn't find starting direction in directions.");
 
@@ -226,7 +232,7 @@ namespace TheSadRogue.Primitives.UnitTests
         public void DecrementValidDirection(Direction startingDir)
         {
             Direction oldDir = startingDir;
-            var dirs = ValidDirections;
+            Direction[] dirs = ValidDirections;
             int start = Array.FindIndex(dirs, x => x == startingDir);
             Assert.False(start == -1, "Couldn't find starting direction in directions.");
 
@@ -235,7 +241,9 @@ namespace TheSadRogue.Primitives.UnitTests
                 startingDir--;
                 int index = start - i;
                 if (index < 0)
+                {
                     index = dirs.Length + index;
+                }
 
                 Assert.Equal(dirs[index], startingDir);
             }
@@ -301,7 +309,7 @@ namespace TheSadRogue.Primitives.UnitTests
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
             (Point p1, Point p2, Direction expectedDir)[] testCases = GetDirectionPairs.ToArray();
 
-            foreach (var testCase in testCases)
+            foreach ((Point p1, Point p2, Direction expectedDir) testCase in testCases)
             {
                 Direction dir = Direction.GetDirection(testCase.p1, testCase.p2);
                 Assert.Equal(testCase.expectedDir, dir);
@@ -311,7 +319,7 @@ namespace TheSadRogue.Primitives.UnitTests
             // the YIncreasesUpwards flag, everything should still match up if we're accounting for the y-deltas properly.
             Direction.SetYIncreasesUpwardsUnsafe(true);
             testCases = GetDirectionPairs.ToArray();
-            foreach (var testCase in testCases)
+            foreach ((Point p1, Point p2, Direction expectedDir) testCase in testCases)
             {
                 Direction dir = Direction.GetDirection(testCase.p1, testCase.p2);
                 Assert.Equal(testCase.expectedDir, dir);
@@ -326,7 +334,7 @@ namespace TheSadRogue.Primitives.UnitTests
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
             (Point p1, Point p2, Direction expectedDir)[] testCases = GetDirectionPairs.ToArray();
 
-            foreach (var testCase in testCases)
+            foreach ((Point p1, Point p2, Direction expectedDir) testCase in testCases)
             {
                 Point delta = testCase.p2 - testCase.p1;
                 Direction dir = Direction.GetDirection(delta);
@@ -340,7 +348,7 @@ namespace TheSadRogue.Primitives.UnitTests
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
             (Point p1, Point p2, Direction expectedDir)[] testCases = GetCardinalDirectionPairs.ToArray();
 
-            foreach (var testCase in testCases)
+            foreach ((Point p1, Point p2, Direction expectedDir) testCase in testCases)
             {
                 Direction dir = Direction.GetCardinalDirection(testCase.p1, testCase.p2);
                 Assert.Equal(testCase.expectedDir, dir);
@@ -350,7 +358,7 @@ namespace TheSadRogue.Primitives.UnitTests
             // the YIncreasesUpwards flag, everything should still match up if we're accounting for the y-deltas properly.
             Direction.SetYIncreasesUpwardsUnsafe(true);
             testCases = GetCardinalDirectionPairs.ToArray();
-            foreach (var testCase in testCases)
+            foreach ((Point p1, Point p2, Direction expectedDir) testCase in testCases)
             {
                 Direction dir = Direction.GetCardinalDirection(testCase.p1, testCase.p2);
                 Assert.Equal(testCase.expectedDir, dir);
@@ -365,7 +373,7 @@ namespace TheSadRogue.Primitives.UnitTests
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
             (Point p1, Point p2, Direction expectedDir)[] testCases = GetCardinalDirectionPairs.ToArray();
 
-            foreach (var testCase in testCases)
+            foreach ((Point p1, Point p2, Direction expectedDir) testCase in testCases)
             {
                 Point delta = testCase.p2 - testCase.p1;
                 Direction dir = Direction.GetCardinalDirection(delta);
@@ -376,9 +384,6 @@ namespace TheSadRogue.Primitives.UnitTests
 
         [Theory]
         [MemberDataTuple(nameof(IsCardinalPairs))]
-        public void IsCardinal(Direction dir, bool expected)
-        {
-            Assert.Equal(expected, dir.IsCardinal());
-        }
+        public void IsCardinal(Direction dir, bool expected) => Assert.Equal(expected, dir.IsCardinal());
     }
 }

--- a/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
+++ b/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
@@ -1,69 +1,77 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using Xunit;
-using Xunit.Sdk;
 
 namespace TheSadRogue.Primitives.UnitTests
 {
-	/// <summary>
-	/// Static/extension methods to help with creating test variables/enumerables for XUnit
-	/// </summary>
-	public static class TestUtils
-	{
-		public static IEnumerable<T> ToEnumerable<T>(this T obj)
-		{
-			yield return obj;
-		}
+    /// <summary>
+    /// Static/extension methods to help with creating test variables/enumerables for XUnit
+    /// </summary>
+    public static class TestUtils
+    {
+        public static IEnumerable<T> ToEnumerable<T>(this T obj)
+        {
+            yield return obj;
+        }
 
-		public static ValueTuple<T> ToValueTuple<T>(this T obj) => new ValueTuple<T>(obj);
+        public static IEnumerable<(T1, T2)> Combinate<T1, T2>(this IEnumerable<T1> l1, IEnumerable<T2> l2)
+        {
+            foreach (T1 x in l1)
+            {
+                foreach (T2 y in l2)
+                {
+                    yield return (x, y);
+                }
+            }
+        }
 
-		public static IEnumerable<ValueTuple<T>> ToValueTuples<T>(this IEnumerable<T> objs) => objs.Select(i => i.ToValueTuple());
+        public static IEnumerable<(T1, T2, T3)> Combinate<T1, T2, T3>(this IEnumerable<(T1 i1, T2 i2)> tuples, IEnumerable<T3> l2)
+        {
+            foreach ((T1 i1, T2 i2) in tuples)
+            {
+                foreach (T3 y in l2)
+                {
+                    yield return (i1, i2, y);
+                }
+            }
+        }
 
-		public static IEnumerable<(T1, T2)> Combinate<T1, T2>(this IEnumerable<T1> l1, IEnumerable<T2> l2)
-		{
-			foreach (var x in l1)
-				foreach (var y in l2)
-					yield return (x, y);
-		}
+        public static void AssertElementEquals<T>(params IReadOnlyList<T>[] lists)
+        {
+            IReadOnlyList<T> list1 = lists[0];
+            int length = list1.Count;
+            foreach (IReadOnlyList<T> list in lists.Skip(1))
+            {
+                Assert.Equal(length, list.Count);
+            }
 
-		public static IEnumerable<(T1, T2, T3)> Combinate<T1, T2, T3>(this IEnumerable<(T1 i1, T2 i2)> tuples, IEnumerable<T3> l2)
-		{
-			foreach (var (i1, i2) in tuples)
-				foreach (var y in l2)
-					yield return (i1, i2, y);
-		}
+            foreach (IReadOnlyList<T> list in lists.Skip(1))
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    Assert.Equal(list1[i], list[i]);
+                }
+            }
+        }
 
-		public static void AssertElementEquals<T>(params IReadOnlyList<T>[] lists)
-		{
-			var list1 = lists[0];
-			int length = list1.Count;
-			foreach (var list in lists.Skip(1))
-				Assert.Equal(length, list.Count);
+        public static void AssertElementEquals<T>(params T[][] lists)
+        {
+            T[] list1 = lists[0];
+            int length = list1.Length;
+            foreach (T[] list in lists.Skip(1))
+            {
+                Assert.Equal(length, list.Length);
+            }
 
-			foreach (var list in lists.Skip(1))
-			{
-				for (int i = 0; i < length; i++)
-					Assert.Equal(list1[i], list[i]);
-			}
-		}
+            foreach (T[] list in lists.Skip(1))
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    Assert.Equal(list1[i], list[i]);
+                }
+            }
+        }
 
-		public static void AssertElementEquals<T>(params T[][] lists)
-		{
-			var list1 = lists[0];
-			int length = list1.Length;
-			foreach (var list in lists.Skip(1))
-				Assert.Equal(length, list.Length);
-
-			foreach (var list in lists.Skip(1))
-			{
-				for (int i = 0; i < length; i++)
-					Assert.Equal(list1[i], list[i]);
-			}
-		}
-
-		public static IEnumerable<T> Enumerable<T>(params T[] objs) => objs;
-	}
+        public static IEnumerable<T> Enumerable<T>(params T[] objs) => objs;
+    }
 }

--- a/TheSadRogue.Primitives.UnitTests/AdjacencyRuleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AdjacencyRuleTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using SadRogue.Primitives;
 using Xunit;
 using XUnit.ValueTuples;
-using SadRogue.Primitives;
-using System.Collections.Generic;
 
 namespace TheSadRogue.Primitives.UnitTests
 {
@@ -12,38 +12,38 @@ namespace TheSadRogue.Primitives.UnitTests
         #region TestData
 
         public static AdjacencyRule[] AdjacencyRules
-            => new AdjacencyRule[] { AdjacencyRule.CARDINALS, AdjacencyRule.DIAGONALS, AdjacencyRule.EIGHT_WAY };
-        
+            => new AdjacencyRule[] { AdjacencyRule.Cardinals, AdjacencyRule.Diagonals, AdjacencyRule.EightWay };
+
         public static Direction[] EightWayDirectionsClockwise
-            => new[]{ Direction.UP, Direction.UP_RIGHT, Direction.RIGHT, Direction.DOWN_RIGHT, Direction.DOWN,
-                Direction.DOWN_LEFT, Direction.LEFT, Direction.UP_LEFT };
+            => new[]{ Direction.Up, Direction.UpRight, Direction.Right, Direction.DownRight, Direction.Down,
+                Direction.DownLeft, Direction.Left, Direction.UpLeft };
 
         public static Direction[] DiagonalDirectionsClockwise
-            => new[]{ Direction.UP_RIGHT,Direction.DOWN_RIGHT, Direction.DOWN_LEFT, Direction.UP_LEFT };
+            => new[] { Direction.UpRight, Direction.DownRight, Direction.DownLeft, Direction.UpLeft };
 
         public static Direction[] CardinalsDirectionsClockwise
-            => new[]{ Direction.UP, Direction.RIGHT, Direction.DOWN, Direction.LEFT };
+            => new[] { Direction.Up, Direction.Right, Direction.Down, Direction.Left };
 
         public static IEnumerable<(AdjacencyRule, Direction)> ClockwisePairs
-            => AdjacencyRule.EIGHT_WAY.ToEnumerable().Combinate(EightWayDirectionsClockwise)
-            .Concat(AdjacencyRule.CARDINALS.ToEnumerable().Combinate(CardinalsDirectionsClockwise))
-            .Concat(AdjacencyRule.DIAGONALS.ToEnumerable().Combinate(DiagonalDirectionsClockwise));
+            => AdjacencyRule.EightWay.ToEnumerable().Combinate(EightWayDirectionsClockwise)
+            .Concat(AdjacencyRule.Cardinals.ToEnumerable().Combinate(CardinalsDirectionsClockwise))
+            .Concat(AdjacencyRule.Diagonals.ToEnumerable().Combinate(DiagonalDirectionsClockwise));
 
         public static IEnumerable<(AdjacencyRule, Direction)> AdjacencyDefaultsClockwise
-            => TestUtils.Enumerable((AdjacencyRule.CARDINALS, Direction.UP), (AdjacencyRule.EIGHT_WAY, Direction.UP), (AdjacencyRule.DIAGONALS, Direction.UP_RIGHT));
+            => TestUtils.Enumerable((AdjacencyRule.Cardinals, Direction.Up), (AdjacencyRule.EightWay, Direction.Up), (AdjacencyRule.Diagonals, Direction.UpRight));
 
         public static IEnumerable<(AdjacencyRule, Direction)> AdjacencyDefaultsCounterClockwise
-            => TestUtils.Enumerable((AdjacencyRule.CARDINALS, Direction.UP), (AdjacencyRule.EIGHT_WAY, Direction.UP), (AdjacencyRule.DIAGONALS, Direction.UP_LEFT));
+            => TestUtils.Enumerable((AdjacencyRule.Cardinals, Direction.Up), (AdjacencyRule.EightWay, Direction.Up), (AdjacencyRule.Diagonals, Direction.UpLeft));
 
         public static IEnumerable<(AdjacencyRule, Direction)> RotatePairs =>
-            AdjacencyRule.CARDINALS.ToEnumerable().Combinate(DiagonalDirectionsClockwise)
-            .Concat(AdjacencyRule.DIAGONALS.ToEnumerable().Combinate(CardinalsDirectionsClockwise));
+            AdjacencyRule.Cardinals.ToEnumerable().Combinate(DiagonalDirectionsClockwise)
+            .Concat(AdjacencyRule.Diagonals.ToEnumerable().Combinate(CardinalsDirectionsClockwise));
 
         public static IEnumerable<(Point, AdjacencyRule)> PointAdjacencyPairs =>
             TestUtils.Enumerable<Point>((1, 2), (-1, -2), (0, 4), (3, 0)).Combinate(AdjacencyRules);
 
-        static public Direction[] ValidDirections = AdjacencyRule.EIGHT_WAY.DirectionsOfNeighborsClockwise().ToArray();
-        static public Direction[] AllDirections => ValidDirections.Append(Direction.NONE).ToArray();
+        public static Direction[] ValidDirections = AdjacencyRule.EightWay.DirectionsOfNeighborsClockwise().ToArray();
+        public static Direction[] AllDirections => ValidDirections.Append(Direction.None).ToArray();
 
         public static IEnumerable<(Point, AdjacencyRule, Direction)> PointClockwisePairs =>
             PointAdjacencyPairs.Combinate(AllDirections);
@@ -51,11 +51,11 @@ namespace TheSadRogue.Primitives.UnitTests
         public static (AdjacencyRule.Types, AdjacencyRule)[] TypeAdjacencyRuleConversion
             => new (AdjacencyRule.Types, AdjacencyRule)[]
             {
-                (AdjacencyRule.Types.CARDINALS, AdjacencyRule.CARDINALS),
-                (AdjacencyRule.Types.DIAGONALS, AdjacencyRule.DIAGONALS),
-                (AdjacencyRule.Types.EIGHT_WAY, AdjacencyRule.EIGHT_WAY)
+                (AdjacencyRule.Types.Cardinals, AdjacencyRule.Cardinals),
+                (AdjacencyRule.Types.Diagonals, AdjacencyRule.Diagonals),
+                (AdjacencyRule.Types.EightWay, AdjacencyRule.EightWay)
             };
-            
+
         #endregion
 
         #region ValidDirections
@@ -64,15 +64,15 @@ namespace TheSadRogue.Primitives.UnitTests
         public void ValidDirectionsClockwiseOrder(AdjacencyRule rule, Direction startingDir)
         {
             Direction[] dirs = null;
-            switch(rule.Type)
+            switch (rule.Type)
             {
-                case AdjacencyRule.Types.CARDINALS:
+                case AdjacencyRule.Types.Cardinals:
                     dirs = CardinalsDirectionsClockwise.ToArray();
                     break;
-                case AdjacencyRule.Types.DIAGONALS:
+                case AdjacencyRule.Types.Diagonals:
                     dirs = DiagonalDirectionsClockwise.ToArray();
                     break;
-                case AdjacencyRule.Types.EIGHT_WAY:
+                case AdjacencyRule.Types.EightWay:
                     dirs = EightWayDirectionsClockwise.ToArray();
                     break;
             }
@@ -85,7 +85,9 @@ namespace TheSadRogue.Primitives.UnitTests
             Assert.False(index == -1, "Direction found in result that shouldn't be there.");
 
             for (int i = 0; i < clockwiseDirs.Length; i++)
+            {
                 Assert.Equal(dirs[(index + i) % dirs.Length], clockwiseDirs[i]);
+            }
         }
 
         [Theory]
@@ -95,13 +97,13 @@ namespace TheSadRogue.Primitives.UnitTests
             Direction[] dirs = null;
             switch (rule.Type)
             {
-                case AdjacencyRule.Types.CARDINALS:
+                case AdjacencyRule.Types.Cardinals:
                     dirs = CardinalsDirectionsClockwise.Reverse().ToArray();
                     break;
-                case AdjacencyRule.Types.DIAGONALS:
+                case AdjacencyRule.Types.Diagonals:
                     dirs = DiagonalDirectionsClockwise.Reverse().ToArray();
                     break;
-                case AdjacencyRule.Types.EIGHT_WAY:
+                case AdjacencyRule.Types.EightWay:
                     dirs = EightWayDirectionsClockwise.Reverse().ToArray();
                     break;
             }
@@ -114,8 +116,9 @@ namespace TheSadRogue.Primitives.UnitTests
             Assert.False(index == -1, "Direction found in result that shouldn't be there.");
 
             for (int i = 0; i < counterclockwiseDirs.Length; i++)
-            Assert.Equal(dirs[(index + i) % dirs.Length], counterclockwiseDirs[i]);
-
+            {
+                Assert.Equal(dirs[(index + i) % dirs.Length], counterclockwiseDirs[i]);
+            }
         }
 
         #endregion
@@ -126,7 +129,7 @@ namespace TheSadRogue.Primitives.UnitTests
         public void NoneDirectionClockwise(AdjacencyRule rule, Direction defaultDir)
         {
             Direction[] defaultDirs = rule.DirectionsOfNeighborsClockwise(defaultDir).ToArray();
-            Direction[] noneDirs = rule.DirectionsOfNeighborsClockwise(Direction.NONE).ToArray();
+            Direction[] noneDirs = rule.DirectionsOfNeighborsClockwise(Direction.None).ToArray();
             Direction[] noDirs = rule.DirectionsOfNeighborsClockwise().ToArray();
 
             TestUtils.AssertElementEquals(defaultDirs, noneDirs, noDirs);
@@ -137,7 +140,7 @@ namespace TheSadRogue.Primitives.UnitTests
         public void NoneDirectionCounterClockwise(AdjacencyRule rule, Direction defaultDir)
         {
             Direction[] defaultDirs = rule.DirectionsOfNeighborsCounterClockwise(defaultDir).ToArray();
-            Direction[] noneDirs = rule.DirectionsOfNeighborsCounterClockwise(Direction.NONE).ToArray();
+            Direction[] noneDirs = rule.DirectionsOfNeighborsCounterClockwise(Direction.None).ToArray();
             Direction[] noDirs = rule.DirectionsOfNeighborsCounterClockwise().ToArray();
 
             TestUtils.AssertElementEquals(defaultDirs, noneDirs, noDirs);
@@ -181,15 +184,21 @@ namespace TheSadRogue.Primitives.UnitTests
 
             int index = Array.FindIndex(cardsFirst, i => !i.IsCardinal());
             if (index == -1)
+            {
                 Assert.Equal(4, cardsFirst.Length);
+            }
             else
             {
                 for (int i = 0; i < cardsFirst.Length; i++)
                 {
                     if (cardsFirst[i].IsCardinal())
+                    {
                         Assert.True(i < index);
+                    }
                     else
+                    {
                         Assert.True(i >= index);
+                    }
                 }
             }
         }
@@ -200,8 +209,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataTuple(nameof(PointClockwisePairs))]
         public void NeighborsClockwise(Point point, AdjacencyRule rule, Direction startDir)
         {
-            var result = rule.NeighborsClockwise(point, startDir).ToArray();
-            var expected = rule.DirectionsOfNeighborsClockwise(startDir).Select(i => point + i).ToArray();
+            Point[] result = rule.NeighborsClockwise(point, startDir).ToArray();
+            Point[] expected = rule.DirectionsOfNeighborsClockwise(startDir).Select(i => point + i).ToArray();
 
             TestUtils.AssertElementEquals(result, expected);
         }
@@ -222,8 +231,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataTuple(nameof(PointClockwisePairs))]
         public void NeighborsCounterClockwise(Point point, AdjacencyRule rule, Direction startDir)
         {
-            var result = rule.NeighborsCounterClockwise(point, startDir).ToArray();
-            var expected = rule.DirectionsOfNeighborsCounterClockwise(startDir).Select(i => point + i).ToArray();
+            Point[] result = rule.NeighborsCounterClockwise(point, startDir).ToArray();
+            Point[] expected = rule.DirectionsOfNeighborsCounterClockwise(startDir).Select(i => point + i).ToArray();
 
             TestUtils.AssertElementEquals(result, expected);
         }
@@ -244,8 +253,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataTuple(nameof(PointAdjacencyPairs))]
         public void NeighborsUnordered(Point point, AdjacencyRule rule)
         {
-            var result = rule.Neighbors(point).ToArray();
-            var expected = rule.DirectionsOfNeighbors().Select(i => point + i).ToArray();
+            Point[] result = rule.Neighbors(point).ToArray();
+            Point[] expected = rule.DirectionsOfNeighbors().Select(i => point + i).ToArray();
 
             TestUtils.AssertElementEquals(result, expected);
         }
@@ -266,8 +275,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(AdjacencyRules))]
         public void TestEquality(AdjacencyRule rule)
         {
-            var compareTo = rule;
-            var allRules = AdjacencyRules;
+            AdjacencyRule compareTo = rule;
+            AdjacencyRule[] allRules = AdjacencyRules;
             Assert.True(rule == compareTo);
 
             Assert.Equal(1, allRules.Count(i => i == compareTo));
@@ -277,8 +286,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(AdjacencyRules))]
         public void TestInequality(AdjacencyRule rule)
         {
-            var compareTo = rule;
-            var allRules = AdjacencyRules;
+            AdjacencyRule compareTo = rule;
+            AdjacencyRule[] allRules = AdjacencyRules;
             Assert.False(rule != compareTo);
 
             Assert.Equal(allRules.Length - 1, allRules.Count(i => i != compareTo));
@@ -288,19 +297,21 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(AdjacencyRules))]
         public void TestEqualityInqeualityOpposite(AdjacencyRule compareRule)
         {
-            var rules = AdjacencyRules;
+            AdjacencyRule[] rules = AdjacencyRules;
 
-            foreach (var rule in rules)
+            foreach (AdjacencyRule rule in rules)
+            {
                 Assert.NotEqual(rule == compareRule, rule != compareRule);
+            }
         }
 
         [Theory]
         [MemberDataEnumerable(nameof(AdjacencyRules))]
         public void TestEqualityEquivalence(AdjacencyRule compareRule)
         {
-            var rules = AdjacencyRules;
+            AdjacencyRule[] rules = AdjacencyRules;
 
-            foreach (var rule in rules)
+            foreach (AdjacencyRule rule in rules)
             {
                 Assert.Equal(rule == compareRule, rule.Equals(compareRule));
                 Assert.Equal(rule == compareRule, rule.Equals((object)compareRule));

--- a/TheSadRogue.Primitives.UnitTests/DistanceTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/DistanceTests.cs
@@ -1,23 +1,23 @@
 ﻿using System.Linq;
+using SadRogue.Primitives;
 using Xunit;
 using XUnit.ValueTuples;
-using SadRogue.Primitives;
 
 namespace TheSadRogue.Primitives.UnitTests
 {
     public class DistanceTests
     {
         #region Testdata
-        public static Distance[] Distances => new Distance[] { Distance.MANHATTAN, Distance.CHEBYSHEV, Distance.EUCLIDEAN };
+        public static Distance[] Distances => new Distance[] { Distance.Manhattan, Distance.Chebyshev, Distance.Euclidean };
 
         public static (Distance.Types, Distance)[] TypeDistanceConversion => new (Distance.Types, Distance)[]
-        { (Distance.Types.CHEBYSHEV, Distance.CHEBYSHEV), (Distance.Types.EUCLIDEAN, Distance.EUCLIDEAN), (Distance.Types.MANHATTAN, Distance.MANHATTAN) };
+        { (Distance.Types.Chebyshev, Distance.Chebyshev), (Distance.Types.Euclidean, Distance.Euclidean), (Distance.Types.Manhattan, Distance.Manhattan) };
 
         public static (Distance, AdjacencyRule)[] AdjacencyRuleConversionValues => new (Distance, AdjacencyRule)[]
-        { (Distance.CHEBYSHEV, AdjacencyRule.EIGHT_WAY), (Distance.EUCLIDEAN, AdjacencyRule.EIGHT_WAY), (Distance.MANHATTAN, AdjacencyRule.CARDINALS) };
+        { (Distance.Chebyshev, AdjacencyRule.EightWay), (Distance.Euclidean, AdjacencyRule.EightWay), (Distance.Manhattan, AdjacencyRule.Cardinals) };
 
         public static (Distance, Radius)[] RadiusConversionValues => new (Distance, Radius)[]
-        { (Distance.CHEBYSHEV, Radius.SQUARE), (Distance.EUCLIDEAN, Radius.CIRCLE), (Distance.MANHATTAN, Radius.DIAMOND) };
+        { (Distance.Chebyshev, Radius.Square), (Distance.Euclidean, Radius.Circle), (Distance.Manhattan, Radius.Diamond) };
         #endregion
 
         #region Equality/Inequality
@@ -25,8 +25,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(Distances))]
         public void TestEquality(Distance dist)
         {
-            var compareTo = dist;
-            var allDists = Distances;
+            Distance compareTo = dist;
+            Distance[] allDists = Distances;
             Assert.True(dist == compareTo);
 
             Assert.Equal(1, allDists.Count(i => i == compareTo));
@@ -36,8 +36,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(Distances))]
         public void TestInequality(Distance dist)
         {
-            var compareTo = dist;
-            var allDists = Distances;
+            Distance compareTo = dist;
+            Distance[] allDists = Distances;
             Assert.False(dist != compareTo);
 
             Assert.Equal(allDists.Length - 1, allDists.Count(i => i != compareTo));
@@ -47,19 +47,21 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(Distances))]
         public void TestEqualityInqeualityOpposite(Distance compareDist)
         {
-            var dists = Distances;
+            Distance[] dists = Distances;
 
-            foreach (var dist in dists)
+            foreach (Distance dist in dists)
+            {
                 Assert.NotEqual(dist == compareDist, dist != compareDist);
+            }
         }
 
         [Theory]
         [MemberDataEnumerable(nameof(Distances))]
         public void TestEqualityEquivalence(Distance compareDist)
         {
-            var dists = Distances;
+            Distance[] dists = Distances;
 
-            foreach (var dist in dists)
+            foreach (Distance dist in dists)
             {
                 Assert.Equal(dist == compareDist, dist.Equals(compareDist));
                 Assert.Equal(dist == compareDist, dist.Equals((object)compareDist));
@@ -80,10 +82,7 @@ namespace TheSadRogue.Primitives.UnitTests
         #region DistanceImplicitConversions
         [Theory]
         [MemberDataTuple(nameof(AdjacencyRuleConversionValues))]
-        public void AdjacencyRuleConversion(Distance dist, AdjacencyRule expected)
-        {
-            Assert.Equal(expected, dist);
-        }
+        public void AdjacencyRuleConversion(Distance dist, AdjacencyRule expected) => Assert.Equal(expected, dist);
 
         [Theory]
         [MemberDataTuple(nameof(RadiusConversionValues))]

--- a/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
@@ -1,23 +1,23 @@
 ﻿using System.Linq;
+using SadRogue.Primitives;
 using Xunit;
 using XUnit.ValueTuples;
-using SadRogue.Primitives;
 
 namespace TheSadRogue.Primitives.UnitTests
 {
     public class RadiusTests
     {
         #region Testdata
-        public static Radius[] Radiuses => new Radius[] { Radius.SQUARE, Radius.CIRCLE, Radius.DIAMOND };
+        public static Radius[] Radiuses => new Radius[] { Radius.Square, Radius.Circle, Radius.Diamond };
 
         public static (Radius.Types, Radius)[] TypeRadiusConversion => new (Radius.Types, Radius)[]
-        { (Radius.Types.SQUARE, Radius.SQUARE), (Radius.Types.CIRCLE, Radius.CIRCLE), (Radius.Types.DIAMOND,Radius.DIAMOND) };
+        { (Radius.Types.Square, Radius.Square), (Radius.Types.Circle, Radius.Circle), (Radius.Types.Diamond,Radius.Diamond) };
 
         public static (Radius, AdjacencyRule)[] AdjacencyRuleConversionValues => new (Radius, AdjacencyRule)[]
-        { (Radius.SQUARE, AdjacencyRule.EIGHT_WAY), (Radius.CIRCLE, AdjacencyRule.EIGHT_WAY), (Radius.DIAMOND, AdjacencyRule.CARDINALS) };
+        { (Radius.Square, AdjacencyRule.EightWay), (Radius.Circle, AdjacencyRule.EightWay), (Radius.Diamond, AdjacencyRule.Cardinals) };
 
         public static (Radius, Distance)[] DistanceConversionValues => new (Radius, Distance)[]
-        { (Radius.SQUARE, Distance.CHEBYSHEV), (Radius.CIRCLE, Distance.EUCLIDEAN), (Radius.DIAMOND, Distance.MANHATTAN) };
+        { (Radius.Square, Distance.Chebyshev), (Radius.Circle, Distance.Euclidean), (Radius.Diamond, Distance.Manhattan) };
         #endregion
 
         #region Equality/Inequality
@@ -25,8 +25,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(Radiuses))]
         public void TestEquality(Radius rad)
         {
-            var compareTo = rad;
-            var allRads = Radiuses;
+            Radius compareTo = rad;
+            Radius[] allRads = Radiuses;
             Assert.True(rad == compareTo);
 
             Assert.Equal(1, allRads.Count(i => i == compareTo));
@@ -36,8 +36,8 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(Radiuses))]
         public void TestInequality(Radius rad)
         {
-            var compareTo = rad;
-            var allRads = Radiuses;
+            Radius compareTo = rad;
+            Radius[] allRads = Radiuses;
             Assert.False(rad != compareTo);
 
             Assert.Equal(allRads.Length - 1, allRads.Count(i => i != compareTo));
@@ -47,19 +47,21 @@ namespace TheSadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(Radiuses))]
         public void TestEqualityInqeualityOpposite(Radius compareRad)
         {
-            var rads = Radiuses;
+            Radius[] rads = Radiuses;
 
-            foreach (var rad in rads)
+            foreach (Radius rad in rads)
+            {
                 Assert.NotEqual(rad == compareRad, rad != compareRad);
+            }
         }
 
         [Theory]
         [MemberDataEnumerable(nameof(Radiuses))]
         public void TestEqualityEquivalence(Radius compareRad)
         {
-            var rads = Radiuses;
+            Radius[] rads = Radiuses;
 
-            foreach (var rad in rads)
+            foreach (Radius rad in rads)
             {
                 Assert.Equal(rad == compareRad, rad.Equals(compareRad));
                 Assert.Equal(rad == compareRad, rad.Equals((object)compareRad));
@@ -80,10 +82,7 @@ namespace TheSadRogue.Primitives.UnitTests
         #region DistanceImplicitConversions
         [Theory]
         [MemberDataTuple(nameof(AdjacencyRuleConversionValues))]
-        public void AdjacencyRuleConversion(Radius dist, AdjacencyRule expected)
-        {
-            Assert.Equal(expected, dist);
-        }
+        public void AdjacencyRuleConversion(Radius dist, AdjacencyRule expected) => Assert.Equal(expected, dist);
 
         [Theory]
         [MemberDataTuple(nameof(DistanceConversionValues))]

--- a/TheSadRogue.Primitives.UnitTests/SerializationTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SerializationTests.cs
@@ -1,25 +1,25 @@
-﻿using Xunit;
-using XUnit.ValueTuples;
-using SadRogue.Primitives;
+﻿using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.IO;
-using System;
+using System.Runtime.Serialization.Formatters.Binary;
+using SadRogue.Primitives;
+using Xunit;
+using XUnit.ValueTuples;
 
 namespace TheSadRogue.Primitives.UnitTests
 {
     public class SerializationTests
     {
         public static IEnumerable<object> SerializeData = new object[] {
-            AdjacencyRule.CARDINALS, AdjacencyRule.EIGHT_WAY,
+            AdjacencyRule.Cardinals, AdjacencyRule.EightWay,
             CreateArea((1, 2), (3, 4), (5,6)),
             new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
             new Color(.5f, .6f, .7f), new Color(120, 121, 122, 100), Color.AliceBlue,
-            Direction.DOWN, Direction.UP_RIGHT,
-            Distance.CHEBYSHEV, Distance.MANHATTAN,
+            Direction.Down, Direction.UpRight,
+            Distance.Chebyshev, Distance.Manhattan,
             new GradientStop(new Color(100, 101, 102, 103), .5f),
             new Point(-1, -5), new Point(4, 9),
-            Radius.CIRCLE, Radius.DIAMOND,
+            Radius.Circle, Radius.Diamond,
             new Rectangle(1, 2, 3, 4), new Rectangle(-10, -4, 56, 68)
         };
 
@@ -36,11 +36,15 @@ namespace TheSadRogue.Primitives.UnitTests
 
             var formatter = new BinaryFormatter();
             using (var stream = new FileStream(name, FileMode.Create, FileAccess.Write))
+            {
                 formatter.Serialize(stream, objToSerialize);
+            }
 
             object reSerialized = default;
             using (var stream = new FileStream(name, FileMode.Open, FileAccess.Read))
+            {
                 reSerialized = formatter.Deserialize(stream);
+            }
 
             File.Delete(name);
             Assert.True(equality(objToSerialize, reSerialized));
@@ -62,10 +66,18 @@ namespace TheSadRogue.Primitives.UnitTests
             Gradient g1 = (Gradient)o1;
             Gradient g2 = (Gradient)o2;
 
-            if (g1.Stops.Length != g2.Stops.Length) return false;
+            if (g1.Stops.Length != g2.Stops.Length)
+            {
+                return false;
+            }
 
             for (int i = 0; i < g1.Stops.Length; i++)
-                if (g1.Stops[i] != g2.Stops[i]) return false;
+            {
+                if (g1.Stops[i] != g2.Stops[i])
+                {
+                    return false;
+                }
+            }
 
             return true;
         }
@@ -76,11 +88,17 @@ namespace TheSadRogue.Primitives.UnitTests
             Palette p2 = (Palette)o2;
 
             if (p1.Length != p2.Length)
+            {
                 return false;
+            }
 
             for (int i = 0; i < p1.Length; i++)
+            {
                 if (p1[i] != p2[i])
+                {
                     return false;
+                }
+            }
 
             return true;
         }

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -16,30 +16,27 @@ namespace SadRogue.Primitives
         /// they are in a cardinal direction, eg. 4-way (manhattan-based) connectivity.
         /// </summary>
         [NonSerialized]
-        public static readonly AdjacencyRule CARDINALS = new AdjacencyRule(Types.CARDINALS);
+        public static readonly AdjacencyRule Cardinals = new AdjacencyRule(Types.Cardinals);
 
         /// <summary>
         /// Represents method of determining adjacency where neighbors are considered adjacent only
         /// if they are in a diagonal direction.
         /// </summary>
         [NonSerialized]
-        public static readonly AdjacencyRule DIAGONALS = new AdjacencyRule(Types.DIAGONALS);
+        public static readonly AdjacencyRule Diagonals = new AdjacencyRule(Types.Diagonals);
 
         /// <summary>
         /// Represents method of determining adjacency where all 8 possible neighbors are considered
         /// adjacent (eg. 8-way connectivity).
         /// </summary>
         [NonSerialized]
-        public static readonly AdjacencyRule EIGHT_WAY = new AdjacencyRule(Types.EIGHT_WAY);
+        public static readonly AdjacencyRule EightWay = new AdjacencyRule(Types.EightWay);
 
         [NonSerialized]
-        private static readonly string[] writeVals = Enum.GetNames(typeof(Types));
+        private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
         // Constructor, takes type.
-        private AdjacencyRule(Types type)
-        {
-            Type = type;
-        }
+        private AdjacencyRule(Types type) => Type = type;
 
         /// <summary>
         /// Enum representing <see cref="AdjacencyRule"/> types. Each AdjacencyRule instance has a <see cref="Type"/> field
@@ -49,19 +46,19 @@ namespace SadRogue.Primitives
         public enum Types
         {
             /// <summary>
-            /// Type for <see cref="AdjacencyRule.CARDINALS"/>.
+            /// Type for <see cref="AdjacencyRule.Cardinals"/>.
             /// </summary>
-            CARDINALS,
+            Cardinals,
 
             /// <summary>
-            /// Type for <see cref="AdjacencyRule.DIAGONALS"/>.
+            /// Type for <see cref="AdjacencyRule.Diagonals"/>.
             /// </summary>
-            DIAGONALS,
+            Diagonals,
 
             /// <summary>
-            /// Type for <see cref="AdjacencyRule.EIGHT_WAY"/>.
+            /// Type for <see cref="AdjacencyRule.EightWay"/>.
             /// </summary>
-            EIGHT_WAY
+            EightWay
         }
 
         /// <summary>
@@ -79,14 +76,14 @@ namespace SadRogue.Primitives
         {
             switch (adjacencyRuleType)
             {
-                case Types.CARDINALS:
-                    return CARDINALS;
+                case Types.Cardinals:
+                    return Cardinals;
 
-                case Types.DIAGONALS:
-                    return DIAGONALS;
+                case Types.Diagonals:
+                    return Diagonals;
 
-                case Types.EIGHT_WAY:
-                    return EIGHT_WAY;
+                case Types.EightWay:
+                    return EightWay;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Type)} type to {nameof(AdjacencyRule)} -- this is a bug!."); // Will not occur
@@ -102,29 +99,29 @@ namespace SadRogue.Primitives
         {
             switch (Type)
             {
-                case Types.CARDINALS:
-                    yield return Direction.UP;
-                    yield return Direction.DOWN;
-                    yield return Direction.LEFT;
-                    yield return Direction.RIGHT;
+                case Types.Cardinals:
+                    yield return Direction.Up;
+                    yield return Direction.Down;
+                    yield return Direction.Left;
+                    yield return Direction.Right;
                     break;
 
-                case Types.DIAGONALS:
-                    yield return Direction.UP_LEFT;
-                    yield return Direction.UP_RIGHT;
-                    yield return Direction.DOWN_LEFT;
-                    yield return Direction.DOWN_RIGHT;
+                case Types.Diagonals:
+                    yield return Direction.UpLeft;
+                    yield return Direction.UpRight;
+                    yield return Direction.DownLeft;
+                    yield return Direction.DownRight;
                     break;
 
-                case Types.EIGHT_WAY:
-                    yield return Direction.UP;
-                    yield return Direction.DOWN;
-                    yield return Direction.LEFT;
-                    yield return Direction.RIGHT;
-                    yield return Direction.UP_LEFT;
-                    yield return Direction.UP_RIGHT;
-                    yield return Direction.DOWN_LEFT;
-                    yield return Direction.DOWN_RIGHT;
+                case Types.EightWay:
+                    yield return Direction.Up;
+                    yield return Direction.Down;
+                    yield return Direction.Left;
+                    yield return Direction.Right;
+                    yield return Direction.UpLeft;
+                    yield return Direction.UpRight;
+                    yield return Direction.DownLeft;
+                    yield return Direction.DownRight;
                     break;
             }
         }
@@ -134,7 +131,7 @@ namespace SadRogue.Primitives
         /// method. Appropriate directions are returned in clockwise order from the given starting
         /// direction.
         /// </summary>
-        /// <param name="startingDirection">The direction to start with.  <see cref="Direction.NONE"/>
+        /// <param name="startingDirection">The direction to start with.  <see cref="Direction.None"/>
         /// causes the default starting direction to be used, which is UP for CARDINALS/EIGHT_WAY, and UP_RIGHT
         /// for diagonals.</param>
         /// <returns>Directions that lead to neighboring locations.</returns>
@@ -142,12 +139,16 @@ namespace SadRogue.Primitives
         {
             switch (Type)
             {
-                case Types.CARDINALS:
-                    if (startingDirection == Direction.NONE)
-                        startingDirection = Direction.UP;
+                case Types.Cardinals:
+                    if (startingDirection == Direction.None)
+                    {
+                        startingDirection = Direction.Up;
+                    }
 
                     if ((int)startingDirection.Type % 2 == 0)
+                    {
                         startingDirection++; // Make it a cardinal
+                    }
 
                     yield return startingDirection;
                     yield return startingDirection + 2;
@@ -155,12 +156,16 @@ namespace SadRogue.Primitives
                     yield return startingDirection + 6;
                     break;
 
-                case Types.DIAGONALS:
-                    if (startingDirection == Direction.NONE)
-                        startingDirection = Direction.UP_RIGHT;
+                case Types.Diagonals:
+                    if (startingDirection == Direction.None)
+                    {
+                        startingDirection = Direction.UpRight;
+                    }
 
                     if ((int)startingDirection.Type % 2 == 1)
+                    {
                         startingDirection++; // Make it a diagonal
+                    }
 
                     yield return startingDirection;
                     yield return startingDirection + 2;
@@ -168,9 +173,11 @@ namespace SadRogue.Primitives
                     yield return startingDirection + 6;
                     break;
 
-                case Types.EIGHT_WAY:
-                    if (startingDirection == Direction.NONE)
-                        startingDirection = Direction.UP;
+                case Types.EightWay:
+                    if (startingDirection == Direction.None)
+                    {
+                        startingDirection = Direction.Up;
+                    }
 
                     for (int i = 1; i <= 8; i++)
                     {
@@ -186,7 +193,7 @@ namespace SadRogue.Primitives
         /// method. Appropriate directions are returned in counter-clockwise order from the given
         /// starting direction.
         /// </summary>
-        /// <param name="startingDirection">The direction to start with.  null or <see cref="Direction.NONE"/>
+        /// <param name="startingDirection">The direction to start with.  null or <see cref="Direction.None"/>
         /// causes the default starting direction to be used, which is UP for CARDINALS/EIGHT_WAY, and UP_LEFT
         /// for diagonals.</param>
         /// <returns>Directions that lead to neighboring locations.</returns>
@@ -194,12 +201,16 @@ namespace SadRogue.Primitives
         {
             switch (Type)
             {
-                case Types.CARDINALS:
-                    if (startingDirection == Direction.NONE)
-                        startingDirection = Direction.UP;
+                case Types.Cardinals:
+                    if (startingDirection == Direction.None)
+                    {
+                        startingDirection = Direction.Up;
+                    }
 
                     if ((int)startingDirection.Type % 2 == 0)
+                    {
                         startingDirection--; // Make it a cardinal
+                    }
 
                     yield return startingDirection;
                     yield return startingDirection - 2;
@@ -207,12 +218,16 @@ namespace SadRogue.Primitives
                     yield return startingDirection - 6;
                     break;
 
-                case Types.DIAGONALS:
-                    if (startingDirection == null || startingDirection == Direction.NONE)
-                        startingDirection = Direction.UP_LEFT;
+                case Types.Diagonals:
+                    if (startingDirection == null || startingDirection == Direction.None)
+                    {
+                        startingDirection = Direction.UpLeft;
+                    }
 
                     if ((int)startingDirection.Type % 2 == 1)
+                    {
                         startingDirection--; // Make it a diagonal
+                    }
 
                     yield return startingDirection;
                     yield return startingDirection - 2;
@@ -220,9 +235,11 @@ namespace SadRogue.Primitives
                     yield return startingDirection - 6;
                     break;
 
-                case Types.EIGHT_WAY:
-                    if (startingDirection == null || startingDirection == Direction.NONE)
-                        startingDirection = Direction.UP;
+                case Types.EightWay:
+                    if (startingDirection == null || startingDirection == Direction.None)
+                    {
+                        startingDirection = Direction.Up;
+                    }
 
                     for (int i = 1; i <= 8; i++)
                     {
@@ -241,8 +258,10 @@ namespace SadRogue.Primitives
         /// <returns>All neighbors of the given location.</returns>
         public IEnumerable<Point> Neighbors(Point startingLocation)
         {
-            foreach (var dir in DirectionsOfNeighbors())
+            foreach (Direction dir in DirectionsOfNeighbors())
+            {
                 yield return startingLocation + dir;
+            }
         }
 
         /// <summary>
@@ -253,15 +272,17 @@ namespace SadRogue.Primitives
         /// <param name="startingLocation">Location to return neighbors for.</param>
         /// <param name="startingDirection">
         /// The neighbor in this direction will be returned first, proceeding clockwise.
-        /// If <see cref="Direction.NONE"/> is specified, the default starting direction
-        /// is used, which is <see cref="Direction.UP"/> for CARDINALS/EIGHT_WAY, and <see cref="Direction.UP_RIGHT"/>
+        /// If <see cref="Direction.None"/> is specified, the default starting direction
+        /// is used, which is <see cref="Direction.Up"/> for CARDINALS/EIGHT_WAY, and <see cref="Direction.UpRight"/>
         /// for DIAGONALS.
         /// </param>
         /// <returns>All neighbors of the given location.</returns>
         public IEnumerable<Point> NeighborsClockwise(Point startingLocation, Direction startingDirection = default)
         {
-            foreach (var dir in DirectionsOfNeighborsClockwise(startingDirection))
+            foreach (Direction dir in DirectionsOfNeighborsClockwise(startingDirection))
+            {
                 yield return startingLocation + dir;
+            }
         }
 
         /// <summary>
@@ -272,15 +293,17 @@ namespace SadRogue.Primitives
         /// <param name="startingLocation">Location to return neighbors for.</param>
         /// <param name="startingDirection">
         /// The neighbor in this direction will be returned first, proceeding counter-clockwise.
-        /// If <see cref="Direction.NONE"/> is specified, the default starting direction
-        /// is used, which is <see cref="Direction.UP"/> for CARDINALS/EIGHT_WAY, and
-        /// <see cref="Direction.UP_LEFT"/> for DIAGONALS.
+        /// If <see cref="Direction.None"/> is specified, the default starting direction
+        /// is used, which is <see cref="Direction.Up"/> for CARDINALS/EIGHT_WAY, and
+        /// <see cref="Direction.UpLeft"/> for DIAGONALS.
         /// </param>
         /// <returns>All neighbors of the given location.</returns>
         public IEnumerable<Point> NeighborsCounterClockwise(Point startingLocation, Direction startingDirection = default)
         {
-            foreach (var dir in DirectionsOfNeighborsCounterClockwise(startingDirection))
+            foreach (Direction dir in DirectionsOfNeighborsCounterClockwise(startingDirection))
+            {
                 yield return startingLocation + dir;
+            }
         }
 
         /// <summary>
@@ -327,6 +350,6 @@ namespace SadRogue.Primitives
         /// Returns a string representation of the <see cref="AdjacencyRule"/>.
         /// </summary>
         /// <returns>A string representation of the <see cref="AdjacencyRule"/>.</returns>
-        public override string ToString() => writeVals[(int)Type];
+        public override string ToString() => s_writeVals[(int)Type];
     }
 }

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -13,7 +13,7 @@ namespace SadRogue.Primitives
     public class Area : IReadOnlyArea
     {
         private readonly HashSet<Point> positionsSet;
-        private List<Point> _positions;
+        private readonly List<Point> _positions;
 
         private int left, top, bottom, right;
 
@@ -40,7 +40,9 @@ namespace SadRogue.Primitives
             get
             {
                 if (right < left)
-                    return Rectangle.EMPTY;
+                {
+                    return Rectangle.Empty;
+                }
 
                 return new Rectangle(left, top, right - left + 1, bottom - top + 1);
             }
@@ -49,12 +51,12 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Number of (unique) positions in the area.
         /// </summary>
-        public int Count { get { return _positions.Count; } }
+        public int Count => _positions.Count;
 
         /// <summary>
         /// List of all (unique) positions in the area.
         /// </summary>
-        public IReadOnlyList<Point> Positions { get { return _positions.AsReadOnly(); } }
+        public IReadOnlyList<Point> Positions => _positions.AsReadOnly();
 
         /// <summary>
         /// Gets an area containing all positions in <paramref name="area1"/>, minus those that are in
@@ -68,10 +70,12 @@ namespace SadRogue.Primitives
         {
             var retVal = new Area();
 
-            foreach (var pos in area1.Positions)
+            foreach (Point pos in area1.Positions)
             {
                 if (area2.Contains(pos))
+                {
                     continue;
+                }
 
                 retVal.Add(pos);
             }
@@ -90,14 +94,22 @@ namespace SadRogue.Primitives
             var retVal = new Area();
 
             if (!area1.Bounds.Intersects(area2.Bounds))
+            {
                 return retVal;
+            }
 
             if (area1.Count > area2.Count)
+            {
                 Swap(ref area1, ref area2);
+            }
 
-            foreach (var pos in area1.Positions)
+            foreach (Point pos in area1.Positions)
+            {
                 if (area2.Contains(pos))
+                {
                     retVal.Add(pos);
+                }
+            }
 
             return retVal;
         }
@@ -138,8 +150,10 @@ namespace SadRogue.Primitives
         {
             var retVal = new Area();
 
-            foreach (var pos in lhs.Positions)
+            foreach (Point pos in lhs.Positions)
+            {
                 retVal.Add(pos + rhs);
+            }
 
             return retVal;
         }
@@ -153,22 +167,34 @@ namespace SadRogue.Primitives
         public static bool operator ==(Area lhs, Area rhs)
         {
             if (ReferenceEquals(lhs, rhs))
+            {
                 return true;
+            }
 
             // If one side is null (can't both be null or above would have returned)
             if (ReferenceEquals(null, lhs) || ReferenceEquals(null, rhs))
+            {
                 return false;
+            }
 
             // Quick checks that can short-circuit a function that would otherwise require looping over all points
             if (lhs.Count != rhs.Count)
+            {
                 return false;
+            }
 
             if (lhs.Bounds != rhs.Bounds)
+            {
                 return false;
+            }
 
-            foreach (var pos in lhs.Positions)
+            foreach (Point pos in lhs.Positions)
+            {
                 if (!rhs.Contains(pos))
+                {
                     return false;
+                }
+            }
 
             return true;
         }
@@ -189,10 +215,25 @@ namespace SadRogue.Primitives
                 _positions.Add(position);
 
                 // Update bounds
-                if (position.X > right) right = position.X;
-                if (position.X < left) left = position.X;
-                if (position.Y > bottom) bottom = position.Y;
-                if (position.Y < top) top = position.Y;
+                if (position.X > right)
+                {
+                    right = position.X;
+                }
+
+                if (position.X < left)
+                {
+                    left = position.X;
+                }
+
+                if (position.Y > bottom)
+                {
+                    bottom = position.Y;
+                }
+
+                if (position.Y < top)
+                {
+                    top = position.Y;
+                }
             }
         }
 
@@ -203,8 +244,10 @@ namespace SadRogue.Primitives
         /// <param name="positions">Positions to add to the list.</param>
         public void Add(IEnumerable<Point> positions)
         {
-            foreach (var pos in positions)
+            foreach (Point pos in positions)
+            {
                 Add(pos);
+            }
         }
 
         /// <summary>
@@ -213,8 +256,10 @@ namespace SadRogue.Primitives
         /// <param name="rectangle">Rectangle indicating which points to add.</param>
         public void Add(Rectangle rectangle)
         {
-            foreach (var pos in rectangle.Positions())
+            foreach (Point pos in rectangle.Positions())
+            {
                 Add(pos);
+            }
         }
 
         /// <summary>
@@ -223,8 +268,10 @@ namespace SadRogue.Primitives
         /// <param name="area">Area containing positions to add.</param>
         public void Add(IReadOnlyArea area)
         {
-            foreach (var pos in area.Positions)
+            foreach (Point pos in area.Positions)
+            {
                 Add(pos);
+            }
         }
 
         /// <summary>
@@ -244,11 +291,17 @@ namespace SadRogue.Primitives
         public bool Contains(IReadOnlyArea area)
         {
             if (!Bounds.Contains(area.Bounds))
+            {
                 return false;
+            }
 
-            foreach (var pos in area.Positions)
+            foreach (Point pos in area.Positions)
+            {
                 if (!Contains(pos))
+                {
                     return false;
+                }
+            }
 
             return true;
         }
@@ -264,7 +317,10 @@ namespace SadRogue.Primitives
         public override bool Equals(object obj)
         {
             var area = obj as Area;
-            if (area == null) return false;
+            if (area == null)
+            {
+                return false;
+            }
 
             return this == area;
         }
@@ -286,20 +342,30 @@ namespace SadRogue.Primitives
         public bool Intersects(IReadOnlyArea area)
         {
             if (!area.Bounds.Intersects(Bounds))
+            {
                 return false;
+            }
 
             if (Count <= area.Count)
             {
-                foreach (var pos in Positions)
+                foreach (Point pos in Positions)
+                {
                     if (area.Contains(pos))
+                    {
                         return true;
+                    }
+                }
 
                 return false;
             }
 
-            foreach (var pos in area.Positions)
+            foreach (Point pos in area.Positions)
+            {
                 if (Contains(pos))
+                {
                     return true;
+                }
+            }
 
             return false;
         }
@@ -320,18 +386,24 @@ namespace SadRogue.Primitives
         {
             bool recalculateBounds = false;
 
-            foreach (var pos in _positions.Where(predicate))
+            foreach (Point pos in _positions.Where(predicate))
             {
                 if (positionsSet.Remove(pos))
+                {
                     if (pos.X == left || pos.X == right || pos.Y == top || pos.Y == bottom)
+                    {
                         recalculateBounds = true;
+                    }
+                }
             }
 
             _positions.RemoveAll(c => predicate(c));
 
 
             if (recalculateBounds)
+            {
                 RecalculateBounds();
+            }
         }
 
         /// <summary>
@@ -341,15 +413,23 @@ namespace SadRogue.Primitives
         public void Remove(HashSet<Point> positions)
         {
             bool recalculateBounds = false;
-            foreach (var pos in positions)
+            foreach (Point pos in positions)
+            {
                 if (positionsSet.Remove(pos))
+                {
                     if (pos.X == left || pos.X == right || pos.Y == top || pos.Y == bottom)
+                    {
                         recalculateBounds = true;
+                    }
+                }
+            }
 
             _positions.RemoveAll(c => positions.Contains(c));
 
             if (recalculateBounds)
+            {
                 RecalculateBounds();
+            }
         }
 
         /// <summary>
@@ -359,9 +439,13 @@ namespace SadRogue.Primitives
         public void Remove(IEnumerable<Point> positions)
         {
             if (positions is HashSet<Point> set)
+            {
                 Remove(set);
+            }
             else
+            {
                 Remove(new HashSet<Point>(positions));
+            }
         }
 
         /// <summary>
@@ -385,12 +469,16 @@ namespace SadRogue.Primitives
         {
             var result = new StringBuilder("[");
             bool first = true;
-            foreach (var item in _positions)
+            foreach (Point item in _positions)
             {
                 if (first)
+                {
                     first = false;
+                }
                 else
+                {
                     result.Append(", ");
+                }
 
                 result.Append(item.ToString());
             }
@@ -405,12 +493,27 @@ namespace SadRogue.Primitives
             int rightLocal = int.MinValue, bottomLocal = int.MinValue;
 
             // Find new bounds
-            foreach (var pos in _positions)
+            foreach (Point pos in _positions)
             {
-                if (pos.X > rightLocal) rightLocal = pos.X;
-                if (pos.X < leftLocal) leftLocal = pos.X;
-                if (pos.Y > bottomLocal) bottomLocal = pos.Y;
-                if (pos.Y < topLocal) topLocal = pos.Y;
+                if (pos.X > rightLocal)
+                {
+                    rightLocal = pos.X;
+                }
+
+                if (pos.X < leftLocal)
+                {
+                    leftLocal = pos.X;
+                }
+
+                if (pos.Y > bottomLocal)
+                {
+                    bottomLocal = pos.Y;
+                }
+
+                if (pos.Y < topLocal)
+                {
+                    topLocal = pos.Y;
+                }
             }
 
             left = leftLocal;
@@ -421,7 +524,7 @@ namespace SadRogue.Primitives
 
         private static void Swap(ref IReadOnlyArea lhs, ref IReadOnlyArea rhs)
         {
-            var temp = lhs;
+            IReadOnlyArea temp = lhs;
             lhs = rhs;
             rhs = temp;
         }

--- a/TheSadRogue.Primitives/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/BoundedRectangle.cs
@@ -8,10 +8,14 @@ namespace SadRogue.Primitives
 	/// keeping track of a camera's view area.
 	/// </summary>
     [Serializable]
-	public class BoundedRectangle : IEquatable<BoundedRectangle>
+    public class BoundedRectangle : IEquatable<BoundedRectangle>
     {
         private Rectangle _area;
+        // A bug in code cleanup will add the readonly modifier to this field even though it would break the BoundingBox property at compile-time,
+        // unless we disable the warning for this line
+#pragma warning disable IDE0044
         private Rectangle _boundingBox;
+#pragma warning restore IDE0044
 
         /// <summary>
         /// Constructor.
@@ -23,7 +27,7 @@ namespace SadRogue.Primitives
             _boundingBox = boundingBox;
             _area = area;
 
-            boundLock();
+            BoundLock();
         }
 
         /// <summary>
@@ -38,7 +42,9 @@ namespace SadRogue.Primitives
             {
                 _area = value;
                 if (!_boundingBox.Contains(_area))
-                    boundLock();
+                {
+                    BoundLock();
+                }
             }
         }
 
@@ -47,10 +53,7 @@ namespace SadRogue.Primitives
         /// property does not explicitly provide a set accessor, it is returning a reference so therefore
         /// the property may be assigned to.
         /// </summary>
-        public ref Rectangle BoundingBox
-        {
-            get => ref _boundingBox;
-        }
+        public ref Rectangle BoundingBox => ref _boundingBox;
 
         /// <summary>
         /// True if the given BoundedRectangle has the same Bounds and Area as the current one.
@@ -92,24 +95,39 @@ namespace SadRogue.Primitives
         /// </returns>
         public static bool operator !=(BoundedRectangle lhs, BoundedRectangle rhs) => !(lhs == rhs);
 
-        private void boundLock()
+        private void BoundLock()
         {
             int x = _area.X, y = _area.Y, width = _area.Width, height = _area.Height;
 
             if (width > _boundingBox.Width)
+            {
                 width = _boundingBox.Width;
+            }
+
             if (height > _boundingBox.Height)
+            {
                 height = _boundingBox.Height;
+            }
 
             if (x < _boundingBox.X)
+            {
                 x = _boundingBox.X;
+            }
+
             if (y < _boundingBox.Y)
+            {
                 y = _boundingBox.Y;
+            }
 
             if (x > _boundingBox.MaxExtentX - width + 1)
+            {
                 x = _boundingBox.MaxExtentX - width + 1;
+            }
+
             if (y > _boundingBox.MaxExtentY - height + 1)
+            {
                 y = _boundingBox.MaxExtentY - height + 1;
+            }
 
             _area = new Rectangle(x, y, width, height);
         }

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -3,9 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Text;
-using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Runtime.Serialization;
+using System.Text;
 
 namespace SadRogue.Primitives
 {
@@ -175,10 +175,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="packedValue">The packed value.</param>
         [CLSCompliant(false)]
-        public Color(uint packedValue)
-        {
-            _packedValue = packedValue;
-        }
+        public Color(uint packedValue) => _packedValue = packedValue;
 
         /// <summary>
         /// Constructs an RGBA color from a <see cref="Color"/> and an alpha value.
@@ -189,7 +186,7 @@ namespace SadRogue.Primitives
         {
             if ((alpha & 0xFFFFFF00) != 0)
             {
-                var clampedA = (uint)MathHelpers.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
+                uint clampedA = (uint)MathHelpers.Clamp(alpha, byte.MinValue, byte.MaxValue);
 
                 _packedValue = (color._packedValue & 0x00FFFFFF) | (clampedA << 24);
             }
@@ -244,9 +241,9 @@ namespace SadRogue.Primitives
 
             if (((r | g | b) & 0xFFFFFF00) != 0)
             {
-                var clampedR = (uint)MathHelpers.Clamp(r, Byte.MinValue, Byte.MaxValue);
-                var clampedG = (uint)MathHelpers.Clamp(g, Byte.MinValue, Byte.MaxValue);
-                var clampedB = (uint)MathHelpers.Clamp(b, Byte.MinValue, Byte.MaxValue);
+                uint clampedR = (uint)MathHelpers.Clamp(r, byte.MinValue, byte.MaxValue);
+                uint clampedG = (uint)MathHelpers.Clamp(g, byte.MinValue, byte.MaxValue);
+                uint clampedB = (uint)MathHelpers.Clamp(b, byte.MinValue, byte.MaxValue);
 
                 _packedValue |= (clampedB << 16) | (clampedG << 8) | (clampedR);
             }
@@ -267,10 +264,10 @@ namespace SadRogue.Primitives
         {
             if (((r | g | b | alpha) & 0xFFFFFF00) != 0)
             {
-                var clampedR = (uint)MathHelpers.Clamp(r, Byte.MinValue, Byte.MaxValue);
-                var clampedG = (uint)MathHelpers.Clamp(g, Byte.MinValue, Byte.MaxValue);
-                var clampedB = (uint)MathHelpers.Clamp(b, Byte.MinValue, Byte.MaxValue);
-                var clampedA = (uint)MathHelpers.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
+                uint clampedR = (uint)MathHelpers.Clamp(r, byte.MinValue, byte.MaxValue);
+                uint clampedG = (uint)MathHelpers.Clamp(g, byte.MinValue, byte.MaxValue);
+                uint clampedB = (uint)MathHelpers.Clamp(b, byte.MinValue, byte.MaxValue);
+                uint clampedA = (uint)MathHelpers.Clamp(alpha, byte.MinValue, byte.MaxValue);
 
                 _packedValue = (clampedA << 24) | (clampedB << 16) | (clampedG << 8) | (clampedR);
             }
@@ -290,10 +287,7 @@ namespace SadRogue.Primitives
         /// <param name="g"></param>
         /// <param name="b"></param>
         /// <param name="alpha"></param>
-        public Color(byte r, byte g, byte b, byte alpha)
-        {
-            _packedValue = ((uint)alpha << 24) | ((uint)b << 16) | ((uint)g << 8) | (r);
-        }
+        public Color(byte r, byte g, byte b, byte alpha) => _packedValue = ((uint)alpha << 24) | ((uint)b << 16) | ((uint)g << 8) | (r);
 
         /// <summary>
         /// Gets or sets the blue component.
@@ -305,7 +299,7 @@ namespace SadRogue.Primitives
             {
                 unchecked
                 {
-                    return (byte)(this._packedValue >> 16);
+                    return (byte)(_packedValue >> 16);
                 }
             }
         }
@@ -320,7 +314,7 @@ namespace SadRogue.Primitives
             {
                 unchecked
                 {
-                    return (byte)(this._packedValue >> 8);
+                    return (byte)(_packedValue >> 8);
                 }
             }
         }
@@ -335,7 +329,7 @@ namespace SadRogue.Primitives
             {
                 unchecked
                 {
-                    return (byte)this._packedValue;
+                    return (byte)_packedValue;
                 }
             }
         }
@@ -350,7 +344,7 @@ namespace SadRogue.Primitives
             {
                 unchecked
                 {
-                    return (byte)(this._packedValue >> 24);
+                    return (byte)(_packedValue >> 24);
                 }
             }
         }
@@ -361,10 +355,7 @@ namespace SadRogue.Primitives
         /// <param name="a"><see cref="Color"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="Color"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public static bool operator ==(Color a, Color b)
-        {
-            return (a._packedValue == b._packedValue);
-        }
+        public static bool operator ==(Color a, Color b) => (a._packedValue == b._packedValue);
 
         /// <summary>
         /// Compares whether two <see cref="Color"/> instances are not equal.
@@ -372,29 +363,20 @@ namespace SadRogue.Primitives
         /// <param name="a"><see cref="Color"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="Color"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
-        public static bool operator !=(Color a, Color b)
-        {
-            return (a._packedValue != b._packedValue);
-        }
+        public static bool operator !=(Color a, Color b) => (a._packedValue != b._packedValue);
 
         /// <summary>
         /// Gets the hash code of this <see cref="Color"/>.
         /// </summary>
         /// <returns>Hash code of this <see cref="Color"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this._packedValue.GetHashCode();
-        }
+        public override int GetHashCode() => _packedValue.GetHashCode();
 
         /// <summary>
         /// Compares whether current instance is equal to specified object.
         /// </summary>
         /// <param name="obj">The <see cref="Color"/> to compare.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public override bool Equals(object obj)
-        {
-            return ((obj is Color) && this.Equals((Color)obj));
-        }
+        public override bool Equals(object obj) => ((obj is Color) && Equals((Color)obj));
 
         #region Color Bank Ansi
         /// <summary>
@@ -1756,10 +1738,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="color">The color to calculate the luma from.</param>
         /// <returns>A value based on this code: (color.R + color.R + color.B + color.G + color.G + color.G) / 6f</returns>
-        public float GetLuma()
-        {
-            return (R + R + B + G + G + G) / 6f;
-        }
+        public float GetLuma() => (R + R + B + G + G + G) / 6f;
 
         /// <summary>
         /// Gets the brightness of a color.
@@ -1783,18 +1762,20 @@ namespace SadRogue.Primitives
         /// <remarks>Taken from the mono source code.</remarks>
         public float GetSaturation()
         {
-            byte minval = (byte)Math.Min(R, Math.Min(G, B));
-            byte maxval = (byte)Math.Max(R, Math.Max(G, B));
+            byte minval = Math.Min(R, Math.Min(G, B));
+            byte maxval = Math.Max(R, Math.Max(G, B));
 
 
             if (maxval == minval)
+            {
                 return 0.0f;
-
+            }
 
             int sum = maxval + minval;
             if (sum > 255)
+            {
                 sum = 510 - sum;
-
+            }
 
             return (float)(maxval - minval) / sum;
         }
@@ -1807,15 +1788,16 @@ namespace SadRogue.Primitives
         /// <remarks>Taken from the mono source code.</remarks>
         public float GetHue()
         {
-            byte minval = (byte)Math.Min(R, Math.Min(G, B));
-            byte maxval = (byte)Math.Max(R, Math.Max(G, B));
+            byte minval = Math.Min(R, Math.Min(G, B));
+            byte maxval = Math.Max(R, Math.Max(G, B));
 
 
             if (maxval == minval)
+            {
                 return 0.0f;
+            }
 
-
-            float diff = (float)(maxval - minval);
+            float diff = maxval - minval;
             float rnorm = (maxval - R) / diff;
             float gnorm = (maxval - G) / diff;
             float bnorm = (maxval - B) / diff;
@@ -1823,14 +1805,24 @@ namespace SadRogue.Primitives
 
             float hue = 0.0f;
             if (R == maxval)
+            {
                 hue = 60.0f * (6.0f + bnorm - gnorm);
-            if (G == maxval)
-                hue = 60.0f * (2.0f + rnorm - bnorm);
-            if (B == maxval)
-                hue = 60.0f * (4.0f + gnorm - rnorm);
-            if (hue > 360.0f)
-                hue -= 360.0f;
+            }
 
+            if (G == maxval)
+            {
+                hue = 60.0f * (2.0f + rnorm - bnorm);
+            }
+
+            if (B == maxval)
+            {
+                hue = 60.0f * (4.0f + gnorm - rnorm);
+            }
+
+            if (hue > 360.0f)
+            {
+                hue -= 360.0f;
+            }
 
             return hue;
         }
@@ -1842,7 +1834,7 @@ namespace SadRogue.Primitives
         /// <param name="value2">Destination <see cref="Color"/>.</param>
         /// <param name="amount">Interpolation factor.</param>
         /// <returns>Interpolated <see cref="Color"/>.</returns>
-        public static Color Lerp(Color value1, Color value2, Single amount)
+        public static Color Lerp(Color value1, Color value2, float amount)
         {
             amount = MathHelpers.Clamp(amount, 0, 1);
             return new Color(
@@ -1858,10 +1850,7 @@ namespace SadRogue.Primitives
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
-        public static Color Multiply(Color value, float scale)
-        {
-            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
-        }
+        public static Color Multiply(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
         /// Creates an array of colors that includes the <paramref name="startingColor"/> and <paramref name="endingColor"/> and <paramref name="steps"/> of colors between them.
@@ -1915,9 +1904,13 @@ namespace SadRogue.Primitives
                 float var_1;
 
                 if (l < 0.5)
+                {
                     var_2 = l * (1 + s);
+                }
                 else
+                {
                     var_2 = (l + s) - (s * l);
+                }
 
                 var_1 = 2 * l - var_2;
 
@@ -1931,11 +1924,31 @@ namespace SadRogue.Primitives
 
         private static float Hue_2_RGB(float v1, float v2, float vH)
         {
-            if (vH < 0) vH += 1;
-            if (vH > 1) vH -= 1;
-            if ((6 * vH) < 1) return (v1 + (v2 - v1) * 6 * vH);
-            if ((2 * vH) < 1) return (v2);
-            if ((3 * vH) < 2) return (v1 + (v2 - v1) * ((2 / 3) - vH) * 6);
+            if (vH < 0)
+            {
+                vH += 1;
+            }
+
+            if (vH > 1)
+            {
+                vH -= 1;
+            }
+
+            if ((6 * vH) < 1)
+            {
+                return (v1 + (v2 - v1) * 6 * vH);
+            }
+
+            if ((2 * vH) < 1)
+            {
+                return (v2);
+            }
+
+            if ((3 * vH) < 2)
+            {
+                return (v1 + (v2 - v1) * ((2 / 3) - vH) * 6);
+            }
+
             return (v1);
         }
 
@@ -1945,37 +1958,28 @@ namespace SadRogue.Primitives
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
-        public static Color operator *(Color value, float scale)
-        {
-            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
-        }
+        public static Color operator *(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
         /// Gets or sets packed value of this <see cref="Color"/>.
         /// </summary>
         [CLSCompliant(false)]
-        public UInt32 PackedValue => _packedValue;
+        public uint PackedValue => _packedValue;
 
 
-        internal string DebugDisplayString
-        {
-            get
-            {
-                return string.Concat(
-                    this.R.ToString(), "  ",
-                    this.G.ToString(), "  ",
-                    this.B.ToString(), "  ",
-                    this.A.ToString()
+        internal string DebugDisplayString => string.Concat(
+                    R.ToString(), "  ",
+                    G.ToString(), "  ",
+                    B.ToString(), "  ",
+                    A.ToString()
                 );
-            }
-        }
 
 
         /// <summary>
-        /// Returns a <see cref="String"/> representation of this <see cref="Color"/> in the format:
+        /// Returns a <see cref="string"/> representation of this <see cref="Color"/> in the format:
         /// {R:[red] G:[green] B:[blue] A:[alpha]}
         /// </summary>
-        /// <returns><see cref="String"/> representation of this <see cref="Color"/>.</returns>
+        /// <returns><see cref="string"/> representation of this <see cref="Color"/>.</returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder(25);
@@ -1999,10 +2003,7 @@ namespace SadRogue.Primitives
         /// <param name="b">Blue component value.</param>
         /// <param name="a">Alpha component value.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
-        public static Color FromNonPremultiplied(int r, int g, int b, int a)
-        {
-            return new Color(r * a / 255, g * a / 255, b * a / 255, a);
-        }
+        public static Color FromNonPremultiplied(int r, int g, int b, int a) => new Color(r * a / 255, g * a / 255, b * a / 255, a);
 
         #region IEquatable<Color> Members
 
@@ -2011,10 +2012,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">The <see cref="Color"/> to compare.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public bool Equals(Color other)
-        {
-            return this.PackedValue == other.PackedValue;
-        }
+        public bool Equals(Color other) => PackedValue == other.PackedValue;
 
         #endregion
 

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -12,11 +12,11 @@ namespace SadRogue.Primitives
     /// <remarks>
     /// The static <see cref="Direction.YIncreasesUpward"/> flag defines the way that many algorithms
     /// interpret the coordinate plane.  By default, this flag is false, meaning that the y-value of positions
-    /// is assumed to DECREASE as you proceed in the direction defined by <see cref="Direction.UP"/>, and
+    /// is assumed to DECREASE as you proceed in the direction defined by <see cref="Direction.Up"/>, and
     /// increase as you go downward.  If the coordinate plane is displayed on the screen, the origin would be
     /// the top left corner.  This default setting matches the typical console/computer graphic definition of the
     /// coordinate plane.  Setting the flag to true inverts this, so that the y-value of positions INCREASES
-    /// as you proceed in the direction defined by <see cref="Direction.UP"/>.  This places the origin in the bottom
+    /// as you proceed in the direction defined by <see cref="Direction.Up"/>.  This places the origin in the bottom
     /// left corner, and matches a typical mathmatical definition of a euclidean coordinate plane, as well as the scene
     /// coordinate plane defined by Unity and other game engines.
     /// </remarks>
@@ -24,50 +24,47 @@ namespace SadRogue.Primitives
     public struct Direction : IEquatable<Direction>
     {
         [NonSerialized]
-        private static readonly string[] writeVals = Enum.GetNames(typeof(Types));
+        private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
         // All directions that aren't NONE.
         [NonSerialized]
-        private static readonly Types[] validTypes = Enum.GetValues(typeof(Types)).Cast<Types>().Skip(1).ToArray();
+        private static readonly Types[] s_validTypes = Enum.GetValues(typeof(Types)).Cast<Types>().Skip(1).ToArray();
         [NonSerialized]
-        private static readonly (int dx, int dy)[] deltaVals;
+        private static readonly (int dx, int dy)[] s_deltaVals;
 
         [NonSerialized]
-        private static bool _yIncreasesUpward;
+        private static bool s_yIncreasesUpward;
 
         [NonSerialized]
-        private static bool initYInc;
+        private static bool s_initYInc;
 
         static Direction()
         {
-            deltaVals = new (int, int)[9];
+            s_deltaVals = new (int, int)[9];
 
             // These delta values don't change so we initialize these now
-            deltaVals[(int)Types.LEFT] = (-1, 0);
-            deltaVals[(int)Types.RIGHT] = (1, 0);
-            deltaVals[(int)Types.NONE] = (0, 0);
+            s_deltaVals[(int)Types.Left] = (-1, 0);
+            s_deltaVals[(int)Types.Right] = (1, 0);
+            s_deltaVals[(int)Types.None] = (0, 0);
 
             // Initialize direction instances to point to each type
-            UP = new Direction(Types.UP);
-            UP_RIGHT = new Direction(Types.UP_RIGHT);
-            RIGHT = new Direction(Types.RIGHT);
-            DOWN_RIGHT = new Direction(Types.DOWN_RIGHT);
-            DOWN = new Direction(Types.DOWN);
-            DOWN_LEFT = new Direction(Types.DOWN_LEFT);
-            LEFT = new Direction(Types.LEFT);
-            UP_LEFT = new Direction(Types.UP_LEFT);
-            NONE = new Direction(Types.NONE);
+            Up = new Direction(Types.Up);
+            UpRight = new Direction(Types.UpRight);
+            Right = new Direction(Types.Right);
+            DownRight = new Direction(Types.DownRight);
+            Down = new Direction(Types.Down);
+            DownLeft = new Direction(Types.DownLeft);
+            Left = new Direction(Types.Left);
+            UpLeft = new Direction(Types.UpLeft);
+            None = new Direction(Types.None);
 
             // YIncreasesUpward property setter sets all the remaining dx/dy values in the array
-            initYInc = false;
+            s_initYInc = false;
             // Initializes rest of distance values.  Safe to do becuase nobody can be using directions, as they haven't been initialized.
             SetYIncreasesUpwardsUnsafe(false);
         }
 
-        private Direction(Types type)
-        {
-            this.Type = type;
-        }
+        private Direction(Types type) => Type = type;
 
         /// <summary>
         /// Enum representing Direction types. Each Direction instance has a <see cref="Type"/> field
@@ -77,103 +74,103 @@ namespace SadRogue.Primitives
         public enum Types
         {
             /// <summary>
-            /// Type for <see cref="Direction.NONE"/>.
+            /// Type for <see cref="Direction.None"/>.
             /// </summary>
-            NONE,
+            None,
             /// <summary>
-            /// Type for <see cref="Direction.UP"/>.
+            /// Type for <see cref="Direction.Up"/>.
             /// </summary>
-            UP,
+            Up,
 
             /// <summary>
-            /// Type for <see cref="Direction.UP_RIGHT"/>.
+            /// Type for <see cref="Direction.UpRight"/>.
             /// </summary>
-            UP_RIGHT,
+            UpRight,
 
             /// <summary>
-            /// Type for <see cref="Direction.RIGHT"/>.
+            /// Type for <see cref="Direction.Right"/>.
             /// </summary>
-            RIGHT,
+            Right,
 
             /// <summary>
-            /// Type for <see cref="Direction.DOWN_RIGHT"/>.
+            /// Type for <see cref="Direction.DownRight"/>.
             /// </summary>
-            DOWN_RIGHT,
+            DownRight,
 
             /// <summary>
-            /// Type for <see cref="Direction.DOWN"/>.
+            /// Type for <see cref="Direction.Down"/>.
             /// </summary>
-            DOWN,
+            Down,
 
             /// <summary>
-            /// Type for <see cref="Direction.DOWN_LEFT"/>.
+            /// Type for <see cref="Direction.DownLeft"/>.
             /// </summary>
-            DOWN_LEFT,
+            DownLeft,
 
             /// <summary>
-            /// Type for <see cref="Direction.LEFT"/>.
+            /// Type for <see cref="Direction.Left"/>.
             /// </summary>
-            LEFT,
+            Left,
 
             /// <summary>
-            /// Type for <see cref="Direction.UP_LEFT"/>.
+            /// Type for <see cref="Direction.UpLeft"/>.
             /// </summary>
-            UP_LEFT
+            UpLeft
         };
 
         /// <summary>
         /// Down direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction DOWN;
+        public static readonly Direction Down;
 
         /// <summary>
         /// Down-left direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction DOWN_LEFT;
+        public static readonly Direction DownLeft;
 
         /// <summary>
         /// Down-right direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction DOWN_RIGHT;
+        public static readonly Direction DownRight;
 
         /// <summary>
         /// Left direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction LEFT;
+        public static readonly Direction Left;
 
         /// <summary>
         /// No direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction NONE;
+        public static readonly Direction None;
 
         /// <summary>
         /// Right direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction RIGHT;
+        public static readonly Direction Right;
 
         /// <summary>
         /// Up direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction UP;
+        public static readonly Direction Up;
 
         /// <summary>
         /// Up-left direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction UP_LEFT;
+        public static readonly Direction UpLeft;
 
         /// <summary>
         /// Up-right direction.
         /// </summary>
         [NonSerialized]
-        public static readonly Direction UP_RIGHT;
+        public static readonly Direction UpRight;
 
         /// <summary>
         /// Whether or not a positive y-value indicates an upward change. To set this value, use <see cref="SetYIncreasesUpwardsUnsafe(bool)"/>, however note that this is an unsafe
@@ -184,17 +181,17 @@ namespace SadRogue.Primitives
         /// If true, directions with an upwards component represent a positive change in y-value, and ones with downward components
         /// represent a negative change in y-value.  Changing this to false (which is the default) inverts this.
         /// </remarks>
-        public static bool YIncreasesUpward => _yIncreasesUpward;
+        public static bool YIncreasesUpward => s_yIncreasesUpward;
 
         /// <summary>
         /// Change in x-value represented by this direction.
         /// </summary>
-        public int DeltaX => deltaVals[(int)Type].dx;
+        public int DeltaX => s_deltaVals[(int)Type].dx;
 
         /// <summary>
         /// Change in y-value represented by this direction.
         /// </summary>
-        public int DeltaY => deltaVals[(int)Type].dy;
+        public int DeltaY => s_deltaVals[(int)Type].dy;
 
         /// <summary>
         /// Enum type corresponding to direction being represented.
@@ -229,7 +226,7 @@ namespace SadRogue.Primitives
         /// <param name="lhs"/>
         /// <param name="rhs"/>
         /// <returns>True if the two directions are equal, false if not.</returns>
-        public static bool operator ==(Direction lhs, Direction rhs) => lhs.Type ==rhs.Type;
+        public static bool operator ==(Direction lhs, Direction rhs) => lhs.Type == rhs.Type;
 
         /// <summary>
         /// True if the types are not equal.
@@ -243,7 +240,7 @@ namespace SadRogue.Primitives
 
         // Do not change manually outside of YIncreasesUpwards functionality
         [NonSerialized]
-        internal static int yMult;
+        internal static int s_yMult;
 
         /// <summary>
         /// Changes the value of <see cref="YIncreasesUpward"/>.  This operation is not safe to perform if another thread may be directly or indirectly using Directions.
@@ -252,18 +249,18 @@ namespace SadRogue.Primitives
         /// <param name="newValue">New value to assign to <see cref="YIncreasesUpward"/>.</param>
         public static void SetYIncreasesUpwardsUnsafe(bool newValue)
         {
-            if (_yIncreasesUpward != newValue || !initYInc)
+            if (s_yIncreasesUpward != newValue || !s_initYInc)
             {
-                initYInc = true;
-                _yIncreasesUpward = newValue;
-                yMult = (_yIncreasesUpward) ? -1 : 1;
+                s_initYInc = true;
+                s_yIncreasesUpward = newValue;
+                s_yMult = (s_yIncreasesUpward) ? -1 : 1;
 
-                deltaVals[(int)Types.UP] = (0, -1 * yMult);
-                deltaVals[(int)Types.DOWN] = (0, 1 * yMult);
-                deltaVals[(int)Types.UP_LEFT] = (-1, -1 * yMult);
-                deltaVals[(int)Types.UP_RIGHT] = (1, -1 * yMult);
-                deltaVals[(int)Types.DOWN_LEFT] = (-1, 1 * yMult);
-                deltaVals[(int)Types.DOWN_RIGHT] = (1, 1 * yMult);
+                s_deltaVals[(int)Types.Up] = (0, -1 * s_yMult);
+                s_deltaVals[(int)Types.Down] = (0, 1 * s_yMult);
+                s_deltaVals[(int)Types.UpLeft] = (-1, -1 * s_yMult);
+                s_deltaVals[(int)Types.UpRight] = (1, -1 * s_yMult);
+                s_deltaVals[(int)Types.DownLeft] = (-1, 1 * s_yMult);
+                s_deltaVals[(int)Types.DownRight] = (1, 1 * s_yMult);
             }
         }
 
@@ -297,9 +294,11 @@ namespace SadRogue.Primitives
             int dy = deltaChange.Y;
 
             if (dx == 0 && dy == 0)
-                return NONE;
+            {
+                return None;
+            }
 
-            dy *= yMult;
+            dy *= s_yMult;
 
             double angle = Math.Atan2(dy, dx);
             double degree = MathHelpers.ToDegree(angle);
@@ -307,15 +306,26 @@ namespace SadRogue.Primitives
             degree %= 360; // Normalize angle to 0-360
 
             if (degree < 45.0)
-                return UP;
-            if (degree < 135.0)
-                return RIGHT;
-            if (degree < 225.0)
-                return DOWN;
-            if (degree < 315.0)
-                return LEFT;
+            {
+                return Up;
+            }
 
-            return UP;
+            if (degree < 135.0)
+            {
+                return Right;
+            }
+
+            if (degree < 225.0)
+            {
+                return Down;
+            }
+
+            if (degree < 315.0)
+            {
+                return Left;
+            }
+
+            return Up;
         }
 
         /// <summary>
@@ -347,9 +357,11 @@ namespace SadRogue.Primitives
             int dy = deltaChange.Y;
 
             if (dx == 0 && dy == 0)
-                return NONE;
+            {
+                return None;
+            }
 
-            dy *= yMult;
+            dy *= s_yMult;
 
             double angle = Math.Atan2(dy, dx);
             double degree = MathHelpers.ToDegree(angle);
@@ -357,23 +369,46 @@ namespace SadRogue.Primitives
             degree %= 360; // Normalize angle to 0-360
 
             if (degree < 22.5)
-                return UP;
-            if (degree < 67.5)
-                return UP_RIGHT;
-            if (degree < 112.5)
-                return RIGHT;
-            if (degree < 157.5)
-                return DOWN_RIGHT;
-            if (degree < 202.5)
-                return DOWN;
-            if (degree < 247.5)
-                return DOWN_LEFT;
-            if (degree < 292.5)
-                return LEFT;
-            if (degree < 337.5)
-                return UP_LEFT;
+            {
+                return Up;
+            }
 
-            return UP;
+            if (degree < 67.5)
+            {
+                return UpRight;
+            }
+
+            if (degree < 112.5)
+            {
+                return Right;
+            }
+
+            if (degree < 157.5)
+            {
+                return DownRight;
+            }
+
+            if (degree < 202.5)
+            {
+                return Down;
+            }
+
+            if (degree < 247.5)
+            {
+                return DownLeft;
+            }
+
+            if (degree < 292.5)
+            {
+                return Left;
+            }
+
+            if (degree < 337.5)
+            {
+                return UpLeft;
+            }
+
+            return Up;
         }
 
         /// <summary>
@@ -384,14 +419,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The given direction moved counter-clockwise <paramref name="i"/> times.
         /// </returns>
-        public static Direction operator -(Direction d, int i) => (d == NONE) ? NONE : ToDirection(validTypes[WrapAround((int)d.Type - i - 1, 8)]);
+        public static Direction operator -(Direction d, int i) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type - i - 1, 8)]);
 
         /// <summary>
         /// Moves the direction counter-clockwise by one.
         /// </summary>
         /// <param name="d"/>
         /// <returns>The direction one unit counterclockwise of <paramref name="d"/>.</returns>
-        public static Direction operator --(Direction d) => (d == NONE) ? NONE : ToDirection(validTypes[WrapAround((int)d.Type - 2, 8)]);
+        public static Direction operator --(Direction d) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type - 2, 8)]);
 
         /// <summary>
         /// Moves the direction clockwise <paramref name="i"/> times.
@@ -401,14 +436,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The given direction moved clockwise <paramref name="i"/> times.
         /// </returns>
-        public static Direction operator +(Direction d, int i) => (d == NONE) ? NONE : ToDirection(validTypes[WrapAround((int)d.Type + i - 1, 8)]);
+        public static Direction operator +(Direction d, int i) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type + i - 1, 8)]);
 
         /// <summary>
         /// Moves the direction clockwise by one.
         /// </summary>
         /// <param name="d"/>
         /// <returns>The direction one unit clockwise of <paramref name="d"/>.</returns>
-        public static Direction operator ++(Direction d) => (d == NONE) ? NONE : ToDirection(validTypes[WrapAround((int)d.Type, 8)]);
+        public static Direction operator ++(Direction d) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type, 8)]);
 
         /// <summary>
         /// Gets the Direction class instance representing the direction type specified.
@@ -419,32 +454,32 @@ namespace SadRogue.Primitives
         {
             switch (directionType)
             {
-                case Types.UP:
-                    return UP;
+                case Types.Up:
+                    return Up;
 
-                case Types.UP_RIGHT:
-                    return UP_RIGHT;
+                case Types.UpRight:
+                    return UpRight;
 
-                case Types.RIGHT:
-                    return RIGHT;
+                case Types.Right:
+                    return Right;
 
-                case Types.DOWN_RIGHT:
-                    return DOWN_RIGHT;
+                case Types.DownRight:
+                    return DownRight;
 
-                case Types.DOWN:
-                    return DOWN;
+                case Types.Down:
+                    return Down;
 
-                case Types.DOWN_LEFT:
-                    return DOWN_LEFT;
+                case Types.DownLeft:
+                    return DownLeft;
 
-                case Types.LEFT:
-                    return LEFT;
+                case Types.Left:
+                    return Left;
 
-                case Types.UP_LEFT:
-                    return UP_LEFT;
+                case Types.UpLeft:
+                    return UpLeft;
 
-                case Types.NONE:
-                    return NONE;
+                case Types.None:
+                    return None;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Type)} instance to {nameof(Direction)} -- this is a bug!."); // Will not occur
@@ -455,13 +490,13 @@ namespace SadRogue.Primitives
         /// Returns true if the current direction is a cardinal direction.
         /// </summary>
         /// <returns>True if the current direction is a cardinal direction, false otherwise.</returns>
-        public bool IsCardinal() => this != NONE && (DeltaX == 0 || DeltaY == 0);
+        public bool IsCardinal() => this != None && (DeltaX == 0 || DeltaY == 0);
 
         /// <summary>
         /// Writes the string (eg. "UP", "UP_RIGHT", etc.) for the direction.
         /// </summary>
         /// <returns>String representation of the direction.</returns>
-        public override string ToString() => writeVals[(int)Type];
+        public override string ToString() => s_writeVals[(int)Type];
 
         #region Tuple Compatibility
         /// <summary>

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -20,19 +20,19 @@ namespace SadRogue.Primitives
         /// Represents chebyshev distance (equivalent to 8-way movement with no extra cost for diagonals).
         /// </summary>
         [NonSerialized]
-        public static Distance CHEBYSHEV = new Distance(Types.CHEBYSHEV);
+        public static Distance Chebyshev = new Distance(Types.Chebyshev);
 
         /// <summary>
         /// Represents euclidean distance (equivalent to 8-way movement with ~1.41 movement cost for diagonals).
         /// </summary>
         [NonSerialized]
-        public static Distance EUCLIDEAN = new Distance(Types.EUCLIDEAN);
+        public static Distance Euclidean = new Distance(Types.Euclidean);
 
         /// <summary>
         /// Represents manhattan distance (equivalent to 4-way, cardinal-only movement).
         /// </summary>
         [NonSerialized]
-        public static Distance MANHATTAN = new Distance(Types.MANHATTAN);
+        public static Distance Manhattan = new Distance(Types.Manhattan);
 
         /// <summary>
         /// Enum value representing the method of calcuating distance -- useful for using
@@ -41,12 +41,9 @@ namespace SadRogue.Primitives
         public readonly Types Type;
 
         [NonSerialized]
-        private static readonly string[] writeVals = Enum.GetNames(typeof(Types));
+        private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
-        private Distance(Types type)
-        {
-            Type = type;
-        }
+        private Distance(Types type) => Type = type;
 
         /// <summary>
         /// Enum representing Distance types. Each Distance instance has a <see cref="Type"/> field
@@ -56,19 +53,19 @@ namespace SadRogue.Primitives
         public enum Types
         {
             /// <summary>
-            /// Enum type for <see cref="Distance.MANHATTAN"/>.
+            /// Enum type for <see cref="Distance.Manhattan"/>.
             /// </summary>
-            MANHATTAN,
+            Manhattan,
 
             /// <summary>
-            /// Enum type for <see cref="Distance.EUCLIDEAN"/>.
+            /// Enum type for <see cref="Distance.Euclidean"/>.
             /// </summary>
-            EUCLIDEAN,
+            Euclidean,
 
             /// <summary>
-            /// Enum type for <see cref="Distance.CHEBYSHEV"/>.
+            /// Enum type for <see cref="Distance.Chebyshev"/>.
             /// </summary>
-            CHEBYSHEV
+            Chebyshev
         };
 
         /// <summary>
@@ -83,14 +80,14 @@ namespace SadRogue.Primitives
         {
             switch (distance.Type)
             {
-                case Types.MANHATTAN:
-                    return Radius.DIAMOND;
+                case Types.Manhattan:
+                    return Radius.Diamond;
 
-                case Types.EUCLIDEAN:
-                    return Radius.CIRCLE;
+                case Types.Euclidean:
+                    return Radius.Circle;
 
-                case Types.CHEBYSHEV:
-                    return Radius.SQUARE;
+                case Types.Chebyshev:
+                    return Radius.Square;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!"); // Will not occur
@@ -109,12 +106,12 @@ namespace SadRogue.Primitives
         {
             switch (distance.Type)
             {
-                case Types.MANHATTAN:
-                    return AdjacencyRule.CARDINALS;
+                case Types.Manhattan:
+                    return AdjacencyRule.Cardinals;
 
-                case Types.CHEBYSHEV:
-                case Types.EUCLIDEAN:
-                    return AdjacencyRule.EIGHT_WAY;
+                case Types.Chebyshev:
+                case Types.Euclidean:
+                    return AdjacencyRule.EightWay;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Distance)} to {nameof(AdjacencyRule)} -- this is a bug!"); // Will not occur
@@ -130,14 +127,14 @@ namespace SadRogue.Primitives
         {
             switch (distanceType)
             {
-                case Types.MANHATTAN:
-                    return MANHATTAN;
+                case Types.Manhattan:
+                    return Manhattan;
 
-                case Types.EUCLIDEAN:
-                    return EUCLIDEAN;
+                case Types.Euclidean:
+                    return Euclidean;
 
-                case Types.CHEBYSHEV:
-                    return CHEBYSHEV;
+                case Types.Chebyshev:
+                    return Chebyshev;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Types)} to {nameof(Distance)} -- this is a bug!"); // Will not occur
@@ -150,7 +147,7 @@ namespace SadRogue.Primitives
         /// <param name="start">Starting point.</param>
         /// <param name="end">Ending point.</param>
         /// <returns>The distance between the two points.</returns>
-        public double Calculate(Point start, Point end) => Calculate((double)start.X, (double)start.Y, (double)end.X, (double)end.Y);
+        public double Calculate(Point start, Point end) => Calculate(start.X, start.Y, end.X, end.Y);
 
         /// <summary>
         /// Returns the distance between the two (2D) points specified.
@@ -174,7 +171,7 @@ namespace SadRogue.Primitives
         /// <param name="deltaChange">The delta-x and delta-y between the two locations.</param>
         /// ///
         /// <returns>The distance between two locations withe the given delta-change values.</returns>
-        public double Calculate(Point deltaChange) => Calculate((double)deltaChange.X, (double)deltaChange.Y);
+        public double Calculate(Point deltaChange) => Calculate(deltaChange.X, deltaChange.Y);
 
         /// <summary>
         /// Returns the distance between two locations, given the change in X and change in Y value.
@@ -190,15 +187,15 @@ namespace SadRogue.Primitives
             double radius = 0;
             switch (Type)
             {
-                case Types.CHEBYSHEV:
+                case Types.Chebyshev:
                     radius = Math.Max(dx, dy); // Radius is the longest axial distance
                     break;
 
-                case Types.MANHATTAN:
+                case Types.Manhattan:
                     radius = dx + dy; // Simply manhattan distance
                     break;
 
-                case Types.EUCLIDEAN:
+                case Types.Euclidean:
                     radius = Math.Sqrt(dx * dx + dy * dy); // Spherical radius
                     break;
             }
@@ -249,6 +246,6 @@ namespace SadRogue.Primitives
         /// Returns a string representation of the distance calculation method represented.
         /// </summary>
         /// <returns>A string representation of the distance method represented.</returns>
-        public override string ToString() => writeVals[(int)Type];
+        public override string ToString() => s_writeVals[(int)Type];
     }
 }

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Collections;
-using System;
+using System.Collections.Generic;
 
 namespace SadRogue.Primitives
 {
@@ -64,12 +64,16 @@ namespace SadRogue.Primitives
 
 
             if (colorList.Length != stopList.Length)
+            {
                 throw new global::System.Exception("Both colors and stops much match in array length.");
+            }
 
             Stops = new GradientStop[colorList.Length];
 
             for (int i = 0; i < colorList.Length; i++)
+            {
                 Stops[i] = new GradientStop(colorList[i], stopList[i]);
+            }
         }
 
         /// <summary>
@@ -89,7 +93,9 @@ namespace SadRogue.Primitives
         public Gradient(params Color[] colors)
         {
             if (colors.Length == 0)
+            {
                 throw new global::System.ArgumentException("At least one color must be provided on this constructor.");
+            }
 
             if (colors.Length == 1)
             {
@@ -105,7 +111,9 @@ namespace SadRogue.Primitives
                 float stopStrength = 1f / (colors.Length - 1);
 
                 for (int i = 0; i < colors.Length; i++)
+                {
                     Stops[i] = new GradientStop(colors[i], i * stopStrength);
+                }
             }
 
         }
@@ -114,19 +122,13 @@ namespace SadRogue.Primitives
         /// Gets an enumerator with all of the gradient stops.
         /// </summary>
         /// <returns>An enumerator</returns>
-        public IEnumerator<GradientStop> GetEnumerator()
-        {
-            return ((IEnumerable<GradientStop>)Stops).GetEnumerator();
-        }
+        public IEnumerator<GradientStop> GetEnumerator() => ((IEnumerable<GradientStop>)Stops).GetEnumerator();
 
         /// <summary>
         /// Gets an enumerator with all of the gradient stops.
         /// </summary>
         /// <returns>An enumerator.</returns>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return Stops.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => Stops.GetEnumerator();
 
         /// <summary>
         /// Gets an array of colors based from the gradient.
@@ -138,12 +140,15 @@ namespace SadRogue.Primitives
             Color[] returnArray = new Color[count];
 
             if (Stops.Length == 0)
+            {
                 throw new global::System.IndexOutOfRangeException("The ColorGradient object does not have any gradient stops defined.");
-
+            }
             else if (Stops.Length == 1)
             {
                 for (int i = 0; i < count; i++)
+                {
                     returnArray[i] = Stops[0].Color;
+                }
 
                 return returnArray;
             }
@@ -158,12 +163,15 @@ namespace SadRogue.Primitives
             {
                 lerpTotal += lerp;
                 int counter;
-                for (counter = 0; counter < Stops.Length && Stops[counter].Stop < lerpTotal; counter++) ;
+                for (counter = 0; counter < Stops.Length && Stops[counter].Stop < lerpTotal; counter++)
+                {
+                    ;
+                }
 
                 counter--;
-                counter = (int)MathHelpers.Clamp(counter, 0, Stops.Length - 2);
+                counter = MathHelpers.Clamp(counter, 0, Stops.Length - 2);
 
-                float newLerp = (Stops[counter].Stop - (float)lerpTotal) / (Stops[counter].Stop - Stops[counter + 1].Stop);
+                float newLerp = (Stops[counter].Stop - lerpTotal) / (Stops[counter].Stop - Stops[counter + 1].Stop);
 
                 returnArray[i] = Color.Lerp(Stops[counter].Color, Stops[counter + 1].Color, newLerp);
             }
@@ -179,32 +187,30 @@ namespace SadRogue.Primitives
         public Color Lerp(float amount)
         {
             if (Stops.Length == 0)
+            {
                 throw new System.IndexOutOfRangeException("The ColorGradient object does not have any gradient stops defined.");
-
+            }
             else if (Stops.Length == 1)
             {
                 return Stops[0].Color;
             }
 
             int counter;
-            for (counter = 0; counter < Stops.Length && Stops[counter].Stop < amount; counter++) ;
+            for (counter = 0; counter < Stops.Length && Stops[counter].Stop < amount; counter++)
+            {
+                ;
+            }
 
             counter--;
-            counter = (int)MathHelpers.Clamp(counter, 0, Stops.Length - 2);
+            counter = MathHelpers.Clamp(counter, 0, Stops.Length - 2);
 
-            float newLerp = (Stops[counter].Stop - (float)amount) / (Stops[counter].Stop - Stops[counter + 1].Stop);
+            float newLerp = (Stops[counter].Stop - amount) / (Stops[counter].Stop - Stops[counter + 1].Stop);
 
             return Color.Lerp(Stops[counter].Color, Stops[counter + 1].Color, newLerp);
         }
 
-        public static implicit operator Gradient(Color color)
-        {
-            return new Gradient(color, color);
-        }
+        public static implicit operator Gradient(Color color) => new Gradient(color, color);
 
-        public static implicit operator Color(Gradient gradient)
-        {
-            return gradient.Stops[0].Color;
-        }
+        public static implicit operator Color(Gradient gradient) => gradient.Stops[0].Color;
     }
 }

--- a/TheSadRogue.Primitives/MathHelpers.cs
+++ b/TheSadRogue.Primitives/MathHelpers.cs
@@ -12,7 +12,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Result of 1/360; represents in decimal form a percent of a circle that a degree constitutes.
         /// </summary>
-        public const double DEGREE_PCT_OF_CIRCLE = 0.002777777777777778;
+        public const double DegreePctOfCircle = 0.002777777777777778;
 
         /// <summary>
         /// Converts given angle from radians to degrees.
@@ -38,8 +38,16 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Clamp(int value, int min, int max)
         {
-            if (value < min) value = min;
-            if (value > max) value = max;
+            if (value < min)
+            {
+                value = min;
+            }
+
+            if (value > max)
+            {
+                value = max;
+            }
+
             return value;
         }
 
@@ -53,8 +61,16 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Clamp(float value, float min, float max)
         {
-            if (value < min) value = min;
-            if (value > max) value = max;
+            if (value < min)
+            {
+                value = min;
+            }
+
+            if (value > max)
+            {
+                value = max;
+            }
+
             return value;
         }
 
@@ -68,8 +84,16 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Clamp(double value, double min, double max)
         {
-            if (value < min) value = min;
-            if (value > max) value = max;
+            if (value < min)
+            {
+                value = min;
+            }
+
+            if (value > max)
+            {
+                value = max;
+            }
+
             return value;
         }
 
@@ -105,9 +129,13 @@ namespace SadRogue.Primitives
         public static float Wrap(float value, float min, float max)
         {
             if (value < min)
+            {
                 value = max - (min - value) % (max - min);
+            }
             else
+            {
                 value = min + (value - min) % (max - min);
+            }
 
             return value;
         }

--- a/TheSadRogue.Primitives/Palette.cs
+++ b/TheSadRogue.Primitives/Palette.cs
@@ -10,12 +10,12 @@ namespace SadRogue.Primitives
     [Serializable]
     public class Palette : IEnumerable<Color>
     {
-        Color[] colors;
+        private readonly Color[] _colors;
 
         /// <summary>
         /// How many colors the palette has.
         /// </summary>
-        public int Length => colors.Length;
+        public int Length => _colors.Length;
 
         /// <summary>
         /// Gets or sets a color in the palette by index.
@@ -24,8 +24,8 @@ namespace SadRogue.Primitives
         /// <returns>A color.</returns>
         public Color this[int index]
         {
-            get => colors[index];
-            set => colors[index] = value;
+            get => _colors[index];
+            set => _colors[index] = value;
         }
 
         /// <summary>
@@ -34,29 +34,28 @@ namespace SadRogue.Primitives
         /// <param name="colors">The number of colors.</param>
         public Palette(int colors)
         {
-            this.colors = new Color[colors];
+            _colors = new Color[colors];
 
             for (int i = 0; i < colors; i++)
-                this.colors[i] = new Color();
+            {
+                _colors[i] = new Color();
+            }
         }
 
         /// <summary>
         /// Creates a new palette of colors from a list of existing colors.
         /// </summary>
         /// <param name="colors">The list of colors this palette is made from.</param>
-        public Palette(IEnumerable<Color> colors)
-        {
-            this.colors = new List<Color>(colors).ToArray();
-        }
+        public Palette(IEnumerable<Color> colors) => _colors = new List<Color>(colors).ToArray();
 
         /// <summary>
         /// Shifts the entire palette once to the left.
         /// </summary>
         public void ShiftLeft()
         {
-            Color lostColor = colors[0];
-            Array.Copy(colors, 1, colors, 0, colors.Length - 1);
-            colors[colors.Length - 1] = lostColor;
+            Color lostColor = _colors[0];
+            Array.Copy(_colors, 1, _colors, 0, _colors.Length - 1);
+            _colors[_colors.Length - 1] = lostColor;
         }
 
         /// <summary>
@@ -64,9 +63,9 @@ namespace SadRogue.Primitives
         /// </summary>
         public void ShiftRight()
         {
-            Color lostColor = colors[colors.Length - 1];
-            Array.Copy(colors, 0, colors, 1, colors.Length - 1);
-            colors[0] = lostColor;
+            Color lostColor = _colors[_colors.Length - 1];
+            Array.Copy(_colors, 0, _colors, 1, _colors.Length - 1);
+            _colors[0] = lostColor;
         }
 
         /// <summary>
@@ -76,9 +75,9 @@ namespace SadRogue.Primitives
         /// <param name="count">The amount of colors to shift from the starting index.</param>
         public void ShiftLeft(int startingIndex, int count)
         {
-            Color lostColor = colors[startingIndex];
-            Array.Copy(colors, startingIndex + 1, colors, startingIndex, count - 1);
-            colors[startingIndex + count - 1] = lostColor;
+            Color lostColor = _colors[startingIndex];
+            Array.Copy(_colors, startingIndex + 1, _colors, startingIndex, count - 1);
+            _colors[startingIndex + count - 1] = lostColor;
         }
 
         /// <summary>
@@ -88,9 +87,9 @@ namespace SadRogue.Primitives
         /// <param name="count">The amount of colors to shift from the starting index.</param>
         public void ShiftRight(int startingIndex, int count)
         {
-            Color lostColor = colors[startingIndex + count - 1];
-            Array.Copy(colors, startingIndex, colors, startingIndex + 1, count - 1);
-            colors[startingIndex] = lostColor;
+            Color lostColor = _colors[startingIndex + count - 1];
+            Array.Copy(_colors, startingIndex, _colors, startingIndex + 1, count - 1);
+            _colors[startingIndex] = lostColor;
         }
 
         /// <summary>
@@ -98,7 +97,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="color">The color to find.</param>
         /// <returns>The closest matching color.</returns>
-        public Color GetNearest(Color color) => colors[GetNearestIndex(color)];
+        public Color GetNearest(Color color) => _colors[GetNearestIndex(color)];
 
         /// <summary>
         /// Gets the index of the closest color in the palette to the provided color.
@@ -110,9 +109,9 @@ namespace SadRogue.Primitives
             int lowestDistanceIndex = -1;
             int lowestDistance = int.MaxValue;
             int currentDistance;
-            for (int i = 0; i < colors.Length; i++)
+            for (int i = 0; i < _colors.Length; i++)
             {
-                currentDistance = Math.Abs(colors[i].R - color.R) + Math.Abs(colors[i].G - color.G) + Math.Abs(colors[i].B - color.B);
+                currentDistance = Math.Abs(_colors[i].R - color.R) + Math.Abs(_colors[i].G - color.G) + Math.Abs(_colors[i].B - color.B);
 
                 if (currentDistance < lowestDistance)
                 {
@@ -127,18 +126,12 @@ namespace SadRogue.Primitives
         /// Gets the list of colors in the palette.
         /// </summary>
         /// <returns>The colors in the palette.</returns>
-        public IEnumerator<Color> GetEnumerator()
-        {
-            return ((IEnumerable<Color>)colors).GetEnumerator();
-        }
+        public IEnumerator<Color> GetEnumerator() => ((IEnumerable<Color>)_colors).GetEnumerator();
 
         /// <summary>
         /// Gets the list of colors in the palette.
         /// </summary>
         /// <returns>The colors in the palette.</returns>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return colors.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => _colors.GetEnumerator();
     }
 }

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -26,7 +26,7 @@ namespace SadRogue.Primitives
         /// x/y values is not considered a valid coordinate by many functions.
         /// </remarks>
         [NonSerialized]
-        public static readonly Point NONE = new Point(int.MinValue, int.MinValue);
+        public static readonly Point None = new Point(int.MinValue, int.MinValue);
 
         /// <summary>
         /// X-value of the position.
@@ -50,7 +50,7 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// Calculates degree bearing of the line (start =&gt; end), where 0 points in the direction <see cref="Direction.UP"/>.
+        /// Calculates degree bearing of the line (start =&gt; end), where 0 points in the direction <see cref="Direction.Up"/>.
         /// </summary>
         /// <param name="start">Position of line starting point.</param>
         /// <param name="end">Position of line ending point.</param>
@@ -60,7 +60,7 @@ namespace SadRogue.Primitives
 
         /// <summary>
         /// Calculates the degree bearing of a line with the given delta-x and delta-y values, where
-        /// 0 degreees points in the direction <see cref="Direction.UP"/>.
+        /// 0 degreees points in the direction <see cref="Direction.Up"/>.
         /// </summary>
         /// <param name="deltaChange">
         /// Vector, where deltaChange.X is the change in x-values across the line, and deltaChange.Y
@@ -72,7 +72,7 @@ namespace SadRogue.Primitives
             int dx = deltaChange.X;
             int dy = deltaChange.Y;
 
-            dy *= Direction.yMult;
+            dy *= Direction.s_yMult;
             double angle = Math.Atan2(dy, dx);
             double degree = MathHelpers.ToDegree(angle);
             degree += 450; // Rotate to all positive such that 0 is up
@@ -353,7 +353,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="c" />
         /// <returns />
-        public static implicit operator (int x, int y) (Point c) => (c.X, c.Y);
+        public static implicit operator (int x, int y)(Point c) => (c.X, c.Y);
         /// <summary>
         /// Implicitly converts a tuple of two integers to an equivalent Point.
         /// </summary>
@@ -431,10 +431,7 @@ namespace SadRogue.Primitives
         /// <param name="c"></param>
         /// <param name="tuple"></param>
         /// <returns>True if the two positions are equal, false if not.</returns>
-        public static bool operator ==(Point c, (int x, int y) tuple)
-        {
-            return c.X == tuple.x && c.Y == tuple.y;
-        }
+        public static bool operator ==(Point c, (int x, int y) tuple) => c.X == tuple.x && c.Y == tuple.y;
 
         /// <summary>
         /// True if either the x-values or y-values are not equal.
@@ -452,10 +449,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple"></param>
         /// <param name="c"></param>
         /// <returns>True if the two positions are equal, false if not.</returns>
-        public static bool operator ==((int x, int y) tuple, Point c)
-        {
-            return tuple.x == c.X && tuple.y == c.Y;
-        }
+        public static bool operator ==((int x, int y) tuple, Point c) => tuple.x == c.X && tuple.y == c.Y;
 
         /// <summary>
         /// True if either the x-values or y-values are not equal.

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -22,14 +22,14 @@ namespace SadRogue.Primitives
         /// an 8-way movement scheme with a ~1.41 cost multiplier for diagonal movement.
         /// </summary>
         [NonSerialized]
-        public static readonly Radius CIRCLE = new Radius(Types.CIRCLE);
+        public static readonly Radius Circle = new Radius(Types.Circle);
 
         /// <summary>
         /// Radius is a diamond around the center point. DIAMOND would represent movement radius
         /// in a 4-way movement scheme.
         /// </summary>
         [NonSerialized]
-        public static readonly Radius DIAMOND = new Radius(Types.DIAMOND);
+        public static readonly Radius Diamond = new Radius(Types.Diamond);
 
         /// <summary>
         /// Radius is a square around the center point. SQUARE would represent movement radius in
@@ -37,7 +37,7 @@ namespace SadRogue.Primitives
         /// away.
         /// </summary>
         [NonSerialized]
-        public static readonly Radius SQUARE = new Radius(Types.SQUARE);
+        public static readonly Radius Square = new Radius(Types.Square);
 
         /// <summary>
         /// Enum value representing the radius shape -- useful for using Radius types in switch
@@ -46,12 +46,9 @@ namespace SadRogue.Primitives
         public readonly Types Type;
 
         [NonSerialized]
-        private static readonly string[] writeVals = Enum.GetNames(typeof(Types));
+        private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
-        private Radius(Types type)
-        {
-            Type = type;
-        }
+        private Radius(Types type) => Type = type;
 
         /// <summary>
         /// Enum representing Radius types. Each Radius instance has a <see cref="Type"/> field
@@ -63,17 +60,17 @@ namespace SadRogue.Primitives
             /// <summary>
             /// Type for Radius.SQUARE.
             /// </summary>
-            SQUARE,
+            Square,
 
             /// <summary>
             /// Type for Radius.DIAMOND.
             /// </summary>
-            DIAMOND,
+            Diamond,
 
             /// <summary>
             /// Type for Radius.CIRCLE.
             /// </summary>
-            CIRCLE,
+            Circle,
         };
 
         /// <summary>
@@ -86,13 +83,13 @@ namespace SadRogue.Primitives
         /// 
         /// The positions returned are all guaranteed to be within the <paramref name="bounds"/> specified.  As well,
         /// they are guaranteed to be in order from least distance from center to most distance if either
-        /// <see cref="Radius.DIAMOND"/> or <see cref="Radius.SQUARE"/> is being used.
+        /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
         /// </remarks>
         /// <param name="center">Center-point of the radius.</param>
         /// <param name="radius">Length of the radius.</param>
         /// <param name="bounds">Bounds to restrict the returned values by.</param>
         /// <returns>All points in the radius shape defined by the given parameters, in order from least distance to greatest
-        /// if <see cref="Radius.DIAMOND"/> or <see cref="Radius.SQUARE"/> is being used.</returns>
+        /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
         public IEnumerable<Point> PositionsInRadius(Point center, int radius, Rectangle bounds)
             => PositionsInRadius(new RadiusLocationContext(center, radius, bounds));
 
@@ -105,12 +102,12 @@ namespace SadRogue.Primitives
         /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
         /// 
         /// The positions returned are guaranteed to be in order from least distance from center to most distance if either
-        /// <see cref="Radius.DIAMOND"/> or <see cref="Radius.SQUARE"/> is being used.
+        /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
         /// </remarks>
         /// <param name="center">Center-point of the radius.</param>
         /// <param name="radius">Length of the radius.</param>
         /// <returns>All points in the radius shape defined by the given parameters, in order from least distance to greatest
-        /// if <see cref="Radius.DIAMOND"/> or <see cref="Radius.SQUARE"/> is being used.</returns>
+        /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
         public IEnumerable<Point> PositionsInRadius(Point center, int radius)
             => PositionsInRadius(new RadiusLocationContext(center, radius));
 
@@ -124,17 +121,21 @@ namespace SadRogue.Primitives
         /// the bounds are unspecified, in which case no bound restriction results.
         /// 
         /// As well, they are guaranteed to be in order from least distance from center to most distance if either
-        /// <see cref="Radius.DIAMOND"/> or <see cref="Radius.SQUARE"/> is being used.
+        /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
         /// </remarks>
         /// <param name="context">Context defining radius parameters.</param>
         /// <returns>All points in the radius shape defined by the given context, in order from least distance to greatest
-        /// if <see cref="Radius.DIAMOND"/> or <see cref="Radius.SQUARE"/> is being used.</returns>
+        /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
         public IEnumerable<Point> PositionsInRadius(RadiusLocationContext context)
         {
             if (context._newlyInitialized)
+            {
                 context._newlyInitialized = false;
+            }
             else
+            {
                 Array.Clear(context._inQueue, 0, context._inQueue.Length);
+            }
 
             int startArrayIndex = context._inQueue.GetLength(0) / 2;
             Point topLeft = context.Center - context.Radius;
@@ -154,14 +155,16 @@ namespace SadRogue.Primitives
                 yield return cur;
 
                 // Add neighbors
-                foreach (var neighbor in rule.Neighbors(cur))
+                foreach (Point neighbor in rule.Neighbors(cur))
                 {
                     localNeighbor = neighbor - topLeft;
 
                     if (context._inQueue[localNeighbor.X, localNeighbor.Y] ||
-                        context.Bounds != Rectangle.EMPTY && !context.Bounds.Contains(neighbor) ||
+                        context.Bounds != Rectangle.Empty && !context.Bounds.Contains(neighbor) ||
                         distCalc.Calculate(context.Center, neighbor) > context.Radius)
+                    {
                         continue;
+                    }
 
                     q.Enqueue(neighbor);
                     context._inQueue[localNeighbor.X, localNeighbor.Y] = true;
@@ -221,12 +224,12 @@ namespace SadRogue.Primitives
         {
             switch (radius.Type)
             {
-                case Types.CIRCLE:
-                case Types.SQUARE:
-                    return AdjacencyRule.EIGHT_WAY;
+                case Types.Circle:
+                case Types.Square:
+                    return AdjacencyRule.EightWay;
 
-                case Types.DIAMOND:
-                    return AdjacencyRule.CARDINALS;
+                case Types.Diamond:
+                    return AdjacencyRule.Cardinals;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!"); // Will not occur
@@ -245,14 +248,14 @@ namespace SadRogue.Primitives
         {
             switch (radius.Type)
             {
-                case Types.CIRCLE:
-                    return Distance.EUCLIDEAN;
+                case Types.Circle:
+                    return Distance.Euclidean;
 
-                case Types.DIAMOND:
-                    return Distance.MANHATTAN;
+                case Types.Diamond:
+                    return Distance.Manhattan;
 
-                case Types.SQUARE:
-                    return Distance.CHEBYSHEV;
+                case Types.Square:
+                    return Distance.Chebyshev;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Radius)} to {nameof(Distance)} -- this is a bug!"); // Will not occur
@@ -268,14 +271,14 @@ namespace SadRogue.Primitives
         {
             switch (radiusType)
             {
-                case Types.CIRCLE:
-                    return CIRCLE;
+                case Types.Circle:
+                    return Circle;
 
-                case Types.DIAMOND:
-                    return DIAMOND;
+                case Types.Diamond:
+                    return Diamond;
 
-                case Types.SQUARE:
-                    return SQUARE;
+                case Types.Square:
+                    return Square;
 
                 default:
                     throw new Exception($"Could not convert {nameof(Types)} to {nameof(Radius)} -- this is a bug!"); // Will not occur
@@ -286,7 +289,7 @@ namespace SadRogue.Primitives
         /// Returns a string representation of the Radius.
         /// </summary>
         /// <returns>A string representation of the Radius.</returns>
-        public override string ToString() => writeVals[(int)Type];
+        public override string ToString() => s_writeVals[(int)Type];
     }
 
     /// <summary>
@@ -327,7 +330,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Represents the bounds that restrict the valid positions that are considered
         /// inside the radius.  Any positions inside the radius but outside the bounds
-        /// will be ignored and considered outside the radius.Set to <see cref="Rectangle.EMPTY"/>
+        /// will be ignored and considered outside the radius.Set to <see cref="Rectangle.Empty"/>
         /// to indicate no bounds.
         /// </summary>
         public Rectangle Bounds;
@@ -356,6 +359,6 @@ namespace SadRogue.Primitives
         /// <param name="center">The starting center-point of the radius.</param>
         /// <param name="radius">The starting length of the radius.</param>
         public RadiusLocationContext(Point center, int radius)
-            : this(center, radius, Rectangle.EMPTY) { }
+            : this(center, radius, Rectangle.Empty) { }
     }
 }

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -14,7 +14,7 @@ namespace SadRogue.Primitives
         /// The empty rectangle. Has origin of (0, 0) with 0 width and height.
         /// </summary>
         [NonSerialized]
-        public static readonly Rectangle EMPTY = new Rectangle(0, 0, 0, 0);
+        public static readonly Rectangle Empty = new Rectangle(0, 0, 0, 0);
 
         /// <summary>
         /// Constructor.
@@ -65,16 +65,13 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Calculates the area of the rectangle.
         /// </summary>
-        public int Area { get => Width * Height; }
+        public int Area => Width * Height;
 
         /// <summary>
         /// The center coordinate of the rectangle, rounded up if the exact center is between two
         /// positions. The center of a rectangle with width/height 1 is its <see cref="Position"/>.
         /// </summary>
-        public Point Center
-        {
-            get => new Point(X + (Width / 2), Y + (Height / 2));
-        }
+        public Point Center => new Point(X + (Width / 2), Y + (Height / 2));
 
         /// <summary>
         /// The height of the rectangle.
@@ -84,65 +81,53 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Whether or not this rectangle is empty (has width and height of 0).
         /// </summary>
-        public bool IsEmpty { get => (Width == 0 && Height == 0); }
+        public bool IsEmpty => (Width == 0 && Height == 0);
 
         /// <summary>
         /// The maximum X and Y coordinates that are included in the rectangle.
         /// </summary>
-        public Point MaxExtent
-        {
-            get => new Point(MaxExtentX, MaxExtentY);
-        }
+        public Point MaxExtent => new Point(MaxExtentX, MaxExtentY);
 
         /// <summary>
         /// The maximum X-coordinate that is included in the rectangle.
         /// </summary>
-        public int MaxExtentX
-        {
-            get => X + Width - 1;
-        }
+        public int MaxExtentX => X + Width - 1;
 
         /// <summary>
         /// The maximum Y-coordinate that is included in the rectangle.
         /// </summary>
-        public int MaxExtentY
-        {
-            get => Y + Height - 1;
-        }
+        public int MaxExtentY => Y + Height - 1;
 
         /// <summary>
         /// Minimum extent of the rectangle (minimum x and y values that are included within it).
         /// Identical to <see cref="Position"/> because we define the rectangle's position by its
         /// minimum extent.
         /// </summary>
-        public Point MinExtent { get => new Point(X, Y); }
+        public Point MinExtent => new Point(X, Y);
 
         /// <summary>
         /// X-value of the minimum extent of the rectangle (minimum x value that is included within
         /// it). Identical to the <see cref="X"/> value because we define the rectangle's position
         /// by its minimum extent.
         /// </summary>
-        public int MinExtentX { get => X; }
+        public int MinExtentX => X;
 
         /// <summary>
         /// Y-value of the minimum extent of the rectangle (minimum y value that is included within
         /// it). Identical to the <see cref="Y"/> value because we define the rectangle's position
         /// by its minimum extent.
         /// </summary>
-        public int MinExtentY { get => Y; }
+        public int MinExtentY => Y;
 
         /// <summary>
         /// Coord representing the position (min x- and y-values) of the rectangle.
         /// </summary>
-        public Point Position
-        {
-            get => new Point(X, Y);
-        }
+        public Point Position => new Point(X, Y);
 
         /// <summary>
         /// Returns a coordinate (Width, Height), which represents the size of the rectangle.
         /// </summary>
-        public Point Size { get => new Point(Width, Height); }
+        public Point Size => new Point(Width, Height);
 
         /// <summary>
         /// The width of the rectangle.
@@ -214,10 +199,12 @@ namespace SadRogue.Primitives
         {
             var retVal = new Area();
 
-            foreach (var pos in rect1.Positions())
+            foreach (Point pos in rect1.Positions())
             {
                 if (rect2.Contains(pos))
+                {
                     continue;
+                }
 
                 retVal.Add(pos);
             }
@@ -237,12 +224,20 @@ namespace SadRogue.Primitives
             var retVal = new Area();
 
             for (int x = r1.X; x <= r1.MaxExtentX; x++)
+            {
                 for (int y = r1.Y; y <= r1.MaxExtentY; y++)
+                {
                     retVal.Add(new Point(x, y));
+                }
+            }
 
             for (int x = r2.X; x <= r2.MaxExtentX; x++)
+            {
                 for (int y = r2.Y; y <= r2.MaxExtentY; y++)
+                {
                     retVal.Add(new Point(x, y));
+                }
+            }
 
             return retVal;
         }
@@ -270,7 +265,7 @@ namespace SadRogue.Primitives
                 return new Rectangle(minX, minY, exclusiveMaxX - minX, exclusiveMaxY - minY);
             }
 
-            return EMPTY;
+            return Empty;
         }
 
         /// <summary>
@@ -297,10 +292,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"/>
         /// <param name="r2"/>
         /// <returns>true if the rectangles do NOT encompass the same area, false otherwise.</returns>
-        public static bool operator !=(Rectangle r1, Rectangle r2)
-        {
-            return !(r1 == r2);
-        }
+        public static bool operator !=(Rectangle r1, Rectangle r2) => !(r1 == r2);
 
         /// <summary>
         /// Returns whether or not the rectangles have the same position and extents.
@@ -310,10 +302,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// true if the area of the two rectangles encompass the exact same area, false otherwise.
         /// </returns>
-        public static bool operator ==(Rectangle r1, Rectangle r2)
-        {
-            return r1.X == r2.X && r1.Y == r2.Y && r1.Width == r2.Width && r1.Height == r2.Height;
-        }
+        public static bool operator ==(Rectangle r1, Rectangle r2) => r1.X == r2.X && r1.Y == r2.Y && r1.Width == r2.Width && r1.Height == r2.Height;
 
         /// <summary>
         /// Creates and returns a new rectangle that is the same size as the current one, but with
@@ -364,10 +353,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="position">The position to check.</param>
         /// <returns>Whether or not the specified point is considered within the rectangle.</returns>
-        public bool Contains(Point position)
-        {
-            return (position.X >= X && position.X < (X + Width) && position.Y >= Y && position.Y < (Y + Height));
-        }
+        public bool Contains(Point position) => (position.X >= X && position.X < (X + Width) && position.Y >= Y && position.Y < (Y + Height));
 
         /// <summary>
         /// Returns whether or not the specified rectangle is considered completely contained within
@@ -377,10 +363,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the given rectangle is completely contained within the current one, false otherwise.
         /// </returns>
-        public bool Contains(Rectangle other)
-        {
-            return (X <= other.X && other.X + other.Width <= X + Width && Y <= other.Y && other.Y + other.Height <= Y + Height);
-        }
+        public bool Contains(Rectangle other) => (X <= other.X && other.X + other.Width <= X + Width && Y <= other.Y && other.Y + other.Height <= Y + Height);
 
         /// <summary>
         /// Compares based upon whether or not the areas contained within the rectangle are identical
@@ -390,10 +373,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// true if the area of the two rectangles encompass the exact same area, false otherwise.
         /// </returns>
-        public bool Equals(Rectangle other)
-        {
-            return (X == other.X && Y == other.Y && Width == other.Width && Height == other.Height);
-        }
+        public bool Equals(Rectangle other) => (X == other.X && Y == other.Y && Width == other.Width && Height == other.Height);
 
         /// <summary>
         /// Compares to an arbitrary object.
@@ -402,10 +382,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// true if the object specified is a rectangle instance and encompasses the same area, false otherwise.
         /// </returns>
-        public override bool Equals(Object obj)
-        {
-            return obj is Rectangle && this == (Rectangle)obj;
-        }
+        public override bool Equals(object obj) => obj is Rectangle && this == (Rectangle)obj;
 
         /// <summary>
         /// Returns a new rectangle, expanded to include the additional specified rows/columns.
@@ -424,20 +401,14 @@ namespace SadRogue.Primitives
         /// Simple hashing.
         /// </summary>
         /// <returns>Hash code for rectangle.</returns>
-        public override int GetHashCode()
-        {
-            return X.GetHashCode() ^ Y.GetHashCode() ^ Width.GetHashCode() ^ Height.GetHashCode();
-        }
+        public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Width.GetHashCode() ^ Height.GetHashCode();
 
         /// <summary>
         /// Returns whether or not the given rectangle intersects the current one.
         /// </summary>
         /// <param name="other">The rectangle to check.</param>
         /// <returns>True if the given rectangle intersects with the current one, false otherwise.</returns>
-        public bool Intersects(Rectangle other)
-        {
-            return (other.X < X + Width && X < other.X + other.Width && other.Y < Y + Height && Y < other.Y + other.Height);
-        }
+        public bool Intersects(Rectangle other) => (other.X < X + Width && X < other.X + other.Width && other.Y < Y + Height && Y < other.Y + other.Height);
 
         /// <summary>
         /// Creates and returns a new rectangle that has its <see cref="Position"/> moved to the given position.
@@ -454,7 +425,7 @@ namespace SadRogue.Primitives
         /// <returns>A new rectangle that has its position moved in the given direction.</returns>
         public Rectangle Translate(Direction direction)
         {
-            var newPos = Position + direction;
+            Point newPos = Position + direction;
             return new Rectangle(newPos.X, newPos.Y, Width, Height);
         }
 
@@ -479,8 +450,12 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> Positions()
         {
             for (int y = Y; y <= MaxExtentY; y++)
+            {
                 for (int x = X; x <= MaxExtentX; x++)
+                {
                     yield return new Point(x, y);
+                }
+            }
         }
 
         /// <summary>
@@ -579,10 +554,7 @@ namespace SadRogue.Primitives
         /// (<see cref="X"/>, <see cref="Y"/>) -&gt; (<see cref="MaxExtentX"/>, <see cref="MaxExtentY"/>)
         /// </summary>
         /// <returns>String formatted as above.</returns>
-        public override string ToString()
-        {
-            return Position + " -> " + MaxExtent;
-        }
+        public override string ToString() => Position + " -> " + MaxExtent;
 
         /// <summary>
         /// Creates and returns a new rectangle whose position has been moved by the given
@@ -617,7 +589,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="rect" />
         /// <returns />
-        public static implicit operator (int x, int y, int width, int height) (Rectangle rect) => (rect.X, rect.Y, rect.Width, rect.Height);
+        public static implicit operator (int x, int y, int width, int height)(Rectangle rect) => (rect.X, rect.Y, rect.Width, rect.Height);
         /// <summary>
         /// Implicitly converts a tuple of 4 integers (x, y, width, height) to an equivalent GoRogue Rectangle.
         /// </summary>
@@ -646,10 +618,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"></param>
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
-        public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2)
-        {
-            return r1.X == r2.x && r1.Y == r2.y && r1.Width == r2.width && r1.Height == r2.height;
-        }
+        public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2) => r1.X == r2.x && r1.Y == r2.y && r1.Width == r2.width && r1.Height == r2.height;
 
         /// <summary>
         /// True if any of the rectangles' x/y/width/height values are not equal.
@@ -667,10 +636,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"></param>
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
-        public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2)
-        {
-            return r1.x == r2.X && r1.y == r2.Y && r1.width == r2.Width && r1.height == r2.Height;
-        }
+        public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2) => r1.x == r2.X && r1.y == r2.Y && r1.width == r2.Width && r1.height == r2.Height;
 
         /// <summary>
         /// True if any of the rectangles' x/y/width/height values are not equal.
@@ -698,16 +664,24 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> PerimeterPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
+            {
                 yield return new Point(x, MinExtentY); // Minimum y-side perimeter
+            }
 
             for (int y = MinExtentY + 1; y <= MaxExtentY; y++) // Start offset 1, since last loop returned the corner piece
+            {
                 yield return new Point(MaxExtentX, y);
+            }
 
             for (int x = MaxExtentX - 1; x >= MinExtentX; x--) // Again skip 1 because last loop returned the corner piece
+            {
                 yield return new Point(x, MaxExtentY);
+            }
 
             for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--) // Skip 1 on both ends, becuase last loop returned one corner, first loop returned the other
+            {
                 yield return new Point(MinExtentX, y);
+            }
         }
 
         /// <summary>
@@ -717,7 +691,9 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MinYPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
+            {
                 yield return new Point(x, MinExtentY);
+            }
         }
 
         /// <summary>
@@ -727,7 +703,9 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MaxYPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
+            {
                 yield return new Point(x, MaxExtentY);
+            }
         }
 
         /// <summary>
@@ -737,7 +715,9 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MinXPositions()
         {
             for (int y = MinExtentY; y <= MaxExtentY; y++)
+            {
                 yield return new Point(MinExtentX, y);
+            }
         }
 
         /// <summary>
@@ -747,7 +727,9 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MaxXPositions()
         {
             for (int y = MinExtentY; y <= MaxExtentY; y++)
+            {
                 yield return new Point(MaxExtentX, y);
+            }
         }
 
         /// <summary>
@@ -760,13 +742,13 @@ namespace SadRogue.Primitives
         {
             switch (side.Type)
             {
-                case Direction.Types.UP:
+                case Direction.Types.Up:
                     return (Direction.YIncreasesUpward) ? MaxYPositions() : MinYPositions();
-                case Direction.Types.RIGHT:
+                case Direction.Types.Right:
                     return MaxXPositions();
-                case Direction.Types.DOWN:
+                case Direction.Types.Down:
                     return (Direction.YIncreasesUpward) ? MinYPositions() : MaxYPositions();
-                case Direction.Types.LEFT:
+                case Direction.Types.Left:
                     return MinXPositions();
                 default:
                     throw new Exception("Cannot retrieve positions on a non-cardinal side of a rectangle.");


### PR DESCRIPTION
Seemingly lots of changes, but much of it is formatting outside of the .editorconfig changes -- I added the .NET Core repo editorconfig, which enforces these standards, and ran code cleanup on the solution to modify everything to comply with standards.

I did also fix a namespace discrepancy on the MonoGame extension package, where the extension functions were in the wrong namespace.