### PR TITLE
Change mono rect ext class to match style of others

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
@@ -3,7 +3,7 @@ using SadRogueRectangle = SadRogue.Primitives.Rectangle;
 
 namespace SadRogue.Primitives
 {
-    public static class RectangleExtensions
+    public static class SadRogueRectangleExtensions
     {
         public static MonoRectangle ToMonoRectangle(this SadRogueRectangle self) => new MonoRectangle(self.X, self.Y, self.Width, self.Height);
 


### PR DESCRIPTION
Fix the name of the rect ext class in monogame. This PR is going into your SFML PR