### PR TITLE
Fixed #20

### DIFF
--- a/TheSadRogue.Primitives.UnitTests/BoundedRectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/BoundedRectangleTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace SadRogue.Primitives.UnitTests
+{
+    public class BoundedRectangleTests
+    {
+        /// <summary>
+        /// Test that the bounding box being modified appropriately modifies the area as well.
+        /// </summary>
+        [Fact]
+        public void BoundingBoxModfication()
+        {
+            var rect = new BoundedRectangle((0, 1, 10, 10), (0, 0, 15, 15));
+            Assert.True(rect.BoundingBox.Contains(rect.Area));
+
+            // Bounding box modified to something that the current area will violate
+            rect.SetBoundingBox((-10, -10, 10, 10));
+            Assert.True(rect.BoundingBox.Contains(rect.Area));
+        }
+    }
+}

--- a/TheSadRogue.Primitives/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/BoundedRectangle.cs
@@ -31,29 +31,19 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// The rectangle that is guaranteed to be contained completely within <see cref="BoundingBox"/>,
-        /// and will be restricted as such when set to.
+        /// The rectangle that is guaranteed to be contained completely within <see cref="BoundingBox"/>.
+        /// Use <see cref="SetArea(Rectangle)"/> to set the area.
         /// </summary>
-        public Rectangle Area
+        public ref readonly Rectangle Area
         {
-            get => _area;
-
-            set
-            {
-                _area = value;
-                if (!_boundingBox.Contains(_area))
-                {
-                    BoundLock();
-                }
-            }
+            get => ref _area;
         }
 
         /// <summary>
-        /// The rectangle which <see cref="Area"/> is automatically bounded to be within.  Although this
-        /// property does not explicitly provide a set accessor, it is returning a reference so therefore
-        /// the property may be assigned to.
+        /// The rectangle which <see cref="Area"/> is automatically bounded to be within.  Use the
+        /// <see cref="SetBoundingBox(Rectangle)"/> property to set the bounding box.
         /// </summary>
-        public ref Rectangle BoundingBox => ref _boundingBox;
+        public ref readonly Rectangle BoundingBox => ref _boundingBox;
 
         /// <summary>
         /// True if the given BoundedRectangle has the same Bounds and Area as the current one.
@@ -94,6 +84,33 @@ namespace SadRogue.Primitives
         /// True if the types are not equal, false if they are both equal.
         /// </returns>
         public static bool operator !=(BoundedRectangle lhs, BoundedRectangle rhs) => !(lhs == rhs);
+
+        /// <summary>
+        /// Forces the area given to conform to the <see cref="BoundingBox"/> specified and sets it to <see cref="Area"/>.
+        /// </summary>
+        /// <param name="newArea">The new area to bound and set.</param>
+        public void SetArea(Rectangle newArea)
+        {
+            _area = newArea;
+            if (!_boundingBox.Contains(_area))
+            {
+                BoundLock();
+            }
+        }
+
+        /// <summary>
+        /// Sets the bounding box to the specified value, and forces the current area to fit within the bounding box
+        /// as needed.
+        /// </summary>
+        /// <param name="newBoundingBox">The new bounding box to apply.</param>
+        public void SetBoundingBox(Rectangle newBoundingBox)
+        {
+            _boundingBox = newBoundingBox;
+            if (!_boundingBox.Contains(_area))
+            {
+                BoundLock();
+            }
+        }
 
         private void BoundLock()
         {


### PR DESCRIPTION
- Modified `BoundingBox` to use `ref readonly Rectangle` as its return type for properties.  This necessitated the addition of setters for `BoundingBox` and `Area`, since `readonly ref` return types cannot be assigned to. 
    - This is imposing what is technically a new restriction on the library, as `readonly ref` was introduced in C# 7.2.  As such, users of the library must be using a compiler that supports at least C# 7.2.  Although the library previously imposed only a limitation of 7.0, 7.2 appears to be implemented by all the compilers I'm aware of (modern version of Unity included), so I don' think it's much of an issue in that regard.
    - If we want to maintain full C# 7.0 support, the only alternative I can think of is to return `Rectangle` from both of these properties, however this may cause a user to inadvertently create copies of the rectangle.  If `BoundingBox` returns a value type, `myBoundedRect.BoundingBox.X + myBoundedRect.BoundingBox.Width` creates 2 copies of the rectangle thanks to the semantics of value types, although at first glance this is not apparent.