### PR TITLE
Added readonly to struct and Pure attribute to functions

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
@@ -1,11 +1,15 @@
-﻿using MonoColor = Microsoft.Xna.Framework.Color;
+﻿using System.Diagnostics.Contracts;
+using MonoColor = Microsoft.Xna.Framework.Color;
 using SadRogueColor = SadRogue.Primitives.Color;
 
 namespace SadRogue.Primitives
 {
     public static class SadRogueColorExtensions
     {
+        [Pure]
         public static MonoColor ToMonoColor(this SadRogueColor self) => new MonoColor(self.R, self.G, self.B, self.A);
+
+        [Pure]
         public static bool Equals(this SadRogueColor self, MonoColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }
@@ -15,7 +19,10 @@ namespace Microsoft.Xna.Framework
 {
     public static class MonoColorExtensions
     {
+        [Pure]
         public static SadRogueColor ToSadRogueColor(this MonoColor self) => new SadRogueColor(self.R, self.G, self.B, self.A);
+
+        [Pure]
         public static bool Equals(this MonoColor self, SadRogueColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }

--- a/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using SadRogue.Primitives;
 using MonoPoint = Microsoft.Xna.Framework.Point;
 using SadRoguePoint = SadRogue.Primitives.Point;
@@ -7,15 +8,20 @@ namespace SadRogue.Primitives
 {
     public static class SadRoguePointExtensions
     {
-
+        [Pure]
         public static MonoPoint ToMonoPoint(this SadRoguePoint self) => new MonoPoint(self.X, self.Y);
+        [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+        [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
 
+        [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
+        [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, MonoPoint other)
             => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static bool Equals(this SadRoguePoint self, MonoPoint other) => self.X == other.X && self.Y == other.Y;
     }
 }
@@ -24,24 +30,36 @@ namespace Microsoft.Xna.Framework
 {
     public static class MonoPointExtensions
     {
+        [Pure]
         public static SadRoguePoint ToPoint(this MonoPoint self) => new SadRoguePoint(self.X, self.Y);
+        [Pure]
         public static MonoPoint Add(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X + other.X, self.Y + other.Y);
+        [Pure]
         public static MonoPoint Add(this MonoPoint self, int i) => new MonoPoint(self.X + i, self.Y + i);
+        [Pure]
         public static MonoPoint Add(this MonoPoint self, Direction dir) => new MonoPoint(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+        [Pure]
         public static MonoPoint Subtract(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X - other.X, self.Y - other.Y);
+        [Pure]
         public static MonoPoint Subtract(this MonoPoint self, int i) => new MonoPoint(self.X - i, self.Y - i);
 
+        [Pure]
         public static MonoPoint Multiply(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X * other.X, self.Y * other.Y);
+        [Pure]
         public static MonoPoint Multiply(this MonoPoint self, int i) => new MonoPoint(self.X * i, self.Y * i);
+        [Pure]
         public static MonoPoint Multiply(this MonoPoint self, double d)
             => new MonoPoint((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static MonoPoint Divide(this MonoPoint self, SadRoguePoint other)
             => new MonoPoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static MonoPoint Divide(this MonoPoint self, double d)
             => new MonoPoint((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static bool Equals(this MonoPoint self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 }

--- a/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
@@ -1,12 +1,15 @@
-﻿using MonoRectangle = Microsoft.Xna.Framework.Rectangle;
+﻿using System.Diagnostics.Contracts;
+using MonoRectangle = Microsoft.Xna.Framework.Rectangle;
 using SadRogueRectangle = SadRogue.Primitives.Rectangle;
 
 namespace SadRogue.Primitives
 {
     public static class SadRogueRectangleExtensions
     {
+        [Pure]
         public static MonoRectangle ToMonoRectangle(this SadRogueRectangle self) => new MonoRectangle(self.X, self.Y, self.Width, self.Height);
 
+        [Pure]
         public static bool Equals(this SadRogueRectangle self, MonoRectangle other)
             => self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height;
     }
@@ -16,8 +19,10 @@ namespace Microsoft.Xna.Framework
 {
     public static class MonoRectangleExtensions
     {
+        [Pure]
         public static SadRogueRectangle ToRectangle(this MonoRectangle self) => new SadRogueRectangle(self.X, self.Y, self.Width, self.Height);
 
+        [Pure]
         public static bool Equals(this MonoRectangle self, SadRogueRectangle other)
             => self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height;
     }

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -4,16 +4,16 @@
     <!-- Basic package info -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
-	<Version>1.0.0-alpha1</Version>
+	<Version>1.0.0-alpha2</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2019 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+	<Copyright>Copyright © 2020 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-	<PackageReleaseNotes>Initial alpha release.</PackageReleaseNotes>
+	<PackageReleaseNotes>Added Pure attribute to appropriate struct functions.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha1" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha4" />
   </ItemGroup>
   
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.SFML/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/ColorExtensions.cs
@@ -1,11 +1,14 @@
-﻿using SFMLColor = SFML.Graphics.Color;
+﻿using System.Diagnostics.Contracts;
+using SFMLColor = SFML.Graphics.Color;
 using SadRogueColor = SadRogue.Primitives.Color;
 
 namespace SadRogue.Primitives
 {
     public static class SadRogueColorExtensions
     {
+        [Pure]
         public static SFMLColor ToSFMLColor(this SadRogueColor self) => new SFMLColor(self.R, self.G, self.B, self.A);
+        [Pure]
         public static bool Equals(this SadRogueColor self, SFMLColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }
@@ -15,7 +18,9 @@ namespace SFML.Graphics
 {
     public static class SFMLColorExtensions
     {
+        [Pure]
         public static SadRogueColor ToSadRogueColor(this SFMLColor self) => new SadRogueColor(self.R, self.G, self.B, self.A);
+        [Pure]
         public static bool Equals(this SFMLColor self, SadRogueColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }

--- a/TheSadRogue.Primitives.SFML/PointExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/PointExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using SadRogue.Primitives;
 using SFML.System;
 using SadRoguePoint = SadRogue.Primitives.Point;
@@ -7,32 +8,49 @@ namespace SadRogue.Primitives
 {
     public static class SadRoguePointExtensions
     {
-
+        [Pure]
         public static Vector2i ToVector2i(this SadRoguePoint self) => new Vector2i(self.X, self.Y);
+        [Pure]
         public static Vector2u ToVector2u(this SadRoguePoint self) => new Vector2u((uint)self.X, (uint)self.Y);
+        [Pure]
         public static Vector2f ToVector2f(this SadRoguePoint self) => new Vector2f(self.X, self.Y);
+        [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+        [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X + (int)other.X, self.Y + (int)other.Y);
+        [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X + other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y + other.Y, MidpointRounding.AwayFromZero));
+        [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
+        [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X - (int)other.X, self.Y - (int)other.Y);
+        [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X - other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y - other.Y, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
+        [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X * (int)other.X, self.Y * (int)other.Y);
+        [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X * other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * other.Y, MidpointRounding.AwayFromZero));
+        [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2i other)
             => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+        [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2u other)
             => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+        [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X / other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / other.Y, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static bool Equals(this SadRoguePoint self, Vector2i other) => self.X == other.X && self.Y == other.Y;
+        [Pure]
         public static bool Equals(this SadRoguePoint self, Vector2u other) => self.X == other.X && self.Y == other.Y;
+        [Pure]
         public static bool Equals(this SadRoguePoint self, Vector2f other) => self.X == other.X && self.Y == other.Y;
     }
 }
@@ -41,68 +59,104 @@ namespace SFML.System
 {
     public static class Vector2iExtensions
     {
+        [Pure]
         public static SadRoguePoint ToPoint(this Vector2i self) => new SadRoguePoint(self.X, self.Y);
+        [Pure]
         public static Vector2i Add(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X + other.X, self.Y + other.Y);
+        [Pure]
         public static Vector2i Add(this Vector2i self, int i) => new Vector2i(self.X + i, self.Y + i);
+        [Pure]
         public static Vector2i Add(this Vector2i self, Direction dir) => new Vector2i(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+        [Pure]
         public static Vector2i Subtract(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X - other.X, self.Y - other.Y);
+        [Pure]
         public static Vector2i Subtract(this Vector2i self, int i) => new Vector2i(self.X - i, self.Y - i);
 
+        [Pure]
         public static Vector2i Multiply(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X * other.X, self.Y * other.Y);
+        [Pure]
         public static Vector2i Multiply(this Vector2i self, int i) => new Vector2i(self.X * i, self.Y * i);
+        [Pure]
         public static Vector2i Multiply(this Vector2i self, double d)
             => new Vector2i((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static Vector2i Divide(this Vector2i self, SadRoguePoint other)
             => new Vector2i((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static Vector2i Divide(this Vector2i self, double d)
             => new Vector2i((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static bool Equals(this Vector2i self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 
     public static class Vector2uExtensions
     {
+        [Pure]
         public static SadRoguePoint ToPoint(this Vector2u self) => new SadRoguePoint((int)self.X, (int)self.Y);
+        [Pure]
         public static Vector2u Add(this Vector2u self, SadRoguePoint other) => new Vector2u(self.X + (uint)other.X, self.Y + (uint)other.Y);
+        [Pure]
         public static Vector2u Add(this Vector2u self, int i) => new Vector2u(self.X + (uint)i, self.Y + (uint)i);
+        [Pure]
         public static Vector2u Add(this Vector2u self, Direction dir) => new Vector2u((uint)(self.X + dir.DeltaX), (uint)(self.Y + dir.DeltaY));
+        [Pure]
         public static Vector2u Subtract(this Vector2u self, SadRoguePoint other) => new Vector2u((uint)(self.X - other.X), (uint)(self.Y - other.Y));
+        [Pure]
         public static Vector2u Subtract(this Vector2u self, int i) => new Vector2u((uint)(self.X - i), (uint)(self.Y - i));
 
+        [Pure]
         public static Vector2u Multiply(this Vector2u self, SadRoguePoint other) => new Vector2u((uint)(self.X * other.X), (uint)(self.Y * other.Y));
+        [Pure]
         public static Vector2u Multiply(this Vector2u self, int i) => new Vector2u((uint)(self.X * i), (uint)(self.Y * i));
+        [Pure]
         public static Vector2u Multiply(this Vector2u self, double d)
             => new Vector2u((uint)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static Vector2u Divide(this Vector2u self, SadRoguePoint other)
             => new Vector2u((uint)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static Vector2u Divide(this Vector2u self, double d)
             => new Vector2u((uint)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
+        [Pure]
         public static bool Equals(this Vector2u self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 
     public static class Vector2fExtensions
     {
+        [Pure]
         public static SadRoguePoint ToPoint(this Vector2f self)
             => new SadRoguePoint((int)Math.Round(self.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y, MidpointRounding.AwayFromZero));
+        [Pure]
         public static Vector2f Add(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X + other.X, self.Y + other.Y);
+        [Pure]
         public static Vector2f Add(this Vector2f self, int i) => new Vector2f(self.X + i, self.Y + i);
+        [Pure]
         public static Vector2f Add(this Vector2f self, Direction dir) => new Vector2f(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+
+        [Pure]
         public static Vector2f Subtract(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X - other.X, self.Y - other.Y);
+        [Pure]
         public static Vector2f Subtract(this Vector2f self, int i) => new Vector2f(self.X - i, self.Y - i);
 
+        [Pure]
         public static Vector2f Multiply(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X * other.X, self.Y * other.Y);
+        [Pure]
         public static Vector2f Multiply(this Vector2f self, int i) => new Vector2f(self.X * i, self.Y * i);
+        [Pure]
         public static Vector2f Multiply(this Vector2f self, double d) => new Vector2f(self.X * (float)d, self.Y * (float)d);
 
+        [Pure]
         public static Vector2f Divide(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X / other.X, self.Y / other.Y);
-
+        [Pure]
         public static Vector2f Divide(this Vector2f self, double d) => new Vector2f(self.X / (float)d, self.Y / (float)d);
 
+        [Pure]
         public static bool Equals(this Vector2f self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 }

--- a/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
@@ -1,12 +1,15 @@
-﻿using SFML.Graphics;
+﻿using System.Diagnostics.Contracts;
+using SFML.Graphics;
 using SadRogueRectangle = SadRogue.Primitives.Rectangle;
 
 namespace SadRogue.Primitives
 {
     public static class RectangleExtensions
     {
+        [Pure]
         public static IntRect ToIntRect(this SadRogueRectangle self) => new IntRect(self.X, self.Y, self.X + self.Width, self.Y + self.Height);
 
+        [Pure]
         public static bool Equals(this SadRogueRectangle self, IntRect other)
             => self.X == other.Left && self.Y == other.Top && self.Width == other.Width && self.Height == other.Height;
     }
@@ -16,8 +19,10 @@ namespace SFML.Graphics
 {
     public static class IntRectExtensions
     {
+        [Pure]
         public static SadRogueRectangle ToRectangle(this IntRect self) => new SadRogueRectangle(self.Left, self.Top, self.Width - self.Left, self.Height - self.Top);
 
+        [Pure]
         public static bool Equals(this IntRect self, SadRogueRectangle other)
             => self.Left == other.X && self.Top == other.Y && self.Width == other.Width && self.Height == other.Height;
     }

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -4,7 +4,7 @@
     <!-- Basic package info -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
-	<Version>1.0.0-alpha1</Version>
+	<Version>1.0.0-alpha2</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -13,7 +13,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>Initial alpha release.</PackageReleaseNotes>
+	<PackageReleaseNotes>Added Pure attribute to appropriate struct functions.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="SFML.Graphics" Version="2.5.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha1" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha4" />
   </ItemGroup>
   
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -10,7 +10,7 @@ namespace SadRogue.Primitives
     /// static instances are provided.
     /// </summary>
     [Serializable]
-    public struct AdjacencyRule : IEquatable<AdjacencyRule>
+    public readonly struct AdjacencyRule : IEquatable<AdjacencyRule>
     {
         /// <summary>
         /// Represents method of determining adjacency where neighbors are considered adjacent if

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 
 namespace SadRogue.Primitives
 {
     /// <summary>
     /// Structure representing a method for determining which coordinates are adjacent to a given
-    /// coordinate, and which directions those neighbors are in. Cannot be instantiated -- premade
+    /// coordinate, and which directions those neighbors are in. Cannot be instantiated -- pre-made
     /// static instances are provided.
     /// </summary>
     [Serializable]
@@ -33,7 +34,7 @@ namespace SadRogue.Primitives
         public static readonly AdjacencyRule EightWay = new AdjacencyRule(Types.EightWay);
 
         [NonSerialized]
-        private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
+        private static readonly string[] s_writeValues = Enum.GetNames(typeof(Types));
 
         // Constructor, takes type.
         private AdjacencyRule(Types type) => Type = type;
@@ -72,6 +73,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="adjacencyRuleType">The enum value for the adjacency method.</param>
         /// <returns>The <see cref="AdjacencyRule"/> class representing the given adjacency method type.</returns>
+        [Pure]
         public static AdjacencyRule ToAdjacencyRule(Types adjacencyRuleType)
         {
             switch (adjacencyRuleType)
@@ -95,6 +97,7 @@ namespace SadRogue.Primitives
         /// method. Cardinals are returned before any diagonals.
         /// </summary>
         /// <returns>Directions that lead to neighboring locations.</returns>
+        [Pure]
         public IEnumerable<Direction> DirectionsOfNeighbors()
         {
             switch (Type)
@@ -135,6 +138,7 @@ namespace SadRogue.Primitives
         /// causes the default starting direction to be used, which is UP for CARDINALS/EIGHT_WAY, and UP_RIGHT
         /// for diagonals.</param>
         /// <returns>Directions that lead to neighboring locations.</returns>
+        [Pure]
         public IEnumerable<Direction> DirectionsOfNeighborsClockwise(Direction startingDirection = default)
         {
             switch (Type)
@@ -197,6 +201,7 @@ namespace SadRogue.Primitives
         /// causes the default starting direction to be used, which is UP for CARDINALS/EIGHT_WAY, and UP_LEFT
         /// for diagonals.</param>
         /// <returns>Directions that lead to neighboring locations.</returns>
+        [Pure]
         public IEnumerable<Direction> DirectionsOfNeighborsCounterClockwise(Direction startingDirection = default)
         {
             switch (Type)
@@ -219,7 +224,7 @@ namespace SadRogue.Primitives
                     break;
 
                 case Types.Diagonals:
-                    if (startingDirection == null || startingDirection == Direction.None)
+                    if (startingDirection == Direction.None)
                     {
                         startingDirection = Direction.UpLeft;
                     }
@@ -236,7 +241,7 @@ namespace SadRogue.Primitives
                     break;
 
                 case Types.EightWay:
-                    if (startingDirection == null || startingDirection == Direction.None)
+                    if (startingDirection == Direction.None)
                     {
                         startingDirection = Direction.Up;
                     }
@@ -256,6 +261,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="startingLocation">Location to return neighbors for.</param>
         /// <returns>All neighbors of the given location.</returns>
+        [Pure]
         public IEnumerable<Point> Neighbors(Point startingLocation)
         {
             foreach (Direction dir in DirectionsOfNeighbors())
@@ -277,6 +283,7 @@ namespace SadRogue.Primitives
         /// for DIAGONALS.
         /// </param>
         /// <returns>All neighbors of the given location.</returns>
+        [Pure]
         public IEnumerable<Point> NeighborsClockwise(Point startingLocation, Direction startingDirection = default)
         {
             foreach (Direction dir in DirectionsOfNeighborsClockwise(startingDirection))
@@ -298,6 +305,7 @@ namespace SadRogue.Primitives
         /// <see cref="Direction.UpLeft"/> for DIAGONALS.
         /// </param>
         /// <returns>All neighbors of the given location.</returns>
+        [Pure]
         public IEnumerable<Point> NeighborsCounterClockwise(Point startingLocation, Direction startingDirection = default)
         {
             foreach (Direction dir in DirectionsOfNeighborsCounterClockwise(startingDirection))
@@ -311,6 +319,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">AdjacencyRule to compare.</param>
         /// <returns>True if the two directions are the same, false if not.</returns>
+        [Pure]
         public bool Equals(AdjacencyRule other) => Type == other.Type;
 
         /// <summary>
@@ -320,12 +329,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if <paramref name="obj"/> is an AdjacencyRule, and the two adjacency rules are equal, false otherwise.
         /// </returns>
+        [Pure]
         public override bool Equals(object obj) => obj is AdjacencyRule c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.
         /// </summary>
         /// <returns/>
+        [Pure]
         public override int GetHashCode() => Type.GetHashCode();
 
         /// <summary>
@@ -334,6 +345,7 @@ namespace SadRogue.Primitives
         /// <param name="lhs"/>
         /// <param name="rhs"/>
         /// <returns>True if the two adjacency rules are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(AdjacencyRule lhs, AdjacencyRule rhs) => lhs.Type == rhs.Type;
 
         /// <summary>
@@ -344,12 +356,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the types are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(AdjacencyRule lhs, AdjacencyRule rhs) => !(lhs == rhs);
 
         /// <summary>
         /// Returns a string representation of the <see cref="AdjacencyRule"/>.
         /// </summary>
         /// <returns>A string representation of the <see cref="AdjacencyRule"/>.</returns>
-        public override string ToString() => s_writeVals[(int)Type];
+        [Pure]
+        public override string ToString() => s_writeValues[(int)Type];
     }
 }

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -355,6 +356,7 @@ namespace SadRogue.Primitives
         /// <param name="a"><see cref="Color"/> instance on the left of the equal sign.</param>
         /// <param name="b"><see cref="Color"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator ==(Color a, Color b) => (a._packedValue == b._packedValue);
 
         /// <summary>
@@ -362,13 +364,15 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="a"><see cref="Color"/> instance on the left of the not equal sign.</param>
         /// <param name="b"><see cref="Color"/> instance on the right of the not equal sign.</param>
-        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public static bool operator !=(Color a, Color b) => (a._packedValue != b._packedValue);
 
         /// <summary>
         /// Gets the hash code of this <see cref="Color"/>.
         /// </summary>
         /// <returns>Hash code of this <see cref="Color"/>.</returns>
+        [Pure]
         public override int GetHashCode() => _packedValue.GetHashCode();
 
         /// <summary>
@@ -376,7 +380,8 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="obj">The <see cref="Color"/> to compare.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public override bool Equals(object obj) => ((obj is Color) && Equals((Color)obj));
+        [Pure]
+        public override bool Equals(object obj) => (obj is Color color) && Equals(color);
 
         #region Color Bank Ansi
         /// <summary>
@@ -1737,6 +1742,7 @@ namespace SadRogue.Primitives
         /// Gets the luma of an existing color.
         /// </summary>
         /// <returns>A value based on this code: (color.R + color.R + color.B + color.G + color.G + color.G) / 6f</returns>
+        [Pure]
         public float GetLuma() => (R + R + B + G + G + G) / 6f;
 
         /// <summary>
@@ -1744,6 +1750,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>The brightness value.</returns>
         /// <remarks>Taken from the mono source code.</remarks>
+        [Pure]
         public float GetBrightness()
         {
             byte minval = Math.Min(R, Math.Min(G, B));
@@ -1757,6 +1764,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>The saturation value.</returns>
         /// <remarks>Taken from the mono source code.</remarks>
+        [Pure]
         public float GetSaturation()
         {
             byte minval = Math.Min(R, Math.Min(G, B));
@@ -1782,6 +1790,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>The hue value.</returns>
         /// <remarks>Taken from the mono source code.</remarks>
+        [Pure]
         public float GetHue()
         {
             byte minval = Math.Min(R, Math.Min(G, B));
@@ -1830,6 +1839,7 @@ namespace SadRogue.Primitives
         /// <param name="value2">Destination <see cref="Color"/>.</param>
         /// <param name="amount">Interpolation factor.</param>
         /// <returns>Interpolated <see cref="Color"/>.</returns>
+        [Pure]
         public static Color Lerp(Color value1, Color value2, float amount)
         {
             amount = MathHelpers.Clamp(amount, 0, 1);
@@ -1846,6 +1856,7 @@ namespace SadRogue.Primitives
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
+        [Pure]
         public static Color Multiply(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
@@ -1855,6 +1866,7 @@ namespace SadRogue.Primitives
         /// <param name="endingColor">The ending color which will be at index `steps - 1` in the array.</param>
         /// <param name="steps">The gradient steps in the array which uses <see cref="Lerp(Color, Color, float)"/>.</param>
         /// <returns>An array of colors.</returns>
+        [Pure]
         public static Color[] LerpSteps(Color startingColor, Color endingColor, int steps)
         {
             Color[] colors = new Color[steps];
@@ -1883,6 +1895,7 @@ namespace SadRogue.Primitives
         /// <param name="s">The saturation amount.</param>
         /// <param name="l">The luminance amount.</param>
         /// <remarks>Taken from http://www.easyrgb.com/index.php?X=MATH&amp;H=19#text19 </remarks>
+        [Pure]
         public static Color FromHSL(float h, float s, float l)
         {
             if (s == 0f)
@@ -1953,6 +1966,7 @@ namespace SadRogue.Primitives
         /// <param name="value">Source <see cref="Color"/>.</param>
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
+        [Pure]
         public static Color operator *(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
@@ -1975,6 +1989,7 @@ namespace SadRogue.Primitives
         /// {R:[red] G:[green] B:[blue] A:[alpha]}
         /// </summary>
         /// <returns><see cref="string"/> representation of this <see cref="Color"/>.</returns>
+        [Pure]
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder(25);
@@ -1998,6 +2013,7 @@ namespace SadRogue.Primitives
         /// <param name="b">Blue component value.</param>
         /// <param name="a">Alpha component value.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
+        [Pure]
         public static Color FromNonPremultiplied(int r, int g, int b, int a) => new Color(r * a / 255, g * a / 255, b * a / 255, a);
 
         #region IEquatable<Color> Members
@@ -2007,6 +2023,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">The <see cref="Color"/> to compare.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        [Pure]
         public bool Equals(Color other) => PackedValue == other.PackedValue;
 
         #endregion
@@ -2017,6 +2034,7 @@ namespace SadRogue.Primitives
         /// <param name="r"></param>
         /// <param name="g"></param>
         /// <param name="b"></param>
+        [Pure]
         public void Deconstruct(out float r, out float g, out float b)
         {
             r = R;
@@ -2031,6 +2049,7 @@ namespace SadRogue.Primitives
         /// <param name="g"></param>
         /// <param name="b"></param>
         /// <param name="a"></param>
+        [Pure]
         public void Deconstruct(out float r, out float g, out float b, out float a)
         {
             r = R;
@@ -2045,6 +2064,7 @@ namespace SadRogue.Primitives
         /// <param name="r"></param>
         /// <param name="g"></param>
         /// <param name="b"></param>
+        [Pure]
         public void Deconstruct(out byte r, out byte g, out byte b)
         {
             r = R;
@@ -2059,6 +2079,7 @@ namespace SadRogue.Primitives
         /// <param name="g"></param>
         /// <param name="b"></param>
         /// <param name="a"></param>
+        [Pure]
         public void Deconstruct(out byte r, out byte g, out byte b, out byte a)
         {
             r = R;

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -16,7 +16,7 @@ namespace SadRogue.Primitives
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     [Serializable]
-    public struct Color : IEquatable<Color>
+    public readonly struct Color : IEquatable<Color>
     {
         static Color()
         {

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace SadRogue.Primitives
@@ -203,6 +204,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Direction to compare.</param>
         /// <returns>True if the two directions are the same, false if not.</returns>
+        [Pure]
         public bool Equals(Direction other) => Type == other.Type;
 
         /// <summary>
@@ -212,12 +214,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if <paramref name="obj"/> is a Direction, and the two directions are equal, false otherwise.
         /// </returns>
+        [Pure]
         public override bool Equals(object obj) => obj is Direction c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.
         /// </summary>
         /// <returns/>
+        [Pure]
         public override int GetHashCode() => Type.GetHashCode();
 
         /// <summary>
@@ -226,6 +230,7 @@ namespace SadRogue.Primitives
         /// <param name="lhs"/>
         /// <param name="rhs"/>
         /// <returns>True if the two directions are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Direction lhs, Direction rhs) => lhs.Type == rhs.Type;
 
         /// <summary>
@@ -236,6 +241,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the types are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Direction lhs, Direction rhs) => !(lhs == rhs);
 
         // Do not change manually outside of YIncreasesUpwards functionality
@@ -274,6 +280,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The cardinal direction that most closely matches the heading indicated by the given line.
         /// </returns>
+        [Pure]
         public static Direction GetCardinalDirection(Point start, Point end) => GetCardinalDirection(new Point(end.X - start.X, end.Y - start.Y));
 
         /// <summary>
@@ -288,6 +295,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The cardinal direction that most closely matches the degree heading of the given line.
         /// </returns>
+        [Pure]
         public static Direction GetCardinalDirection(Point deltaChange)
         {
             int dx = deltaChange.X;
@@ -337,6 +345,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The direction that most closely matches the heading indicated by the given line.
         /// </returns>
+        [Pure]
         public static Direction GetDirection(Point start, Point end) => GetDirection(new Point(end.X - start.X, end.Y - start.Y));
 
 
@@ -351,6 +360,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The direction that most closely matches the heading indicated by the given input.
         /// </returns>
+        [Pure]
         public static Direction GetDirection(Point deltaChange)
         {
             int dx = deltaChange.X;
@@ -419,6 +429,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The given direction moved counter-clockwise <paramref name="i"/> times.
         /// </returns>
+        [Pure]
         public static Direction operator -(Direction d, int i) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type - i - 1, 8)]);
 
         /// <summary>
@@ -426,6 +437,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="d"/>
         /// <returns>The direction one unit counterclockwise of <paramref name="d"/>.</returns>
+        [Pure]
         public static Direction operator --(Direction d) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type - 2, 8)]);
 
         /// <summary>
@@ -436,6 +448,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// The given direction moved clockwise <paramref name="i"/> times.
         /// </returns>
+        [Pure]
         public static Direction operator +(Direction d, int i) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type + i - 1, 8)]);
 
         /// <summary>
@@ -443,6 +456,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="d"/>
         /// <returns>The direction one unit clockwise of <paramref name="d"/>.</returns>
+        [Pure]
         public static Direction operator ++(Direction d) => (d == None) ? None : ToDirection(s_validTypes[WrapAround((int)d.Type, 8)]);
 
         /// <summary>
@@ -450,6 +464,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="directionType">The enum value for the direction.</param>
         /// <returns>The direction class representing the given direction.</returns>
+        [Pure]
         public static Direction ToDirection(Types directionType)
         {
             switch (directionType)
@@ -490,12 +505,14 @@ namespace SadRogue.Primitives
         /// Returns true if the current direction is a cardinal direction.
         /// </summary>
         /// <returns>True if the current direction is a cardinal direction, false otherwise.</returns>
+        [Pure]
         public bool IsCardinal() => this != None && (DeltaX == 0 || DeltaY == 0);
 
         /// <summary>
         /// Writes the string (eg. "UP", "UP_RIGHT", etc.) for the direction.
         /// </summary>
         /// <returns>String representation of the direction.</returns>
+        [Pure]
         public override string ToString() => s_writeVals[(int)Type];
 
         #region Tuple Compatibility
@@ -507,6 +524,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Tuple (tuple.y + d.DeltaX, tuple.y + d.DeltaY).
         /// </returns>
+        [Pure]
         public static (int x, int y) operator +((int x, int y) tuple, Direction d) => (tuple.x + d.DeltaX, tuple.y + d.DeltaY);
         #endregion
 

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -22,7 +22,7 @@ namespace SadRogue.Primitives
     /// coordinate plane defined by Unity and other game engines.
     /// </remarks>
     [Serializable]
-    public struct Direction : IEquatable<Direction>
+    public readonly struct Direction : IEquatable<Direction>
     {
         [NonSerialized]
         private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -15,7 +15,7 @@ namespace SadRogue.Primitives
     /// locations and a radius shape are implied by a distance calculation).
     /// </remarks>
     [Serializable]
-    public struct Distance : IEquatable<Distance>
+    public readonly struct Distance : IEquatable<Distance>
     {
         /// <summary>
         /// Represents chebyshev distance (equivalent to 8-way movement with no extra cost for diagonals).

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 
 namespace SadRogue.Primitives
 {
@@ -76,6 +77,7 @@ namespace SadRogue.Primitives
         /// casted will be returned.
         /// </remarks>
         /// <param name="distance"/>
+        [Pure]
         public static implicit operator Radius(Distance distance)
         {
             switch (distance.Type)
@@ -102,6 +104,7 @@ namespace SadRogue.Primitives
         /// distance calculation casted will be returned.
         /// </remarks>
         /// <param name="distance"/>
+        [Pure]
         public static implicit operator AdjacencyRule(Distance distance)
         {
             switch (distance.Type)
@@ -123,6 +126,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="distanceType">The enum value for the distance calculation method.</param>
         /// <returns>The Distance class representing the given distance calculation.</returns>
+        [Pure]
         public static Distance ToDistance(Types distanceType)
         {
             switch (distanceType)
@@ -147,6 +151,7 @@ namespace SadRogue.Primitives
         /// <param name="start">Starting point.</param>
         /// <param name="end">Ending point.</param>
         /// <returns>The distance between the two points.</returns>
+        [Pure]
         public double Calculate(Point start, Point end) => Calculate(start.X, start.Y, end.X, end.Y);
 
         /// <summary>
@@ -157,6 +162,7 @@ namespace SadRogue.Primitives
         /// <param name="endX">X-Coordinate of the ending point.</param>
         /// <param name="endY">Y-Coordinate of the ending point.</param>
         /// <returns>The distance between the two points.</returns>
+        [Pure]
         public double Calculate(double startX, double startY, double endX, double endY)
         {
             double dx = startX - endX;
@@ -169,8 +175,8 @@ namespace SadRogue.Primitives
         /// (specified by the X and Y values of the given vector).
         /// </summary>
         /// <param name="deltaChange">The delta-x and delta-y between the two locations.</param>
-        /// ///
         /// <returns>The distance between two locations withe the given delta-change values.</returns>
+        [Pure]
         public double Calculate(Point deltaChange) => Calculate(deltaChange.X, deltaChange.Y);
 
         /// <summary>
@@ -179,6 +185,7 @@ namespace SadRogue.Primitives
         /// <param name="dx">The delta-x between the two locations.</param>
         /// <param name="dy">The delta-y between the two locations.</param>
         /// <returns>The distance between two locations with the given delta-change values.</returns>
+        [Pure]
         public double Calculate(double dx, double dy)
         {
             dx = Math.Abs(dx);
@@ -207,6 +214,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Distance to compare.</param>
         /// <returns>True if the two distance calculation methods are the same, false if not.</returns>
+        [Pure]
         public bool Equals(Distance other) => Type == other.Type;
 
         /// <summary>
@@ -216,12 +224,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if <paramref name="obj"/> is a Distance, and the two distance calculations are equal, false otherwise.
         /// </returns>
+        [Pure]
         public override bool Equals(object obj) => obj is Distance c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.
         /// </summary>
         /// <returns/>
+        [Pure]
         public override int GetHashCode() => Type.GetHashCode();
 
         /// <summary>
@@ -230,6 +240,7 @@ namespace SadRogue.Primitives
         /// <param name="lhs"/>
         /// <param name="rhs"/>
         /// <returns>True if the two distance calculations are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Distance lhs, Distance rhs) => lhs.Type == rhs.Type;
 
         /// <summary>
@@ -240,12 +251,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the types are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Distance lhs, Distance rhs) => !(lhs == rhs);
 
         /// <summary>
         /// Returns a string representation of the distance calculation method represented.
         /// </summary>
         /// <returns>A string representation of the distance method represented.</returns>
+        [Pure]
         public override string ToString() => s_writeVals[(int)Type];
     }
 }

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -9,7 +9,7 @@ namespace SadRogue.Primitives
     /// A gradient stop. Defines a color and where it is located within the gradient.
     /// </summary>
     [Serializable]
-    public struct GradientStop : IEquatable<GradientStop>
+    public readonly struct GradientStop : IEquatable<GradientStop>
     {
         /// <summary>
         /// The color.

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 
 namespace SadRogue.Primitives
 {
@@ -31,13 +32,19 @@ namespace SadRogue.Primitives
             Stop = stop;
         }
 
+        [Pure]
         public static bool operator ==(GradientStop lhs, GradientStop rhs) => lhs.Color == rhs.Color && lhs.Stop == rhs.Stop;
+
+        [Pure]
         public static bool operator !=(GradientStop lhs, GradientStop rhs) => !(lhs == rhs);
 
+        [Pure]
         public override int GetHashCode() => Color.GetHashCode() ^ Stop.GetHashCode();
 
+        [Pure]
         public override bool Equals(object obj) => obj is GradientStop g && this == g;
 
+        [Pure]
         public bool Equals(GradientStop g) => Color == g.Color && Stop == g.Stop;
     }
 

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -16,7 +16,7 @@ namespace SadRogue.Primitives
     /// as well as interoperability with other grid-based classes like <see cref="Direction"/>.
     /// </remarks>
     [Serializable]
-    public struct Point : IEquatable<Point>, IEquatable<(int x, int y)>
+    public readonly struct Point : IEquatable<Point>, IEquatable<(int x, int y)>
     {
         /// <summary>
         /// Point value that represents None or no position (since Point is not a nullable type).

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 
 namespace SadRogue.Primitives
 {
@@ -55,18 +56,20 @@ namespace SadRogue.Primitives
         /// <param name="start">Position of line starting point.</param>
         /// <param name="end">Position of line ending point.</param>
         /// <returns>The degree bearing of the line specified by the two given points.</returns>
+        [Pure]
         public static double BearingOfLine(Point start, Point end) => BearingOfLine(start - end);
 
 
         /// <summary>
         /// Calculates the degree bearing of a line with the given delta-x and delta-y values, where
-        /// 0 degreees points in the direction <see cref="Direction.Up"/>.
+        /// 0 degrees points in the direction <see cref="Direction.Up"/>.
         /// </summary>
         /// <param name="deltaChange">
         /// Vector, where deltaChange.X is the change in x-values across the line, and deltaChange.Y
         /// is the change in y-values across the line.
         /// </param>
         /// <returns>The degree bearing of the line with the given dx and dy values.</returns>
+        [Pure]
         public static double BearingOfLine(Point deltaChange)
         {
             int dx = deltaChange.X;
@@ -92,6 +95,7 @@ namespace SadRogue.Primitives
         /// The "magnitude" of the euclidean distance between the two points -- basically the
         /// distance formula without the square root.
         /// </returns>
+        [Pure]
         public static double EuclideanDistanceMagnitude(Point c1, Point c2) => EuclideanDistanceMagnitude(c2 - c1);
 
         /// <summary>
@@ -108,6 +112,7 @@ namespace SadRogue.Primitives
         /// The "magnitude" of the euclidean distance of two locations with the given dx and dy
         /// values -- basically the distance formula without the square root.
         /// </returns>
+        [Pure]
         public static double EuclideanDistanceMagnitude(Point deltaChange) => deltaChange.X * deltaChange.X + deltaChange.Y * deltaChange.Y;
 
 
@@ -117,6 +122,7 @@ namespace SadRogue.Primitives
         /// <param name="c1">The first point.</param>
         /// <param name="c2">The second point.</param>
         /// <returns>The midpoint between <paramref name="c1"/> and <paramref name="c2"/>.</returns>
+        [Pure]
         public static Point Midpoint(Point c1, Point c2) =>
             new Point((int)Math.Round((c1.X + c2.X) / 2.0f, MidpointRounding.AwayFromZero), (int)Math.Round((c1.Y + c2.Y) / 2.0f, MidpointRounding.AwayFromZero));
 
@@ -126,6 +132,7 @@ namespace SadRogue.Primitives
         /// <param name="c1"></param>
         /// <param name="c2"></param>
         /// <returns>The coordinate(<paramref name="c1"/> - <paramref name="c2"/>).</returns>
+        [Pure]
         public static Point operator -(Point c1, Point c2) => new Point(c1.X - c2.X, c1.Y - c2.Y);
 
         /// <summary>
@@ -134,6 +141,7 @@ namespace SadRogue.Primitives
         /// <param name="point"/>
         /// <param name="direction"/>
         /// <returns>The coordinate (point.X - direction.DeltaX, point.Y - direction.DeltaY).</returns>
+        [Pure]
         public static Point operator -(Point point, Direction direction) => new Point(point.X - direction.DeltaX, point.Y - direction.DeltaY);
 
         /// <summary>
@@ -142,6 +150,7 @@ namespace SadRogue.Primitives
         /// <param name="c"></param>
         /// <param name="i"></param>
         /// <returns>The coordinate (c.X - <paramref name="i"/>, c.Y - <paramref name="i"/>).</returns>
+        [Pure]
         public static Point operator -(Point c, int i) => new Point(c.X - i, c.Y - i);
 
         /// <summary>
@@ -152,6 +161,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if either the x-values or y-values are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Point c1, Point c2) => !(c1 == c2);
 
         /// <summary>
@@ -160,6 +170,7 @@ namespace SadRogue.Primitives
         /// <param name="c1"/>
         /// <param name="c2"/>
         /// <returns>Position (c1.X * c2.X, c1.Y * c2.Y)</returns>
+        [Pure]
         public static Point operator *(Point c1, Point c2) => new Point(c1.X * c2.X, c1.Y * c2.Y);
 
         /// <summary>
@@ -168,6 +179,7 @@ namespace SadRogue.Primitives
         /// <param name="c"></param>
         /// <param name="i"></param>
         /// <returns>Coordinate (c.X * <paramref name="i"/>, c.Y * <paramref name="i"/>)</returns>
+        [Pure]
         public static Point operator *(Point c, int i) => new Point(c.X * i, c.Y * i);
 
         /// <summary>
@@ -180,6 +192,7 @@ namespace SadRogue.Primitives
         /// Position (c.X * <paramref name="i"/>, c.Y * <paramref name="i"/>), with the resulting values
         /// rounded to nearest integer.
         /// </returns>
+        [Pure]
         public static Point operator *(Point c, double i) =>
             new Point((int)Math.Round(c.X * i, MidpointRounding.AwayFromZero), (int)Math.Round(c.Y * i, MidpointRounding.AwayFromZero));
 
@@ -190,6 +203,7 @@ namespace SadRogue.Primitives
         /// <param name="c1"/>
         /// <param name="c2"/>
         /// <returns>Position (c1.X / c2.X, c1.Y / c2.Y), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static Point operator /(Point c1, Point c2) =>
             new Point((int)Math.Round(c1.X / (double)c2.X, MidpointRounding.AwayFromZero), (int)Math.Round(c1.Y / (double)c2.Y, MidpointRounding.AwayFromZero));
 
@@ -200,6 +214,7 @@ namespace SadRogue.Primitives
         /// <param name="c"></param>
         /// <param name="i"></param>
         /// <returns>(c.X / <paramref name="i"/>, c.Y / <paramref name="i"/>), with the resulting values rounded to the nearest integer.</returns>
+        [Pure]
         public static Point operator /(Point c, double i) =>
             new Point((int)Math.Round(c.X / i, MidpointRounding.AwayFromZero), (int)Math.Round(c.Y / i, MidpointRounding.AwayFromZero));
 
@@ -209,6 +224,7 @@ namespace SadRogue.Primitives
         /// <param name="c1"></param>
         /// <param name="c2"></param>
         /// <returns>The position (c1.X + c2.X, c1.Y + c2.Y)</returns>
+        [Pure]
         public static Point operator +(Point c1, Point c2) => new Point(c1.X + c2.X, c1.Y + c2.Y);
 
         /// <summary>
@@ -217,6 +233,7 @@ namespace SadRogue.Primitives
         /// <param name="c"></param>
         /// <param name="i"></param>
         /// <returns>Position (c.X + <paramref name="i"/>, c.Y + <paramref name="i"/>.</returns>
+        [Pure]
         public static Point operator +(Point c, int i) => new Point(c.X + i, c.Y + i);
 
         /// <summary>
@@ -227,6 +244,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Position (c.X + d.DeltaX, c.Y + d.DeltaY)
         /// </returns>
+        [Pure]
         public static Point operator +(Point c, Direction d) => new Point(c.X + d.DeltaX, c.Y + d.DeltaY);
 
         /// <summary>
@@ -235,6 +253,7 @@ namespace SadRogue.Primitives
         /// <param name="c1"></param>
         /// <param name="c2"></param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Point c1, Point c2) => c1.X == c2.X && c1.Y == c2.Y;
 
         /// <summary>
@@ -243,6 +262,7 @@ namespace SadRogue.Primitives
         /// <param name="index">The index in 1D form.</param>
         /// <param name="width">The width of the 2D array.</param>
         /// <returns>The position represented by the 1D index given.</returns>
+        [Pure]
         public static Point FromIndex(int index, int width) => new Point(index % width, index / width);
 
         /// <summary>
@@ -252,6 +272,7 @@ namespace SadRogue.Primitives
         /// <param name="y">Y-value of the coordinate.</param>
         /// <param name="width">The width of the 2D array, used to do the math to calculate index.</param>
         /// <returns>The 1D index of the position specified.</returns>
+        [Pure]
         public static int ToIndex(int x, int y, int width) => y * width + x;
 
         /// <summary>
@@ -260,6 +281,7 @@ namespace SadRogue.Primitives
         /// <param name="index">The index in 1D form.</param>
         /// <param name="width">The width of the 2D array.</param>
         /// <returns>The X-value for the location represented by the given index.</returns>
+        [Pure]
         public static int ToXValue(int index, int width) => index % width;
 
         /// <summary>
@@ -268,6 +290,7 @@ namespace SadRogue.Primitives
         /// <param name="index">The index in 1D form.</param>
         /// <param name="width">The width of the 2D array.</param>
         /// <returns>The Y-value for the location represented by the given index.</returns>
+        [Pure]
         public static int ToYValue(int index, int width) => index / width;
 
         /// <summary>
@@ -277,6 +300,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if <paramref name="obj"/> is a Coord instance, and the two positions are equal, false otherwise.
         /// </returns>
+        [Pure]
         public override bool Equals(object obj) => obj is Point c && Equals(c);
 
         /// <summary>
@@ -284,13 +308,14 @@ namespace SadRogue.Primitives
         /// does not collide often.
         /// </summary>
         /// <remarks>
-        /// This hashing algorithm uses a seperate bit-mixing algorithm for <see cref="X"/> and
-        /// <see cref="Y"/>, with X and Y each multiplied by a differet large integer, then xors
+        /// This hashing algorithm uses a separate bit-mixing algorithm for <see cref="X"/> and
+        /// <see cref="Y"/>, with X and Y each multiplied by a different large integer, then xors
         /// the mixed values, does a right shift, and finally multiplies by an overflowing prime
         /// number.  This hashing algorithm should produce an exceptionally low collision rate for
         /// coordinates between (0, 0) and (255, 255), and remain relatively reasonable beyond that.
         /// </remarks>
         /// <returns>The hash-code for the Point.</returns>
+        [Pure]
         public override int GetHashCode()
         {
             // Intentional overflow on both of these, part of hash-code generation
@@ -304,12 +329,14 @@ namespace SadRogue.Primitives
         /// <param name="width">The width of the 2D map/array this location is referring to --
         /// used to do the math to calculate index.</param>
         /// <returns>The 1D index of this Point.</returns>
+        [Pure]
         public int ToIndex(int width) => Y * width + X;
 
         /// <summary>
         /// Returns representation (X, Y).
         /// </summary>
         /// <returns>String (X, Y)</returns>
+        [Pure]
         public override string ToString() => $"({X},{Y})";
 
         /// <summary>
@@ -321,6 +348,7 @@ namespace SadRogue.Primitives
         /// delta-y value.
         /// </param>
         /// <returns>The position (<see cref="X"/> + deltaChange.X, <see cref="Y"/> + deltaChange.Y)</returns>
+        [Pure]
         public Point Translate(Point deltaChange) => new Point(X + deltaChange.X, Y + deltaChange.Y);
 
         /// <summary>
@@ -328,6 +356,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="x">X-value for the new Point.</param>
         /// <returns>A new Point, with its X value changed to the given one.</returns>
+        [Pure]
         public Point WithX(int x) => new Point(x, Y);
 
         /// <summary>
@@ -335,6 +364,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="y">Y-value for the new Point.</param>
         /// <returns>A new Point, with its Y value changed to the given one.</returns>
+        [Pure]
         public Point WithY(int y) => new Point(X, y);
 
         /// <summary>
@@ -342,6 +372,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Position to compare.</param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public bool Equals(Point other) => X == other.X && Y == other.Y;
 
         #region TupleCompatibility
@@ -350,6 +381,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="x" />
         /// <param name="y" />
+        [Pure]
         public void Deconstruct(out int x, out int y)
         {
             x = X;
@@ -361,12 +393,14 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="c" />
         /// <returns />
+        [Pure]
         public static implicit operator (int x, int y)(Point c) => (c.X, c.Y);
         /// <summary>
         /// Implicitly converts a tuple of two integers to an equivalent Point.
         /// </summary>
         /// <param name="tuple" />
         /// <returns />
+        [Pure]
         public static implicit operator Point((int x, int y) tuple) => new Point(tuple.x, tuple.y);
 
         /// <summary>
@@ -375,6 +409,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple" />
         /// <param name="c" />
         /// <returns>A tuple (tuple.x + c.X, tuple.y + c.Y).</returns>
+        [Pure]
         public static (int x, int y) operator +((int x, int y) tuple, Point c) => (tuple.x + c.X, tuple.y + c.Y);
         /// <summary>
         /// Adds the x and y values of a tuple of two integers to a Point.
@@ -382,6 +417,7 @@ namespace SadRogue.Primitives
         /// <param name="c" />
         /// <param name="tuple" />
         /// <returns>Position (c.X + tuple.x, c.Y + tuple.y).</returns>
+        [Pure]
         public static Point operator +(Point c, (int x, int y) tuple) => new Point(c.X + tuple.x, c.Y + tuple.y);
 
         /// <summary>
@@ -390,6 +426,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple" />
         /// <param name="c" />
         /// <returns>A tuple (tuple.x - c.X, tuple.y - c.Y).</returns>
+        [Pure]
         public static (int x, int y) operator -((int x, int y) tuple, Point c) => (tuple.x - c.X, tuple.y - c.Y);
         /// <summary>
         /// Subtracts the x and y values of a tuple of two integers from a Point.
@@ -397,6 +434,7 @@ namespace SadRogue.Primitives
         /// <param name="c" />
         /// <param name="tuple" />
         /// <returns>Position (c.X - tuple.x, c.Y - tuple.y).</returns>
+        [Pure]
         public static Point operator -(Point c, (int x, int y) tuple) => new Point(c.X - tuple.x, c.Y - tuple.y);
 
         /// <summary>
@@ -405,6 +443,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple"/>
         /// <param name="c"/>
         /// <returns>Position (tuple.x * c.X, tuple.y * c.Y).</returns>
+        [Pure]
         public static (int x, int y) operator *((int x, int y) tuple, Point c) => (tuple.x * c.X, tuple.y * c.Y);
 
         /// <summary>
@@ -413,6 +452,7 @@ namespace SadRogue.Primitives
         /// <param name="c"/>
         /// <param name="tuple"/>
         /// <returns>Position (c.X * tuple.x, c.Y * tuple.y).</returns>
+        [Pure]
         public static Point operator *(Point c, (int x, int y) tuple) => new Point(c.X * tuple.x, c.Y * tuple.y);
 
         /// <summary>
@@ -421,6 +461,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple"/>
         /// <param name="c"/>
         /// <returns>Position (tuple.x / c.X, tuple.y / c.Y), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static (int x, int y) operator /((int x, int y) tuple, Point c)
             => new Point((int)Math.Round(tuple.x / (double)c.X, MidpointRounding.AwayFromZero), (int)Math.Round(tuple.y / (double)c.Y, MidpointRounding.AwayFromZero));
 
@@ -430,6 +471,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple"/>
         /// <param name="c"/>
         /// <returns>Position (c.X / tuple.x, c.Y / tuple.y), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static (int x, int y) operator /(Point c, (int x, int y) tuple)
             => new Point((int)Math.Round(c.X / (double)tuple.x, MidpointRounding.AwayFromZero), (int)Math.Round(c.Y / (double)tuple.y, MidpointRounding.AwayFromZero));
 
@@ -439,6 +481,7 @@ namespace SadRogue.Primitives
         /// <param name="c"></param>
         /// <param name="tuple"></param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Point c, (int x, int y) tuple) => c.X == tuple.x && c.Y == tuple.y;
 
         /// <summary>
@@ -449,6 +492,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if either the x-values or y-values are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Point c, (int x, int y) tuple) => !(c == tuple);
 
         /// <summary>
@@ -457,6 +501,7 @@ namespace SadRogue.Primitives
         /// <param name="tuple"></param>
         /// <param name="c"></param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==((int x, int y) tuple, Point c) => tuple.x == c.X && tuple.y == c.Y;
 
         /// <summary>
@@ -467,6 +512,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if either the x-values or y-values are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=((int x, int y) tuple, Point c) => !(tuple == c);
 
         /// <summary>
@@ -474,6 +520,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Point to compare.</param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public bool Equals((int x, int y) other) => X == other.x && Y == other.y;
         #endregion
     }

--- a/TheSadRogue.Primitives/PointExtensions.cs
+++ b/TheSadRogue.Primitives/PointExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace SadRogue.Primitives
+﻿using System.Diagnostics.Contracts;
+
+namespace SadRogue.Primitives
 {
     /// <summary>
     /// Contains set of operators that match ones defined by other packages for interoperability,
@@ -12,6 +14,7 @@
         /// <param name="self"/>
         /// <param name="other"/>
         /// <returns>Position (self.X + other.X, self.Y + other.Y).</returns>
+        [Pure]
         public static Point Add(this Point self, Point other) => self + other;
 
         /// <summary>
@@ -20,6 +23,7 @@
         /// <param name="self"/>
         /// <param name="i"/>
         /// <returns>Position (self.X + i, self.Y + i).</returns>
+        [Pure]
         public static Point Add(this Point self, int i) => self + i;
 
         /// <summary>
@@ -28,6 +32,7 @@
         /// <param name="self"/>
         /// <param name="dir"/>
         /// <returns>Position (c.X + d.DeltaX, c.Y + d.DeltaY)</returns>
+        [Pure]
         public static Point Add(this Point self, Direction dir) => self + dir;
 
         /// <summary>
@@ -36,6 +41,7 @@
         /// <param name="self"/>
         /// <param name="other"/>
         /// <returns>Position (self.X - other.X, self.Y - other.Y).</returns>
+        [Pure]
         public static Point Subtract(this Point self, Point other) => self - other;
 
         /// <summary>
@@ -44,6 +50,7 @@
         /// <param name="self"/>
         /// <param name="i"/>
         /// <returns>Position (self.X - i, self.Y - i).</returns>
+        [Pure]
         public static Point Subtract(this Point self, int i) => self - i;
 
         /// <summary>
@@ -52,6 +59,7 @@
         /// <param name="self"/>
         /// <param name="other"/>
         /// <returns>Position (self.X * other.X, self.Y * other.Y).</returns>
+        [Pure]
         public static Point Multiply(this Point self, Point other) => self * other;
 
         /// <summary>
@@ -60,6 +68,7 @@
         /// <param name="self"/>
         /// <param name="i"/>
         /// <returns>Position (self.X * i, self.Y * i).</returns>
+        [Pure]
         public static Point Multiply(this Point self, int i) => self * i;
 
         /// <summary>
@@ -68,6 +77,7 @@
         /// <param name="self"/>
         /// <param name="d"/>
         /// <returns>Position (self.X * d, self.Y * d), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static Point Multiply(this Point self, double d) => self * d;
 
         /// <summary>
@@ -76,6 +86,7 @@
         /// <param name="self"/>
         /// <param name="other"/>
         /// <returns>Position (self.X / other.X, self.Y / other.Y), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static Point Divide(this Point self, Point other) => self / other;
 
         /// <summary>
@@ -84,6 +95,7 @@
         /// <param name="self"/>
         /// <param name="i"/>
         /// <returns>Position(self.X / i, self.Y / i), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static Point Divide(this Point self, int i) => self / i;
 
         /// <summary>
@@ -92,6 +104,7 @@
         /// <param name="self"/>
         /// <param name="d"/>
         /// <returns>Position(self.X / d, self.Y / d), with each value rounded to the nearest integer.</returns>
+        [Pure]
         public static Point Divide(this Point self, double d) => self / d;
     }
 }

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -16,7 +16,7 @@ namespace SadRogue.Primitives
     /// shape).
     /// </remarks>
     [Serializable]
-    public struct Radius : IEquatable<Radius>
+    public readonly struct Radius : IEquatable<Radius>
     {
         /// <summary>
         /// Radius is a circle around the center point. CIRCLE would represent movement radius in

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 
 namespace SadRogue.Primitives
 {
@@ -90,6 +91,7 @@ namespace SadRogue.Primitives
         /// <param name="bounds">Bounds to restrict the returned values by.</param>
         /// <returns>All points in the radius shape defined by the given parameters, in order from least distance to greatest
         /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
+        [Pure]
         public IEnumerable<Point> PositionsInRadius(Point center, int radius, Rectangle bounds)
             => PositionsInRadius(new RadiusLocationContext(center, radius, bounds));
 
@@ -108,6 +110,7 @@ namespace SadRogue.Primitives
         /// <param name="radius">Length of the radius.</param>
         /// <returns>All points in the radius shape defined by the given parameters, in order from least distance to greatest
         /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
+        [Pure]
         public IEnumerable<Point> PositionsInRadius(Point center, int radius)
             => PositionsInRadius(new RadiusLocationContext(center, radius));
 
@@ -126,6 +129,7 @@ namespace SadRogue.Primitives
         /// <param name="context">Context defining radius parameters.</param>
         /// <returns>All points in the radius shape defined by the given context, in order from least distance to greatest
         /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
+        [Pure]
         public IEnumerable<Point> PositionsInRadius(RadiusLocationContext context)
         {
             if (context._newlyInitialized)
@@ -177,6 +181,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Radius to compare.</param>
         /// <returns>True if the two radius shapes are the same, false if not.</returns>
+        [Pure]
         public bool Equals(Radius other) => Type == other.Type;
 
         /// <summary>
@@ -186,12 +191,14 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if <paramref name="obj"/> is a Radius, and the two radius shapes are equal, false otherwise.
         /// </returns>
+        [Pure]
         public override bool Equals(object obj) => obj is Radius c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.
         /// </summary>
         /// <returns/>
+        [Pure]
         public override int GetHashCode() => Type.GetHashCode();
 
         /// <summary>
@@ -200,6 +207,7 @@ namespace SadRogue.Primitives
         /// <param name="lhs"/>
         /// <param name="rhs"/>
         /// <returns>True if the two radius shapes are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Radius lhs, Radius rhs) => lhs.Type == rhs.Type;
 
         /// <summary>
@@ -210,6 +218,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the types are not equal, false if they are both equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Radius lhs, Radius rhs) => !(lhs == rhs);
 
         /// <summary>
@@ -220,6 +229,7 @@ namespace SadRogue.Primitives
         /// radius shape casted will be returned.
         /// </remarks>
         /// <param name="radius">Radius type being casted.</param>
+        [Pure]
         public static implicit operator AdjacencyRule(Radius radius)
         {
             switch (radius.Type)
@@ -244,6 +254,7 @@ namespace SadRogue.Primitives
         /// distance that creates the radius shape casted will be returned.
         /// </remarks>
         /// <param name="radius">Radius type being casted.</param>
+        [Pure]
         public static implicit operator Distance(Radius radius)
         {
             switch (radius.Type)
@@ -267,6 +278,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="radiusType">The enum value for the radius shape.</param>
         /// <returns>The radius class representing the given radius shape.</returns>
+        [Pure]
         public static Radius ToRadius(Types radiusType)
         {
             switch (radiusType)
@@ -323,7 +335,7 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// The centr-point of the radius represented.
+        /// The center-point of the radius represented.
         /// </summary>
         public Point Center { get; set; }
 

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 
 namespace SadRogue.Primitives
 {
@@ -151,6 +152,7 @@ namespace SadRogue.Primitives
         /// <param name="minExtent">Minimum (x, y) coordinates that are inside the rectangle.</param>
         /// <param name="maxExtent">Maximum (x, y) coordinates that are inside the rectangle.</param>
         /// <returns>A new Rectangle with the given minimum and maximum extents.</returns>
+        [Pure]
         public static Rectangle WithExtents(Point minExtent, Point maxExtent) => new Rectangle(minExtent, maxExtent);
 
         /// <summary>
@@ -166,6 +168,7 @@ namespace SadRogue.Primitives
         /// Number of units to the top and bottom of the center point that are included within the rectangle.
         /// </param>
         /// <returns>A new rectangle with the given center point and radius values.</returns>
+        [Pure]
         public static Rectangle WithRadius(Point center, int horizontalRadius, int verticalRadius) => new Rectangle(center, horizontalRadius, verticalRadius);
 
         /// <summary>
@@ -176,6 +179,7 @@ namespace SadRogue.Primitives
         /// <param name="width">Width of the rectangle.</param>
         /// <param name="height">Height of the rectangle.</param>
         /// <returns>A new rectangle at the given position with the given width and height.</returns>
+        [Pure]
         public static Rectangle WithPositionAndSize(Point position, int width, int height) => new Rectangle(position.X, position.Y, width, height);
 
         /// <summary>
@@ -185,6 +189,7 @@ namespace SadRogue.Primitives
         /// <param name="position">Minimum (x, y) values that are inside the resulting rectangle.</param>
         /// <param name="size">The size of the rectangle, in form (width, height).</param>
         /// <returns>A new rectangle at the given position with the given size.</returns>
+        [Pure]
         public static Rectangle WithPositionAndSize(Point position, Point size) => new Rectangle(position.X, position.Y, size.X, size.Y);
 
         /// <summary>
@@ -195,6 +200,7 @@ namespace SadRogue.Primitives
         /// <param name="rect2"/>
         /// <returns>A <see cref="Primitives.Area"/> representing every location in <paramref name="rect1"/> that
         /// is NOT in <paramref name="rect2"/>.</returns>
+        [Pure]
         public static Area GetDifference(Rectangle rect1, Rectangle rect2)
         {
             var retVal = new Area();
@@ -219,6 +225,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"/>
         /// <param name="r2"/>
         /// <returns>A <see cref="Primitives.Area"/> containing every position in either rectangle.</returns>
+        [Pure]
         public static Area GetExactUnion(Rectangle r1, Rectangle r2)
         {
             var retVal = new Area();
@@ -252,6 +259,7 @@ namespace SadRogue.Primitives
         /// Rectangle representing the intersection of <paramref name="r1"/> and <paramref name="r2"/>, or
         /// the empty rectangle if the two rectangles do not intersect.
         /// </returns>
+        [Pure]
         public static Rectangle GetIntersection(Rectangle r1, Rectangle r2)
         {
             if (r1.Intersects(r2))
@@ -278,6 +286,7 @@ namespace SadRogue.Primitives
         /// The smallest possible rectangle that includes the entire area of both <paramref name="r1"/> and
         /// <paramref name="r2"/>.
         /// </returns>
+        [Pure]
         public static Rectangle GetUnion(Rectangle r1, Rectangle r2)
         {
             int x = Math.Min(r1.X, r2.X);
@@ -292,6 +301,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"/>
         /// <param name="r2"/>
         /// <returns>true if the rectangles do NOT encompass the same area, false otherwise.</returns>
+        [Pure]
         public static bool operator !=(Rectangle r1, Rectangle r2) => !(r1 == r2);
 
         /// <summary>
@@ -302,6 +312,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// true if the area of the two rectangles encompass the exact same area, false otherwise.
         /// </returns>
+        [Pure]
         public static bool operator ==(Rectangle r1, Rectangle r2) => r1.X == r2.X && r1.Y == r2.Y && r1.Width == r2.Width && r1.Height == r2.Height;
 
         /// <summary>
@@ -313,6 +324,7 @@ namespace SadRogue.Primitives
         /// A new rectangle that is the same size as the current one, but with the center moved to
         /// the given location.
         /// </returns>
+        [Pure]
         public Rectangle WithCenter(Point center)
             => new Rectangle(center.X - (Width / 2), center.Y - (Height / 2), Width, Height);
 
@@ -322,6 +334,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="deltaHeight">Delta-change for the height of the new rectangle.</param>
         /// <returns>A new rectangle whose height is modified by the given delta-change value.</returns>
+        [Pure]
         public Rectangle ChangeHeight(int deltaHeight)
             => new Rectangle(X, Y, Width, Height + deltaHeight);
 
@@ -336,6 +349,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// A new rectangle whose width/height are modified by the given delta-change values.
         /// </returns>
+        [Pure]
         public Rectangle ChangeSize(Point deltaChange)
             => new Rectangle(X, Y, Width + deltaChange.X, Height + deltaChange.Y);
 
@@ -345,6 +359,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="deltaWidth">Delta-change for the width of the new rectangle.</param>
         /// <returns>A new rectangle whose width is modified by the given delta-change value.</returns>
+        [Pure]
         public Rectangle ChangeWidth(int deltaWidth)
             => new Rectangle(X, Y, Width + deltaWidth, Height);
 
@@ -353,6 +368,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="position">The position to check.</param>
         /// <returns>Whether or not the specified point is considered within the rectangle.</returns>
+        [Pure]
         public bool Contains(Point position) => (position.X >= X && position.X < (X + Width) && position.Y >= Y && position.Y < (Y + Height));
 
         /// <summary>
@@ -363,6 +379,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the given rectangle is completely contained within the current one, false otherwise.
         /// </returns>
+        [Pure]
         public bool Contains(Rectangle other) => (X <= other.X && other.X + other.Width <= X + Width && Y <= other.Y && other.Y + other.Height <= Y + Height);
 
         /// <summary>
@@ -373,6 +390,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// true if the area of the two rectangles encompass the exact same area, false otherwise.
         /// </returns>
+        [Pure]
         public bool Equals(Rectangle other) => (X == other.X && Y == other.Y && Width == other.Width && Height == other.Height);
 
         /// <summary>
@@ -382,6 +400,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// true if the object specified is a rectangle instance and encompasses the same area, false otherwise.
         /// </returns>
+        [Pure]
         public override bool Equals(object obj) => obj is Rectangle && this == (Rectangle)obj;
 
         /// <summary>
@@ -394,6 +413,7 @@ namespace SadRogue.Primitives
         /// Number of additional rows to include on the top/bottom of the rectangle.
         /// </param>
         /// <returns>A new rectangle, expanded appropriately.</returns>
+        [Pure]
         public Rectangle Expand(int horizontalChange, int verticalChange)
             => new Rectangle(X - horizontalChange, Y - verticalChange, Width + (2 * horizontalChange), Height + (2 * verticalChange));
 
@@ -401,6 +421,7 @@ namespace SadRogue.Primitives
         /// Simple hashing.
         /// </summary>
         /// <returns>Hash code for rectangle.</returns>
+        [Pure]
         public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Width.GetHashCode() ^ Height.GetHashCode();
 
         /// <summary>
@@ -408,6 +429,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">The rectangle to check.</param>
         /// <returns>True if the given rectangle intersects with the current one, false otherwise.</returns>
+        [Pure]
         public bool Intersects(Rectangle other) => (other.X < X + Width && X < other.X + other.Width && other.Y < Y + Height && Y < other.Y + other.Height);
 
         /// <summary>
@@ -415,6 +437,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="position">The position for the new rectangle.</param>
         /// <returns>A new rectangle that has its position changed to the given value.</returns>
+        [Pure]
         public Rectangle WithPosition(Point position)
             => new Rectangle(position.X, position.Y, Width, Height);
 
@@ -423,6 +446,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="direction">The direction to move the new rectangle in.</param>
         /// <returns>A new rectangle that has its position moved in the given direction.</returns>
+        [Pure]
         public Rectangle Translate(Direction direction)
         {
             Point newPos = Position + direction;
@@ -434,6 +458,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="x">The X value for the new rectangle.</param>
         /// <returns>A new rectangle with X changed to the given value.</returns>
+        [Pure]
         public Rectangle WithX(int x) => new Rectangle(x, Y, Width, Height);
 
         /// <summary>
@@ -441,12 +466,14 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="y">The Y value for the new rectangle.</param>
         /// <returns>A new rectangle with Y changed to the given value.</returns>
+        [Pure]
         public Rectangle WithY(int y) => new Rectangle(X, y, Width, Height);
 
         /// <summary>
         /// Returns all positions in the rectangle.
         /// </summary>
         /// <returns>All positions in the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> Positions()
         {
             for (int y = Y; y <= MaxExtentY; y++)
@@ -464,6 +491,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="height">The height for the new rectangle.</param>
         /// <returns>A new rectangle with its height changed to the given value.</returns>
+        [Pure]
         public Rectangle WithHeight(int height)
             => new Rectangle(X, Y, Width, height);
 
@@ -473,6 +501,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="maxExtent">The maximum extent of the new rectangle.</param>
         /// <returns>A new rectangle that has its maximum extent adjusted to the specified value.</returns>
+        [Pure]
         public Rectangle WithMaxExtent(Point maxExtent)
             => new Rectangle(MinExtent, maxExtent);
 
@@ -482,6 +511,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="x">The x-coordinate for the maximum extent of the new rectangle.</param>
         /// <returns>A new rectangle, with its <see cref="MaxExtentX"/> adjusted to the specified value.</returns>
+        [Pure]
         public Rectangle WithMaxExtentX(int x)
             => new Rectangle(MinExtent, new Point(x, MaxExtentY));
 
@@ -491,6 +521,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="y">The y-coordinate for the maximum extent of the new rectangle.</param>
         /// <returns>A new rectangle, with its <see cref="MaxExtentY"/> adjusted to the specified value.</returns>
+        [Pure]
         public Rectangle WithMaxExtentY(int y)
             => new Rectangle(MinExtent, new Point(MaxExtentX, y));
 
@@ -500,6 +531,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="minExtent">The minimum extent of the new rectangle.</param>
         /// <returns>A new rectangle that has its minimum extent adjusted to the specified value.</returns>
+        [Pure]
         public Rectangle WithMinExtent(Point minExtent)
             => new Rectangle(minExtent, MaxExtent);
 
@@ -509,6 +541,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="x">The x-coordinate for the minimum extent of the new rectangle.</param>
         /// <returns>A new rectangle, with its <see cref="MinExtentX"/> adjusted to the specified value.</returns>
+        [Pure]
         public Rectangle WithMinExtentX(int x)
             => new Rectangle(new Point(x, MinExtentY), MaxExtent);
 
@@ -519,6 +552,7 @@ namespace SadRogue.Primitives
         /// <param name="y">The y-coordinate for the minimum extent of the new rectangle.</param>
         /// <returns>A new rectangle, with its <see cref="MinExtentY"/> adjusted to the specified value.</returns>
         /// &gt;
+        [Pure]
         public Rectangle WithMinExtentY(int y)
             => new Rectangle(new Point(MinExtentX, y), MaxExtent);
 
@@ -529,6 +563,7 @@ namespace SadRogue.Primitives
         /// <param name="width">The width for the new rectangle.</param>
         /// <param name="height">The height for the new rectangle.</param>
         /// <returns>A new rectangle with the given width and height.</returns>
+        [Pure]
         public Rectangle WithSize(int width, int height)
             => new Rectangle(X, Y, width, height);
 
@@ -538,6 +573,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="size">Vector (width, height) specifying the width/height of the new rectangle.</param>
         /// <returns>A new rectangle with the given width and height.</returns>
+        [Pure]
         public Rectangle WithSize(Point size)
             => new Rectangle(X, Y, size.X, size.Y);
 
@@ -547,6 +583,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="width">The width for the new rectangle.</param>
         /// <returns>A new rectangle with its <see cref="Width"/> changed to the given value.</returns>
+        [Pure]
         public Rectangle WithWidth(int width) => new Rectangle(X, Y, width, Height);
 
         /// <summary>
@@ -554,6 +591,7 @@ namespace SadRogue.Primitives
         /// (<see cref="X"/>, <see cref="Y"/>) -&gt; (<see cref="MaxExtentX"/>, <see cref="MaxExtentY"/>)
         /// </summary>
         /// <returns>String formatted as above.</returns>
+        [Pure]
         public override string ToString() => Position + " -> " + MaxExtent;
 
         /// <summary>
@@ -564,6 +602,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// A new rectangle, whose position has been moved by the given delta-change values.
         /// </returns>
+        [Pure]
         public Rectangle Translate(Point deltaChange)
             => new Rectangle(X + deltaChange.X, Y + deltaChange.Y, Width, Height);
 
@@ -572,6 +611,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="dx">Value by which to move the new rectangle's x-position.</param>
         /// <returns>A new rectangle, whose x-position has been moved by the given delta-x value.</returns>
+        [Pure]
         public Rectangle TranslateX(int dx)
             => new Rectangle(X + dx, Y, Width, Height);
 
@@ -580,6 +620,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="dy">Value by which to move the new rectangle's y-position.</param>
         /// <returns>A new rectangle, whose y-position has been moved by the given delta-y value.</returns>
+        [Pure]
         public Rectangle TranslateY(int dy)
             => new Rectangle(X, Y + dy, Width, Height);
 
@@ -590,12 +631,14 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="rect" />
         /// <returns />
+        [Pure]
         public static implicit operator (int x, int y, int width, int height)(Rectangle rect) => (rect.X, rect.Y, rect.Width, rect.Height);
         /// <summary>
         /// Implicitly converts a tuple of 4 integers (x, y, width, height) to an equivalent GoRogue Rectangle.
         /// </summary>
         /// <param name="tuple" />
         /// <returns />
+        [Pure]
         public static implicit operator Rectangle((int x, int y, int width, int height) tuple) => new Rectangle(tuple.x, tuple.y, tuple.width, tuple.height);
 
         /// <summary>
@@ -605,6 +648,7 @@ namespace SadRogue.Primitives
         /// <param name="y" />
         /// <param name="width" />
         /// <param name="height" />
+        [Pure]
         public void Deconstruct(out int x, out int y, out int width, out int height)
         {
             x = X;
@@ -619,6 +663,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"></param>
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2) => r1.X == r2.x && r1.Y == r2.y && r1.Width == r2.width && r1.Height == r2.height;
 
         /// <summary>
@@ -629,6 +674,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if any of the x/y/width/height values are not equal, false if they are all equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Rectangle r1, (int x, int y, int width, int height) r2) => !(r1 == r2);
 
         /// <summary>
@@ -637,6 +683,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"></param>
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2) => r1.x == r2.X && r1.y == r2.Y && r1.width == r2.Width && r1.height == r2.Height;
 
         /// <summary>
@@ -647,6 +694,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if any of the x/y/width/height values are not equal, false if they are all equal.
         /// </returns>
+        [Pure]
         public static bool operator !=((int x, int y, int width, int height) r1, Rectangle r2) => !(r1 == r2);
 
         /// <summary>
@@ -654,6 +702,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Point to compare.</param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public bool Equals((int x, int y, int width, int height) other)
             => X == other.x && Y == other.y && Width == other.width && Height == other.height;
         #endregion
@@ -663,12 +712,14 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="rect" />
         /// <returns />
+        [Pure]
         public static implicit operator (Point minExtent, Point maxExtent)(Rectangle rect) => (rect.MinExtent, rect.MaxExtent);
         /// <summary>
         /// Implicitly converts a tuple of 2 Points (minExtent, maxExtent) to an equivalent GoRogue Rectangle.
         /// </summary>
         /// <param name="tuple" />
         /// <returns />
+        [Pure]
         public static implicit operator Rectangle((Point minExtent, Point maxExtent) tuple) => new Rectangle(tuple.minExtent, tuple.maxExtent);
 
         /// <summary>
@@ -676,6 +727,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="minExtent" />
         /// <param name="maxExtent" />
+        [Pure]
         public void Deconstruct(out Point minExtent, out Point maxExtent)
         {
             minExtent = MinExtent;
@@ -688,6 +740,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"></param>
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==(Rectangle r1, (Point minExtent, Point maxExtent) r2) => r1.MinExtent == r2.minExtent && r1.MaxExtent == r2.maxExtent;
 
         /// <summary>
@@ -698,6 +751,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if any of the x/y/width/height values are not equal, false if they are all equal.
         /// </returns>
+        [Pure]
         public static bool operator !=(Rectangle r1, (Point minExtent, Point maxExtent) r2) => !(r1 == r2);
 
         /// <summary>
@@ -706,6 +760,7 @@ namespace SadRogue.Primitives
         /// <param name="r1"></param>
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
+        [Pure]
         public static bool operator ==((Point minExtent, Point maxExtent) r1, Rectangle r2) => r1.minExtent == r2.MinExtent && r1.maxExtent == r2.MaxExtent;
 
         /// <summary>
@@ -716,6 +771,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if any of the x/y/width/height values are not equal, false if they are all equal.
         /// </returns>
+        [Pure]
         public static bool operator !=((Point minExtent, Point maxExtent) r1, Rectangle r2) => !(r1 == r2);
 
         /// <summary>
@@ -723,15 +779,17 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">Point to compare.</param>
         /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
         public bool Equals((Point minExtent, Point maxExtent) other)
             => MinExtent == other.minExtent && MaxExtent == other.maxExtent;
         #endregion
-#endregion
+        #endregion
 
         /// <summary>
         /// Gets all positions that reside on the inner perimeter of the rectangle.
         /// </summary>
         /// <returns>IEnumerable of all positions that reside on the inner perimeter of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> PerimeterPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
@@ -759,6 +817,7 @@ namespace SadRogue.Primitives
         /// Returns all positions on the top edge of the rectangle.
         /// </summary>
         /// <returns>All positions on the top edge of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> TopEdgePositions()
         {
             int topY = (Direction.YIncreasesUpward) ? MaxExtentY : MinExtentY;
@@ -771,6 +830,7 @@ namespace SadRogue.Primitives
         /// Returns all positions on the right edge of the rectangle.
         /// </summary>
         /// <returns>All positions on the right edge of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> RightEdgePositions()
         {
             for (int i = MinExtentY; i <= MaxExtentY; i++)
@@ -781,6 +841,7 @@ namespace SadRogue.Primitives
         /// Returns all positions on the bottom edge of the rectangle.
         /// </summary>
         /// <returns>All positions on the bottom edge of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> BottomEdgePositions()
         {
             int botY = (Direction.YIncreasesUpward) ? MinExtentY : MaxExtentY;
@@ -793,6 +854,7 @@ namespace SadRogue.Primitives
         /// Returns all positions on the left edge of the rectangle.
         /// </summary>
         /// <returns>All positions on the left edge of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> LeftEdgePositions()
         {
             for (int i = MinExtentY; i <= MaxExtentY; i++)
@@ -804,6 +866,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="point"/>
         /// <returns>True if the given position lies along the top edge of the rectangle, false otherwise.</returns>
+        [Pure]
         public bool IsOnTopEdge(Point point)
         {
             int topY = (Direction.YIncreasesUpward) ? MaxExtentY : MinExtentY;
@@ -815,6 +878,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="point"/>
         /// <returns>True if the given position lies along the right edge of the rectangle, false otherwise.</returns>
+        [Pure]
         public bool IsOnRightEdge(Point point) => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MaxExtentX;
 
         /// <summary>
@@ -822,6 +886,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="point"/>
         /// <returns>True if the given position lies along the bottom edge of the rectangle, false otherwise.</returns>
+        [Pure]
         public bool IsOnBottomEdge(Point point)
         {
             int topY = (Direction.YIncreasesUpward) ? MinExtentY : MaxExtentY;
@@ -833,6 +898,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="point"/>
         /// <returns>True if the given position lies along the left edge of the rectangle, false otherwise.</returns>
+        [Pure]
         public bool IsOnLeftEdge(Point point) => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MinExtentX;
 
 
@@ -841,6 +907,7 @@ namespace SadRogue.Primitives
         /// Gets all positions that reside on the min-y line of the rectangle.
         /// </summary>
         /// <returns>IEnumerable of all positions that lie on the min-y line of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> MinYPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
@@ -853,6 +920,7 @@ namespace SadRogue.Primitives
         /// Gets all positions that reside on the max-y line of the rectangle.
         /// </summary>
         /// <returns>IEnumerable of all positions that lie on the max-y line of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> MaxYPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
@@ -865,6 +933,7 @@ namespace SadRogue.Primitives
         /// Gets all positions that reside on the min-x line of the rectangle.
         /// </summary>
         /// <returns>IEnumerable of all positions that lie on the min-x line of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> MinXPositions()
         {
             for (int y = MinExtentY; y <= MaxExtentY; y++)
@@ -877,6 +946,7 @@ namespace SadRogue.Primitives
         /// Gets all positions that reside on the max-x line of the rectangle.
         /// </summary>
         /// <returns>IEnumerable of all positions that lie on the max-x line of the rectangle.</returns>
+        [Pure]
         public IEnumerable<Point> MaxXPositions()
         {
             for (int y = MinExtentY; y <= MaxExtentY; y++)
@@ -886,11 +956,12 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// Gets an IEnumerable of all positions that line on the inner perimiter of the rectangle,
+        /// Gets an IEnumerable of all positions that line on the inner perimeter of the rectangle,
         /// on the given side of the rectangle.
         /// </summary>
         /// <param name="side">Side to get positions for.</param>
-        /// <returns>IEnumerable of all positions that line on the inner perimieter of the rectangle on the given side.</returns>
+        /// <returns>IEnumerable of all positions that line on the inner perimeter of the rectangle on the given side.</returns>
+        [Pure]
         public IEnumerable<Point> PositionsOnSide(Direction side)
         {
             switch (side.Type)

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -9,7 +9,7 @@ namespace SadRogue.Primitives
     /// involving rectangles.
     /// </summary>
     [Serializable]
-    public struct Rectangle : IEquatable<Rectangle>, IEquatable<(int x, int y, int width, int height)>
+    public readonly struct Rectangle : IEquatable<Rectangle>, IEquatable<(int x, int y, int width, int height)>
     {
         /// <summary>
         /// The empty rectangle. Has origin of (0, 0) with 0 width and height.

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -4,7 +4,7 @@
 	<!-- Basic package info -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
-	<Version>1.0.0-alpha3</Version>
+	<Version>1.0.0-alpha4</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -13,7 +13,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
-	<PackageReleaseNotes>Added helper functions to Rectangle for determining if points are on the perimeter.  Added Point - Direction operator.  Fixed nuget package tags.</PackageReleaseNotes>
+	<PackageReleaseNotes>Added Pure attributes to appropriate struct functions.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -13,7 +13,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
-	<PackageReleaseNotes>Added Pure attributes to appropriate struct functions.</PackageReleaseNotes>
+	<PackageReleaseNotes>Added Pure attributes to appropriate struct functions.  Marked appropriate structs as readonly.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
- Made struct definitions themselves indicate that the struct is readonly (C# 7.2 feature introduced readonly structs)
- Added [Pure] attribute to appropriate struct functions, to indicate intent, allow compatibility with pre/post conditions, and help analyzers not produce false positives (including ReSharper)