### PR TITLE
Added tuple/convenience deconstructors for Rectangle

### DIFF
--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -1,0 +1,106 @@
+﻿using Xunit;
+using XUnit.ValueTuples;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace SadRogue.Primitives.UnitTests
+{
+    public class RectangleTests
+    {
+        #region Test Data
+        public static Rectangle[] EqualRectangles = new Rectangle[]
+        {
+            new Rectangle(1, 2, 11, 17),
+            new Rectangle(new Point(1, 2), new Point(11, 18)),
+            new Rectangle(new Point(6, 10), 5, 8)
+        };
+
+        public static Rectangle[] DifferentRectangles = new Rectangle[]
+        {
+            new Rectangle(1, 2, 10, 16),
+            new Rectangle(2, 3, 10, 16),
+            new Rectangle(new Point(0, 0), 5, 6)
+        };
+
+        public static IEnumerable<(Rectangle, Rectangle)> PairwiseEqualRects = EqualRectangles.Combinate(EqualRectangles);
+        #endregion
+
+        #region Constructor Equivalence
+        [Theory]
+        [MemberDataTuple(nameof(PairwiseEqualRects))]
+        public void TestConstructorEquivalence(Rectangle r1, Rectangle r2)
+        {
+            Assert.Equal(r1, r2);
+        }
+        #endregion
+
+        #region Equality/Inequality
+        [Theory]
+        [MemberDataEnumerable(nameof(DifferentRectangles))]
+        public void TestEquality(Rectangle rad)
+        {
+            Rectangle compareTo = rad;
+            Rectangle[] allRects = DifferentRectangles;
+            Assert.True(rad == compareTo);
+
+            Assert.Equal(1, allRects.Count(i => i == compareTo));
+        }
+
+
+        [Theory]
+        [MemberDataEnumerable(nameof(DifferentRectangles))]
+        public void TestInequality(Rectangle rect)
+        {
+            Rectangle compareTo = rect;
+            Rectangle[] allRects = DifferentRectangles;
+            Assert.False(rect != compareTo);
+
+            Assert.Equal(allRects.Length - 1, allRects.Count(i => i != compareTo));
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(DifferentRectangles))]
+        public void TestEqualityInqeualityOpposite(Rectangle compareRect)
+        {
+            Rectangle[] rects = DifferentRectangles;
+
+            foreach (Rectangle rect in rects)
+            {
+                Assert.NotEqual(rect == compareRect, rect != compareRect);
+            }
+        }
+        #endregion
+
+        #region Tuple Conversions
+        [Theory]
+        [MemberDataEnumerable(nameof(DifferentRectangles))]
+        public void TestTupleConversions(Rectangle rect)
+        {
+            (int x, int y, int width, int height) t1 = rect;
+            (Point minExtent, Point maxExtent) t2 = rect;
+
+            Rectangle rect1 = t1;
+            Rectangle rect2 = t2;
+            Assert.Equal(rect, rect1);
+            Assert.Equal(rect1, rect2);
+        }
+        #endregion
+
+        #region Tuple Equality
+        [Theory]
+        [MemberDataEnumerable(nameof(DifferentRectangles))]
+        public void TestTupleEquality(Rectangle rect)
+        {
+            (int x, int y, int width, int height) t1 = rect;
+            (Point minExtent, Point maxExtent) t2 = rect;
+
+            Assert.True(rect == t1);
+            Assert.True(rect == t2);
+            Assert.True(t1 == rect);
+            Assert.True(t2 == rect);
+            Assert.True(rect.Equals(t1));
+            Assert.True(rect.Equals(t2));
+        }
+        #endregion
+    }
+}

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -583,7 +583,8 @@ namespace SadRogue.Primitives
         public Rectangle TranslateY(int dy)
             => new Rectangle(X, Y + dy, Width, Height);
 
-        #region Tuple Compability
+        #region Tuple Compatibility
+        #region (x, y, width, height)
         /// <summary>
         /// Implicitly converts a GoRogue Rectangle to an equivalent tuple of 4 integers (x, y, width, height).
         /// </summary>
@@ -654,8 +655,78 @@ namespace SadRogue.Primitives
         /// <param name="other">Point to compare.</param>
         /// <returns>True if the two positions are equal, false if not.</returns>
         public bool Equals((int x, int y, int width, int height) other)
-        => X == other.x && Y == other.y && Width == other.width && Height == other.height;
+            => X == other.x && Y == other.y && Width == other.width && Height == other.height;
         #endregion
+        #region (minExtent, maxExtent)
+        /// <summary>
+        /// Implicitly converts a GoRogue Rectangle to an equivalent tuple of 2 Points (minExtent, maxExtent).
+        /// </summary>
+        /// <param name="rect" />
+        /// <returns />
+        public static implicit operator (Point minExtent, Point maxExtent)(Rectangle rect) => (rect.MinExtent, rect.MaxExtent);
+        /// <summary>
+        /// Implicitly converts a tuple of 2 Points (minExtent, maxExtent) to an equivalent GoRogue Rectangle.
+        /// </summary>
+        /// <param name="tuple" />
+        /// <returns />
+        public static implicit operator Rectangle((Point minExtent, Point maxExtent) tuple) => new Rectangle(tuple.minExtent, tuple.maxExtent);
+
+        /// <summary>
+        /// Adds support for C# Deconstruction syntax.
+        /// </summary>
+        /// <param name="minExtent" />
+        /// <param name="maxExtent" />
+        public void Deconstruct(out Point minExtent, out Point maxExtent)
+        {
+            minExtent = MinExtent;
+            maxExtent = MaxExtent;
+        }
+
+        /// <summary>
+        /// True if the two rectangles represent the same area.
+        /// </summary>
+        /// <param name="r1"></param>
+        /// <param name="r2"></param>
+        /// <returns>True if the two rectangles are equal, false if not.</returns>
+        public static bool operator ==(Rectangle r1, (Point minExtent, Point maxExtent) r2) => r1.MinExtent == r2.minExtent && r1.MaxExtent == r2.maxExtent;
+
+        /// <summary>
+        /// True if any of the rectangles' x/y/width/height values are not equal.
+        /// </summary>
+        /// <param name="r1"></param>
+        /// <param name="r2"></param>
+        /// <returns>
+        /// True if any of the x/y/width/height values are not equal, false if they are all equal.
+        /// </returns>
+        public static bool operator !=(Rectangle r1, (Point minExtent, Point maxExtent) r2) => !(r1 == r2);
+
+        /// <summary>
+        /// True if the two rectangles represent the same area.
+        /// </summary>
+        /// <param name="r1"></param>
+        /// <param name="r2"></param>
+        /// <returns>True if the two rectangles are equal, false if not.</returns>
+        public static bool operator ==((Point minExtent, Point maxExtent) r1, Rectangle r2) => r1.minExtent == r2.MinExtent && r1.maxExtent == r2.MaxExtent;
+
+        /// <summary>
+        /// True if any of the rectangles' x/y/width/height values are not equal.
+        /// </summary>
+        /// <param name="r1"></param>
+        /// <param name="r2"></param>
+        /// <returns>
+        /// True if any of the x/y/width/height values are not equal, false if they are all equal.
+        /// </returns>
+        public static bool operator !=((Point minExtent, Point maxExtent) r1, Rectangle r2) => !(r1 == r2);
+
+        /// <summary>
+        /// True if the given position has equal x and y values to the current one.
+        /// </summary>
+        /// <param name="other">Point to compare.</param>
+        /// <returns>True if the two positions are equal, false if not.</returns>
+        public bool Equals((Point minExtent, Point maxExtent) other)
+            => MinExtent == other.minExtent && MaxExtent == other.maxExtent;
+        #endregion
+#endregion
 
         /// <summary>
         /// Gets all positions that reside on the inner perimeter of the rectangle.


### PR DESCRIPTION
- Added additional tuple conversions to Rectangle for (Point, Point).
    - Added deconstructors appropriate for the tuple types
    - Added equality comparisons both ways for extra tuple types, as well as implicit conversions

The rectangle constructor has an additional overload that takes `(Point center, int horizontalRadius, int verticalRadius)`.  I deliberately left this out because that method of defining a rectangle only works for rectangles with odd width and height, and as such how to do the conversions is ambiguous and could lead to unintuitive behavior.  We _can_ add some sort of a way to do this, however particularly since we're just talking about tuple  compatibility, I can't see it being a feature that is used terribly often -- the other ways of doing that conversion will be far more common.