### PR TITLE
Updated Projects and Cleaned Up Code

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
@@ -4,11 +4,26 @@ using SadRogueColor = SadRogue.Primitives.Color;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for <see cref="SadRogue.Primitives.Color"/> that enable operations involving
+    /// <see cref="Microsoft.Xna.Framework.Color"/>.
+    /// </summary>
     public static class SadRogueColorExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Color"/> to <see cref="Microsoft.Xna.Framework.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static MonoColor ToMonoColor(this SadRogueColor self) => new MonoColor(self.R, self.G, self.B, self.A);
 
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Color"/> to a <see cref="Microsoft.Xna.Framework.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRogueColor self, MonoColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
@@ -17,11 +32,26 @@ namespace SadRogue.Primitives
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// Extension methods for <see cref="Microsoft.Xna.Framework.Color"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Color"/>.
+    /// </summary>
     public static class MonoColorExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="Microsoft.Xna.Framework.Color"/> to <see cref="SadRogue.Primitives.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRogueColor ToSadRogueColor(this MonoColor self) => new SadRogueColor(self.R, self.G, self.B, self.A);
 
+        /// <summary>
+        /// Compares a <see cref="Microsoft.Xna.Framework.Color"/> to a <see cref="SadRogue.Primitives.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this MonoColor self, SadRogueColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;

--- a/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="self"/>
         /// <returns/>
         [Pure]
-        public static SadRogueColor ToSadRogueColor(this MonoColor self) => new SadRogueColor(self.R, self.G, self.B, self.A);
+        public static SadRogueColor ToSadRogueColor(this MonoColor self)
+            => new SadRogueColor(self.R, self.G, self.B, self.A);
 
         /// <summary>
         /// Compares a <see cref="Microsoft.Xna.Framework.Color"/> to a <see cref="SadRogue.Primitives.Color"/>.

--- a/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
@@ -27,7 +27,9 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Add(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+        public static SadRoguePoint Add(this SadRoguePoint self, MonoPoint other)
+            => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+
         /// <summary>
         /// Subtracts a <see cref="Microsoft.Xna.Framework.Point"/> from a <see cref="SadRogue.Primitives.Point"/>.
         /// </summary>
@@ -35,7 +37,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Subtract(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
+        public static SadRoguePoint Subtract(this SadRoguePoint self, MonoPoint other)
+            => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
 
         /// <summary>
         /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="Microsoft.Xna.Framework.Point"/>.
@@ -44,7 +47,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Multiply(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
+        public static SadRoguePoint Multiply(this SadRoguePoint self, MonoPoint other)
+            => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
 
         /// <summary>
         /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="Microsoft.Xna.Framework.Point"/>, and
@@ -55,7 +59,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, MonoPoint other)
-            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="Microsoft.Xna.Framework.Point"/>.
@@ -91,7 +96,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static MonoPoint Add(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X + other.X, self.Y + other.Y);
+        public static MonoPoint Add(this MonoPoint self, SadRoguePoint other)
+            => new MonoPoint(self.X + other.X, self.Y + other.Y);
 
         /// <summary>
         /// Adds an integer to both the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/>.
@@ -109,7 +115,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="dir"/>
         /// <returns/>
         [Pure]
-        public static MonoPoint Add(this MonoPoint self, Direction dir) => new MonoPoint(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+        public static MonoPoint Add(this MonoPoint self, Direction dir)
+            => new MonoPoint(self.X + dir.DeltaX, self.Y + dir.DeltaY);
 
         /// <summary>
         /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="Microsoft.Xna.Framework.Point"/>.
@@ -118,7 +125,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static MonoPoint Subtract(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X - other.X, self.Y - other.Y);
+        public static MonoPoint Subtract(this MonoPoint self, SadRoguePoint other)
+            => new MonoPoint(self.X - other.X, self.Y - other.Y);
 
         /// <summary>
         /// Subtracts an integer from both the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/>.
@@ -145,7 +153,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static MonoPoint Multiply(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X * other.X, self.Y * other.Y);
+        public static MonoPoint Multiply(this MonoPoint self, SadRoguePoint other)
+            => new MonoPoint(self.X * other.X, self.Y * other.Y);
 
         /// <summary>
         /// Multiplies the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/> by an integer.
@@ -165,7 +174,8 @@ namespace Microsoft.Xna.Framework
         /// <returns/>
         [Pure]
         public static MonoPoint Multiply(this MonoPoint self, double d)
-            => new MonoPoint((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
+            => new MonoPoint((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides a <see cref="Microsoft.Xna.Framework.Point"/> by a <see cref="SadRogue.Primitives.Point"/>, and
@@ -176,7 +186,8 @@ namespace Microsoft.Xna.Framework
         /// <returns/>
         [Pure]
         public static MonoPoint Divide(this MonoPoint self, SadRoguePoint other)
-            => new MonoPoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new MonoPoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/> by a double, then rounds the
@@ -187,7 +198,8 @@ namespace Microsoft.Xna.Framework
         /// <returns/>
         [Pure]
         public static MonoPoint Divide(this MonoPoint self, double d)
-            => new MonoPoint((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
+            => new MonoPoint((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Compares a <see cref="Microsoft.Xna.Framework.Point"/> to a <see cref="SadRogue.Primitives.Point"/>.

--- a/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
@@ -6,21 +6,63 @@ using SadRoguePoint = SadRogue.Primitives.Point;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for <see cref="SadRogue.Primitives.Point"/> that enable operations involving
+    /// <see cref="Microsoft.Xna.Framework.Point"/>.
+    /// </summary>
     public static class SadRoguePointExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Point"/> to <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint ToMonoPoint(this SadRoguePoint self) => new MonoPoint(self.X, self.Y);
+
+        /// <summary>
+        /// Adds a <see cref="Microsoft.Xna.Framework.Point"/> to a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+        /// <summary>
+        /// Subtracts a <see cref="Microsoft.Xna.Framework.Point"/> from a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
 
+        /// <summary>
+        /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, MonoPoint other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
+
+        /// <summary>
+        /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="Microsoft.Xna.Framework.Point"/>, and
+        /// rounds the resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, MonoPoint other)
             => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRoguePoint self, MonoPoint other) => self.X == other.X && self.Y == other.Y;
     }
@@ -28,37 +70,131 @@ namespace SadRogue.Primitives
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// Extension methods for <see cref="Microsoft.Xna.Framework.Point"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Point"/>.
+    /// </summary>
     public static class MonoPointExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="Microsoft.Xna.Framework.Point"/> to <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint ToPoint(this MonoPoint self) => new SadRoguePoint(self.X, self.Y);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Point"/> to a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Add(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X + other.X, self.Y + other.Y);
+
+        /// <summary>
+        /// Adds an integer to both the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Add(this MonoPoint self, int i) => new MonoPoint(self.X + i, self.Y + i);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Direction"/> to a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Add(this MonoPoint self, Direction dir) => new MonoPoint(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Subtract(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X - other.X, self.Y - other.Y);
+
+        /// <summary>
+        /// Subtracts an integer from both the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Subtract(this MonoPoint self, int i) => new MonoPoint(self.X - i, self.Y - i);
 
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Direction"/> from a <see cref="Microsoft.Xna.Framework.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
+        public static MonoPoint Subtract(this MonoPoint self, Direction dir)
+            => new MonoPoint(self.X - dir.DeltaX, self.Y - dir.DeltaY);
+
+        /// <summary>
+        /// Multiplies a <see cref="Microsoft.Xna.Framework.Point"/> by a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Multiply(this MonoPoint self, SadRoguePoint other) => new MonoPoint(self.X * other.X, self.Y * other.Y);
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/> by an integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Multiply(this MonoPoint self, int i) => new MonoPoint(self.X * i, self.Y * i);
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/> by a double, then rounds the
+        /// values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Multiply(this MonoPoint self, double d)
             => new MonoPoint((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Divides a <see cref="Microsoft.Xna.Framework.Point"/> by a <see cref="SadRogue.Primitives.Point"/>, and
+        /// rounds the resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Divide(this MonoPoint self, SadRoguePoint other)
             => new MonoPoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Divides the X and Y values of a <see cref="Microsoft.Xna.Framework.Point"/> by a double, then rounds the
+        /// values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static MonoPoint Divide(this MonoPoint self, double d)
             => new MonoPoint((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Compares a <see cref="Microsoft.Xna.Framework.Point"/> to a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this MonoPoint self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }

--- a/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
@@ -16,7 +16,8 @@ namespace SadRogue.Primitives
         /// <param name="self"/>
         /// <returns/>
         [Pure]
-        public static MonoRectangle ToMonoRectangle(this SadRogueRectangle self) => new MonoRectangle(self.X, self.Y, self.Width, self.Height);
+        public static MonoRectangle ToMonoRectangle(this SadRogueRectangle self)
+            => new MonoRectangle(self.X, self.Y, self.Width, self.Height);
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Rectangle"/> to a <see cref="Microsoft.Xna.Framework.Rectangle"/>.
@@ -44,7 +45,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="self"/>
         /// <returns/>
         [Pure]
-        public static SadRogueRectangle ToRectangle(this MonoRectangle self) => new SadRogueRectangle(self.X, self.Y, self.Width, self.Height);
+        public static SadRogueRectangle ToRectangle(this MonoRectangle self)
+            => new SadRogueRectangle(self.X, self.Y, self.Width, self.Height);
 
         /// <summary>
         /// Compares a <see cref="Microsoft.Xna.Framework.Rectangle"/> to a <see cref="SadRogue.Primitives.Rectangle"/>.

--- a/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
@@ -4,11 +4,26 @@ using SadRogueRectangle = SadRogue.Primitives.Rectangle;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for <see cref="SadRogue.Primitives.Rectangle"/> that enable operations involving
+    /// <see cref="Microsoft.Xna.Framework.Rectangle"/>.
+    /// </summary>
     public static class SadRogueRectangleExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Rectangle"/> to <see cref="Microsoft.Xna.Framework.Rectangle"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static MonoRectangle ToMonoRectangle(this SadRogueRectangle self) => new MonoRectangle(self.X, self.Y, self.Width, self.Height);
 
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Rectangle"/> to a <see cref="Microsoft.Xna.Framework.Rectangle"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRogueRectangle self, MonoRectangle other)
             => self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height;
@@ -17,11 +32,26 @@ namespace SadRogue.Primitives
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// Extension methods for <see cref="Microsoft.Xna.Framework.Rectangle"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Rectangle"/>.
+    /// </summary>
     public static class MonoRectangleExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="Microsoft.Xna.Framework.Rectangle"/> to <see cref="SadRogue.Primitives.Rectangle"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRogueRectangle ToRectangle(this MonoRectangle self) => new SadRogueRectangle(self.X, self.Y, self.Width, self.Height);
 
+        /// <summary>
+        /// Compares a <see cref="Microsoft.Xna.Framework.Rectangle"/> to a <see cref="SadRogue.Primitives.Rectangle"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this MonoRectangle self, SadRogueRectangle other)
             => self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height;

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
 	<Version>1.0.0-alpha2</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
@@ -43,7 +45,7 @@
   
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
-    <Copy SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
   </Target>
 </Project>

--- a/TheSadRogue.Primitives.SFML/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/ColorExtensions.cs
@@ -4,10 +4,26 @@ using SadRogueColor = SadRogue.Primitives.Color;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for <see cref="SadRogue.Primitives.Color"/> that enable operations involving
+    /// <see cref="SFML.Graphics.Color"/>.
+    /// </summary>
     public static class SadRogueColorExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Color"/> to <see cref="SFML.Graphics.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SFMLColor ToSFMLColor(this SadRogueColor self) => new SFMLColor(self.R, self.G, self.B, self.A);
+
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Color"/> to a <see cref="SFML.Graphics.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRogueColor self, SFMLColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
@@ -16,10 +32,26 @@ namespace SadRogue.Primitives
 
 namespace SFML.Graphics
 {
+    /// <summary>
+    /// Extension methods for <see cref="SFML.Graphics.Color"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Color"/>.
+    /// </summary>
     public static class SFMLColorExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SFML.Graphics.Color"/> to <see cref="SadRogue.Primitives.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRogueColor ToSadRogueColor(this SFMLColor self) => new SadRogueColor(self.R, self.G, self.B, self.A);
+
+        /// <summary>
+        /// Compares a <see cref="SFML.Graphics.Color"/> to a  <see cref="SadRogue.Primitives.Color"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SFMLColor self, SadRogueColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;

--- a/TheSadRogue.Primitives.SFML/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/ColorExtensions.cs
@@ -44,7 +44,8 @@ namespace SFML.Graphics
         /// <param name="self"/>
         /// <returns/>
         [Pure]
-        public static SadRogueColor ToSadRogueColor(this SFMLColor self) => new SadRogueColor(self.R, self.G, self.B, self.A);
+        public static SadRogueColor ToSadRogueColor(this SFMLColor self)
+            => new SadRogueColor(self.R, self.G, self.B, self.A);
 
         /// <summary>
         /// Compares a <see cref="SFML.Graphics.Color"/> to a  <see cref="SadRogue.Primitives.Color"/>.

--- a/TheSadRogue.Primitives.SFML/PointExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/PointExtensions.cs
@@ -43,7 +43,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Add(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+        public static SadRoguePoint Add(this SadRoguePoint self, Vector2i other)
+            => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
 
         /// <summary>
         /// Adds a <see cref="SFML.System.Vector2u"/> to a <see cref="SadRogue.Primitives.Point"/>.
@@ -52,7 +53,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Add(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X + (int)other.X, self.Y + (int)other.Y);
+        public static SadRoguePoint Add(this SadRoguePoint self, Vector2u other)
+            => new SadRoguePoint(self.X + (int)other.X, self.Y + (int)other.Y);
 
         /// <summary>
         /// Adds a <see cref="SFML.System.Vector2f"/> to a <see cref="SadRogue.Primitives.Point"/>, and rounds the X
@@ -63,7 +65,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2f other)
-            => new SadRoguePoint((int)Math.Round(self.X + other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y + other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X + other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y + other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Subtracts a <see cref="SFML.System.Vector2i"/> from a <see cref="SadRogue.Primitives.Point"/>.
@@ -72,7 +75,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
+        public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2i other)
+            => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
 
         /// <summary>
         /// Subtracts a <see cref="SFML.System.Vector2u"/> from a <see cref="SadRogue.Primitives.Point"/>.
@@ -81,7 +85,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X - (int)other.X, self.Y - (int)other.Y);
+        public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2u other)
+            => new SadRoguePoint(self.X - (int)other.X, self.Y - (int)other.Y);
 
         /// <summary>
         /// Subtracts a <see cref="SFML.System.Vector2f"/> from a <see cref="SadRogue.Primitives.Point"/>, and rounds
@@ -92,7 +97,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2f other)
-            => new SadRoguePoint((int)Math.Round(self.X - other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y - other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X - other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y - other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2i"/>.
@@ -101,7 +107,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
+        public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2i other)
+            => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
 
         /// <summary>
         /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2u"/>.
@@ -110,7 +117,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X * (int)other.X, self.Y * (int)other.Y);
+        public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2u other)
+            => new SadRoguePoint(self.X * (int)other.X, self.Y * (int)other.Y);
 
         /// <summary>
         /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2f"/>, and rounds
@@ -121,7 +129,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2f other)
-            => new SadRoguePoint((int)Math.Round(self.X * other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X * other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y * other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2i"/>, and rounds the
@@ -132,7 +141,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2i other)
-            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2u"/>, and rounds the
@@ -143,7 +153,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2u other)
-            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2f"/>, and rounds the
@@ -154,7 +165,8 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2f other)
-            => new SadRoguePoint((int)Math.Round(self.X / other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / other.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X / other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2i"/>.
@@ -181,7 +193,8 @@ namespace SadRogue.Primitives
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static bool Equals(this SadRoguePoint self, Vector2f other) => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
+        public static bool Equals(this SadRoguePoint self, Vector2f other)
+            => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
     }
 }
 
@@ -208,7 +221,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2i Add(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X + other.X, self.Y + other.Y);
+        public static Vector2i Add(this Vector2i self, SadRoguePoint other)
+            => new Vector2i(self.X + other.X, self.Y + other.Y);
 
         /// <summary>
         /// Adds an integer to both the X and Y values of a <see cref="SFML.System.Vector2i"/>.
@@ -226,7 +240,8 @@ namespace SFML.System
         /// <param name="dir"/>
         /// <returns/>
         [Pure]
-        public static Vector2i Add(this Vector2i self, Direction dir) => new Vector2i(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+        public static Vector2i Add(this Vector2i self, Direction dir)
+            => new Vector2i(self.X + dir.DeltaX, self.Y + dir.DeltaY);
 
         /// <summary>
         /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="SFML.System.Vector2i"/>.
@@ -235,7 +250,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2i Subtract(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X - other.X, self.Y - other.Y);
+        public static Vector2i Subtract(this Vector2i self, SadRoguePoint other)
+            => new Vector2i(self.X - other.X, self.Y - other.Y);
 
         /// <summary>
         /// Subtracts an integer from both the X and Y values of a <see cref="SFML.System.Vector2i"/>.
@@ -262,7 +278,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2i Multiply(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X * other.X, self.Y * other.Y);
+        public static Vector2i Multiply(this Vector2i self, SadRoguePoint other)
+            => new Vector2i(self.X * other.X, self.Y * other.Y);
 
         /// <summary>
         /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2i"/> by an integer.
@@ -282,7 +299,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static Vector2i Multiply(this Vector2i self, double d)
-            => new Vector2i((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
+            => new Vector2i((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides a <see cref="SFML.System.Vector2i"/> by a <see cref="SadRogue.Primitives.Point"/>, and rounds the
@@ -293,7 +311,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static Vector2i Divide(this Vector2i self, SadRoguePoint other)
-            => new Vector2i((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new Vector2i((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides the X and Y values of a <see cref="SFML.System.Vector2i"/> by a double, then rounds the
@@ -304,7 +323,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static Vector2i Divide(this Vector2i self, double d)
-            => new Vector2i((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
+            => new Vector2i((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Compares a <see cref="SFML.System.Vector2i"/> to a <see cref="SadRogue.Primitives.Point"/>.
@@ -337,7 +357,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2u Add(this Vector2u self, SadRoguePoint other) => new Vector2u(self.X + (uint)other.X, self.Y + (uint)other.Y);
+        public static Vector2u Add(this Vector2u self, SadRoguePoint other)
+            => new Vector2u(self.X + (uint)other.X, self.Y + (uint)other.Y);
 
         /// <summary>
         /// Adds an integer to both the X and Y values of a <see cref="SFML.System.Vector2u"/>.
@@ -355,7 +376,8 @@ namespace SFML.System
         /// <param name="dir"/>
         /// <returns/>
         [Pure]
-        public static Vector2u Add(this Vector2u self, Direction dir) => new Vector2u((uint)(self.X + dir.DeltaX), (uint)(self.Y + dir.DeltaY));
+        public static Vector2u Add(this Vector2u self, Direction dir)
+            => new Vector2u((uint)(self.X + dir.DeltaX), (uint)(self.Y + dir.DeltaY));
 
         /// <summary>
         /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="SFML.System.Vector2u"/>.
@@ -364,7 +386,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2u Subtract(this Vector2u self, SadRoguePoint other) => new Vector2u((uint)(self.X - other.X), (uint)(self.Y - other.Y));
+        public static Vector2u Subtract(this Vector2u self, SadRoguePoint other)
+            => new Vector2u((uint)(self.X - other.X), (uint)(self.Y - other.Y));
 
         /// <summary>
         /// Subtracts an integer from both the X and Y values of a <see cref="SFML.System.Vector2u"/>.
@@ -373,7 +396,8 @@ namespace SFML.System
         /// <param name="i"/>
         /// <returns/>
         [Pure]
-        public static Vector2u Subtract(this Vector2u self, int i) => new Vector2u((uint)(self.X - i), (uint)(self.Y - i));
+        public static Vector2u Subtract(this Vector2u self, int i)
+            => new Vector2u((uint)(self.X - i), (uint)(self.Y - i));
 
         /// <summary>
         /// Subtracts a <see cref="SadRogue.Primitives.Direction"/> from a <see cref="SFML.System.Vector2u"/>.
@@ -391,7 +415,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2u Multiply(this Vector2u self, SadRoguePoint other) => new Vector2u((uint)(self.X * other.X), (uint)(self.Y * other.Y));
+        public static Vector2u Multiply(this Vector2u self, SadRoguePoint other)
+            => new Vector2u((uint)(self.X * other.X), (uint)(self.Y * other.Y));
 
         /// <summary>
         /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2u"/> by an integer.
@@ -400,7 +425,8 @@ namespace SFML.System
         /// <param name="i"/>
         /// <returns/>
         [Pure]
-        public static Vector2u Multiply(this Vector2u self, int i) => new Vector2u((uint)(self.X * i), (uint)(self.Y * i));
+        public static Vector2u Multiply(this Vector2u self, int i)
+            => new Vector2u((uint)(self.X * i), (uint)(self.Y * i));
 
         /// <summary>
         /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2u"/> by a double, then rounds the
@@ -411,7 +437,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static Vector2u Multiply(this Vector2u self, double d)
-            => new Vector2u((uint)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
+            => new Vector2u((uint)Math.Round(self.X * d, MidpointRounding.AwayFromZero),
+                (uint)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides a <see cref="SFML.System.Vector2u"/> by a <see cref="SadRogue.Primitives.Point"/>, and rounds the
@@ -422,7 +449,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static Vector2u Divide(this Vector2u self, SadRoguePoint other)
-            => new Vector2u((uint)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+            => new Vector2u((uint)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero),
+                (uint)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides the X and Y values of a <see cref="SFML.System.Vector2u"/> by a double, then rounds the
@@ -433,7 +461,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static Vector2u Divide(this Vector2u self, double d)
-            => new Vector2u((uint)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
+            => new Vector2u((uint)Math.Round(self.X / d, MidpointRounding.AwayFromZero),
+                (uint)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Compares a <see cref="SFML.System.Vector2u"/> to a <see cref="SadRogue.Primitives.Point"/>.
@@ -459,7 +488,8 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         public static SadRoguePoint ToPoint(this Vector2f self)
-            => new SadRoguePoint((int)Math.Round(self.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y, MidpointRounding.AwayFromZero));
+            => new SadRoguePoint((int)Math.Round(self.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(self.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Adds a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2f"/>.
@@ -468,7 +498,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Add(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X + other.X, self.Y + other.Y);
+        public static Vector2f Add(this Vector2f self, SadRoguePoint other)
+            => new Vector2f(self.X + other.X, self.Y + other.Y);
 
         /// <summary>
         /// Adds an integer to both the X and Y values of a <see cref="SFML.System.Vector2f"/>.
@@ -486,7 +517,8 @@ namespace SFML.System
         /// <param name="dir"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Add(this Vector2f self, Direction dir) => new Vector2f(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+        public static Vector2f Add(this Vector2f self, Direction dir)
+            => new Vector2f(self.X + dir.DeltaX, self.Y + dir.DeltaY);
 
         /// <summary>
         /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="SFML.System.Vector2f"/>.
@@ -495,7 +527,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Subtract(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X - other.X, self.Y - other.Y);
+        public static Vector2f Subtract(this Vector2f self, SadRoguePoint other)
+            => new Vector2f(self.X - other.X, self.Y - other.Y);
 
         /// <summary>
         /// Subtracts an integer from both the X and Y values of a <see cref="SFML.System.Vector2f"/>.
@@ -522,7 +555,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Multiply(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X * other.X, self.Y * other.Y);
+        public static Vector2f Multiply(this Vector2f self, SadRoguePoint other)
+            => new Vector2f(self.X * other.X, self.Y * other.Y);
 
         /// <summary>
         /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2i"/> by an integer.
@@ -540,7 +574,8 @@ namespace SFML.System
         /// <param name="d"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Multiply(this Vector2f self, double d) => new Vector2f(self.X * (float)d, self.Y * (float)d);
+        public static Vector2f Multiply(this Vector2f self, double d)
+            => new Vector2f(self.X * (float)d, self.Y * (float)d);
 
         /// <summary>
         /// Divides a <see cref="SFML.System.Vector2f"/> by a <see cref="SadRogue.Primitives.Point"/>.
@@ -549,7 +584,8 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Divide(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X / other.X, self.Y / other.Y);
+        public static Vector2f Divide(this Vector2f self, SadRoguePoint other)
+            => new Vector2f(self.X / other.X, self.Y / other.Y);
 
         /// <summary>
         /// Divides the X and Y values of a <see cref="SFML.System.Vector2f"/> by a double.
@@ -558,7 +594,8 @@ namespace SFML.System
         /// <param name="d"/>
         /// <returns/>
         [Pure]
-        public static Vector2f Divide(this Vector2f self, double d) => new Vector2f(self.X / (float)d, self.Y / (float)d);
+        public static Vector2f Divide(this Vector2f self, double d)
+            => new Vector2f(self.X / (float)d, self.Y / (float)d);
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2f"/>.
@@ -567,6 +604,7 @@ namespace SFML.System
         /// <param name="other"/>
         /// <returns/>
         [Pure]
-        public static bool Equals(this Vector2f self, SadRoguePoint other) => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
+        public static bool Equals(this Vector2f self, SadRoguePoint other)
+            => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
     }
 }

--- a/TheSadRogue.Primitives.SFML/PointExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/PointExtensions.cs
@@ -6,157 +6,567 @@ using SadRoguePoint = SadRogue.Primitives.Point;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for <see cref="SadRogue.Primitives.Point"/> that enable operations involving
+    /// similar types from SFML.
+    /// </summary>
     public static class SadRoguePointExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Point"/> to <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static Vector2i ToVector2i(this SadRoguePoint self) => new Vector2i(self.X, self.Y);
+
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Point"/> to <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static Vector2u ToVector2u(this SadRoguePoint self) => new Vector2u((uint)self.X, (uint)self.Y);
+
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Point"/> to <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static Vector2f ToVector2f(this SadRoguePoint self) => new Vector2f(self.X, self.Y);
+
+        /// <summary>
+        /// Adds a <see cref="SFML.System.Vector2i"/> to a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X + other.X, self.Y + other.Y);
+
+        /// <summary>
+        /// Adds a <see cref="SFML.System.Vector2u"/> to a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X + (int)other.X, self.Y + (int)other.Y);
+
+        /// <summary>
+        /// Adds a <see cref="SFML.System.Vector2f"/> to a <see cref="SadRogue.Primitives.Point"/>, and rounds the X
+        /// and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Add(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X + other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y + other.Y, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Subtracts a <see cref="SFML.System.Vector2i"/> from a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X - other.X, self.Y - other.Y);
+
+        /// <summary>
+        /// Subtracts a <see cref="SFML.System.Vector2u"/> from a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X - (int)other.X, self.Y - (int)other.Y);
+
+        /// <summary>
+        /// Subtracts a <see cref="SFML.System.Vector2f"/> from a <see cref="SadRogue.Primitives.Point"/>, and rounds
+        /// the resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Subtract(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X - other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y - other.Y, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2i other) => new SadRoguePoint(self.X * other.X, self.Y * other.Y);
+
+        /// <summary>
+        /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2u other) => new SadRoguePoint(self.X * (int)other.X, self.Y * (int)other.Y);
+
+        /// <summary>
+        /// Multiplies a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2f"/>, and rounds
+        /// the resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Multiply(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X * other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * other.Y, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2i"/>, and rounds the
+        /// resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2i other)
             => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2u"/>, and rounds the
+        /// resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2u other)
             => new SadRoguePoint((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Divides a <see cref="SadRogue.Primitives.Point"/> by a <see cref="SFML.System.Vector2f"/>, and rounds the
+        /// resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint Divide(this SadRoguePoint self, Vector2f other)
             => new SadRoguePoint((int)Math.Round(self.X / other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / other.Y, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRoguePoint self, Vector2i other) => self.X == other.X && self.Y == other.Y;
+
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRoguePoint self, Vector2u other) => self.X == other.X && self.Y == other.Y;
+
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
-        public static bool Equals(this SadRoguePoint self, Vector2f other) => self.X == other.X && self.Y == other.Y;
+        public static bool Equals(this SadRoguePoint self, Vector2f other) => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
     }
 }
 
 namespace SFML.System
 {
+    /// <summary>
+    /// Extension methods for <see cref="SFML.System.Vector2i"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Point"/>.
+    /// </summary>
     public static class Vector2iExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SFML.System.Vector2i"/> to <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint ToPoint(this Vector2i self) => new SadRoguePoint(self.X, self.Y);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Add(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X + other.X, self.Y + other.Y);
+
+        /// <summary>
+        /// Adds an integer to both the X and Y values of a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Add(this Vector2i self, int i) => new Vector2i(self.X + i, self.Y + i);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Direction"/> to a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Add(this Vector2i self, Direction dir) => new Vector2i(self.X + dir.DeltaX, self.Y + dir.DeltaY);
+
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Subtract(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X - other.X, self.Y - other.Y);
+
+        /// <summary>
+        /// Subtracts an integer from both the X and Y values of a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Subtract(this Vector2i self, int i) => new Vector2i(self.X - i, self.Y - i);
 
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Direction"/> from a <see cref="SFML.System.Vector2i"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
+        public static Vector2i Subtract(this Vector2i self, Direction dir)
+            => new Vector2i(self.X - dir.DeltaX, self.Y - dir.DeltaY);
+
+        /// <summary>
+        /// Multiplies a <see cref="SFML.System.Vector2i"/> by a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Multiply(this Vector2i self, SadRoguePoint other) => new Vector2i(self.X * other.X, self.Y * other.Y);
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2i"/> by an integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Multiply(this Vector2i self, int i) => new Vector2i(self.X * i, self.Y * i);
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2i"/> by a double, then rounds the
+        /// values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Multiply(this Vector2i self, double d)
             => new Vector2i((int)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Divides a <see cref="SFML.System.Vector2i"/> by a <see cref="SadRogue.Primitives.Point"/>, and rounds the
+        /// resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Divide(this Vector2i self, SadRoguePoint other)
             => new Vector2i((int)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Divides the X and Y values of a <see cref="SFML.System.Vector2i"/> by a double, then rounds the
+        /// values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static Vector2i Divide(this Vector2i self, double d)
             => new Vector2i((int)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Compares a <see cref="SFML.System.Vector2i"/> to a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this Vector2i self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 
+    /// <summary>
+    /// Extension methods for <see cref="SFML.System.Vector2u"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Point"/>.
+    /// </summary>
     public static class Vector2uExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SFML.System.Vector2u"/> to <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint ToPoint(this Vector2u self) => new SadRoguePoint((int)self.X, (int)self.Y);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Add(this Vector2u self, SadRoguePoint other) => new Vector2u(self.X + (uint)other.X, self.Y + (uint)other.Y);
+
+        /// <summary>
+        /// Adds an integer to both the X and Y values of a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Add(this Vector2u self, int i) => new Vector2u(self.X + (uint)i, self.Y + (uint)i);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Direction"/> to a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Add(this Vector2u self, Direction dir) => new Vector2u((uint)(self.X + dir.DeltaX), (uint)(self.Y + dir.DeltaY));
+
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Subtract(this Vector2u self, SadRoguePoint other) => new Vector2u((uint)(self.X - other.X), (uint)(self.Y - other.Y));
+
+        /// <summary>
+        /// Subtracts an integer from both the X and Y values of a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Subtract(this Vector2u self, int i) => new Vector2u((uint)(self.X - i), (uint)(self.Y - i));
 
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Direction"/> from a <see cref="SFML.System.Vector2u"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
+        public static Vector2u Subtract(this Vector2u self, Direction dir)
+            => new Vector2u((uint)(self.X - dir.DeltaX), (uint)(self.Y - dir.DeltaY));
+
+        /// <summary>
+        /// Multiplies a <see cref="SFML.System.Vector2u"/> by a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Multiply(this Vector2u self, SadRoguePoint other) => new Vector2u((uint)(self.X * other.X), (uint)(self.Y * other.Y));
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2u"/> by an integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Multiply(this Vector2u self, int i) => new Vector2u((uint)(self.X * i), (uint)(self.Y * i));
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2u"/> by a double, then rounds the
+        /// values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Multiply(this Vector2u self, double d)
             => new Vector2u((uint)Math.Round(self.X * d, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y * d, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Divides a <see cref="SFML.System.Vector2u"/> by a <see cref="SadRogue.Primitives.Point"/>, and rounds the
+        /// resulting X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Divide(this Vector2u self, SadRoguePoint other)
             => new Vector2u((uint)Math.Round(self.X / (double)other.X, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y / (double)other.Y, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Divides the X and Y values of a <see cref="SFML.System.Vector2u"/> by a double, then rounds the
+        /// values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static Vector2u Divide(this Vector2u self, double d)
             => new Vector2u((uint)Math.Round(self.X / d, MidpointRounding.AwayFromZero), (uint)Math.Round(self.Y / d, MidpointRounding.AwayFromZero));
 
+        /// <summary>
+        /// Compares a <see cref="SFML.System.Vector2u"/> to a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this Vector2u self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 
+    /// <summary>
+    /// Extension methods for <see cref="SFML.System.Vector2f"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Point"/>.
+    /// </summary>
     public static class Vector2fExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SFML.System.Vector2f"/> to <see cref="SadRogue.Primitives.Point"/>,
+        /// rounding the X and Y values to the nearest integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRoguePoint ToPoint(this Vector2f self)
             => new SadRoguePoint((int)Math.Round(self.X, MidpointRounding.AwayFromZero), (int)Math.Round(self.Y, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Add(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X + other.X, self.Y + other.Y);
+
+        /// <summary>
+        /// Adds an integer to both the X and Y values of a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Add(this Vector2f self, int i) => new Vector2f(self.X + i, self.Y + i);
+
+        /// <summary>
+        /// Adds a <see cref="SadRogue.Primitives.Direction"/> to a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Add(this Vector2f self, Direction dir) => new Vector2f(self.X + dir.DeltaX, self.Y + dir.DeltaY);
 
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Point"/> from a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Subtract(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X - other.X, self.Y - other.Y);
+
+        /// <summary>
+        /// Subtracts an integer from both the X and Y values of a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Subtract(this Vector2f self, int i) => new Vector2f(self.X - i, self.Y - i);
 
+        /// <summary>
+        /// Subtracts a <see cref="SadRogue.Primitives.Direction"/> from a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns/>
+        public static Vector2f Subtract(this Vector2f self, Direction dir)
+            => new Vector2f(self.X - dir.DeltaX, self.Y - dir.DeltaY);
+
+        /// <summary>
+        /// Multiplies a <see cref="SFML.System.Vector2f"/> by a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Multiply(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X * other.X, self.Y * other.Y);
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2i"/> by an integer.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="i"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Multiply(this Vector2f self, int i) => new Vector2f(self.X * i, self.Y * i);
+
+        /// <summary>
+        /// Multiplies the X and Y values of a <see cref="SFML.System.Vector2f"/> by a double.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Multiply(this Vector2f self, double d) => new Vector2f(self.X * (float)d, self.Y * (float)d);
 
+        /// <summary>
+        /// Divides a <see cref="SFML.System.Vector2f"/> by a <see cref="SadRogue.Primitives.Point"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Divide(this Vector2f self, SadRoguePoint other) => new Vector2f(self.X / other.X, self.Y / other.Y);
+
+        /// <summary>
+        /// Divides the X and Y values of a <see cref="SFML.System.Vector2f"/> by a double.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="d"/>
+        /// <returns/>
         [Pure]
         public static Vector2f Divide(this Vector2f self, double d) => new Vector2f(self.X / (float)d, self.Y / (float)d);
 
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2f"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
-        public static bool Equals(this Vector2f self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
+        public static bool Equals(this Vector2f self, SadRoguePoint other) => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
     }
 }

--- a/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
@@ -16,7 +16,8 @@ namespace SadRogue.Primitives
         /// <param name="self"/>
         /// <returns/>
         [Pure]
-        public static IntRect ToIntRect(this SadRogueRectangle self) => new IntRect(self.X, self.Y, self.X + self.Width, self.Y + self.Height);
+        public static IntRect ToIntRect(this SadRogueRectangle self)
+            => new IntRect(self.X, self.Y, self.X + self.Width, self.Y + self.Height);
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Rectangle"/> to a <see cref="SFML.Graphics.IntRect"/>.
@@ -44,7 +45,8 @@ namespace SFML.Graphics
         /// <param name="self"/>
         /// <returns/>
         [Pure]
-        public static SadRogueRectangle ToRectangle(this IntRect self) => new SadRogueRectangle(self.Left, self.Top, self.Width - self.Left, self.Height - self.Top);
+        public static SadRogueRectangle ToRectangle(this IntRect self)
+            => new SadRogueRectangle(self.Left, self.Top, self.Width - self.Left, self.Height - self.Top);
 
         /// <summary>
         /// Compares a <see cref="SFML.Graphics.IntRect"/> to a <see cref="SadRogue.Primitives.Rectangle"/>.

--- a/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
@@ -4,11 +4,26 @@ using SadRogueRectangle = SadRogue.Primitives.Rectangle;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for <see cref="SadRogue.Primitives.Rectangle"/> that enable operations involving
+    /// <see cref="SFML.Graphics.IntRect"/>.
+    /// </summary>
     public static class RectangleExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SadRogue.Primitives.Rectangle"/> to <see cref="SFML.Graphics.IntRect"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static IntRect ToIntRect(this SadRogueRectangle self) => new IntRect(self.X, self.Y, self.X + self.Width, self.Y + self.Height);
 
+        /// <summary>
+        /// Compares a <see cref="SadRogue.Primitives.Rectangle"/> to a <see cref="SFML.Graphics.IntRect"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this SadRogueRectangle self, IntRect other)
             => self.X == other.Left && self.Y == other.Top && self.Width == other.Width && self.Height == other.Height;
@@ -17,11 +32,26 @@ namespace SadRogue.Primitives
 
 namespace SFML.Graphics
 {
+    /// <summary>
+    /// Extension methods for <see cref="SFML.Graphics.IntRect"/> that enable operations involving
+    /// <see cref="SadRogue.Primitives.Rectangle"/>.
+    /// </summary>
     public static class IntRectExtensions
     {
+        /// <summary>
+        /// Converts from <see cref="SFML.Graphics.IntRect"/> to <see cref="SadRogue.Primitives.Rectangle"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <returns/>
         [Pure]
         public static SadRogueRectangle ToRectangle(this IntRect self) => new SadRogueRectangle(self.Left, self.Top, self.Width - self.Left, self.Height - self.Top);
 
+        /// <summary>
+        /// Compares a <see cref="SFML.Graphics.IntRect"/> to a <see cref="SadRogue.Primitives.Rectangle"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
         [Pure]
         public static bool Equals(this IntRect self, SadRogueRectangle other)
             => self.Left == other.X && self.Top == other.Y && self.Width == other.Width && self.Height == other.Height;

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
 	<Version>1.0.0-alpha2</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
@@ -43,8 +45,8 @@
   
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
-    <Copy SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
   </Target>
 
 </Project>

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
@@ -13,44 +13,46 @@ namespace SadRogue.Primitives.UnitTests
     public class DirectionTests
     {
         #region TestData
+
         public static Direction[] ValidDirections = AdjacencyRule.EightWay.DirectionsOfNeighborsClockwise().ToArray();
         public static Direction[] AllDirections => ValidDirections.Append(Direction.None).ToArray();
         public static Point[] TestPoints => new[] { new Point(1, 2), new Point(0, 0), new Point(-2, -5) };
         public static IEnumerable<(Point, Direction)> PointDirPairs => TestPoints.Combinate(AllDirections);
 
-        public static IEnumerable<(Direction, int)> AddSubDirPairs => ValidDirections.Combinate(Enumerable.Range(0, 11));
+        public static IEnumerable<(Direction, int)> AddSubDirPairs
+            => ValidDirections.Combinate(Enumerable.Range(0, 11));
 
         public static IEnumerable<(Point, Point, Direction)> GetDirectionBasePairs =>
-            new (Point p1, Point p2, Direction d)[] {
-            ((0, 0), (0, 0), Direction.None),
-            ((0, 0), (0, 0) + Direction.Up, Direction.Up),
-            ((0, 0), (0, 0) + Direction.UpRight, Direction.UpRight),
-            ((0, 0), (0, 0) + Direction.Right, Direction.Right),
-            ((0, 0), (0, 0) + Direction.DownRight, Direction.DownRight),
-            ((0, 0), (0, 0) + Direction.Down, Direction.Down),
-            ((0, 0), (0, 0) + Direction.DownLeft, Direction.DownLeft),
-            ((0, 0), (0, 0) + Direction.Left, Direction.Left),
-            ((0, 0), (0, 0) + Direction.UpLeft, Direction.UpLeft)
-        };
+            new (Point p1, Point p2, Direction d)[]
+            {
+                ((0, 0), (0, 0), Direction.None), ((0, 0), (0, 0) + Direction.Up, Direction.Up),
+                ((0, 0), (0, 0) + Direction.UpRight, Direction.UpRight),
+                ((0, 0), (0, 0) + Direction.Right, Direction.Right),
+                ((0, 0), (0, 0) + Direction.DownRight, Direction.DownRight),
+                ((0, 0), (0, 0) + Direction.Down, Direction.Down),
+                ((0, 0), (0, 0) + Direction.DownLeft, Direction.DownLeft),
+                ((0, 0), (0, 0) + Direction.Left, Direction.Left),
+                ((0, 0), (0, 0) + Direction.UpLeft, Direction.UpLeft)
+            };
 
         private static IEnumerable<(Point, Point, Direction)> GetCardinalDirectionBasePairs =>
-            new (Point p1, Point p2, Direction d)[] {
-            ((0, 0), (0, 0), Direction.None),
-            ((0, 0), (0, 0) + Direction.Up, Direction.Up),
-            ((0, 0), (0, 0) + Direction.UpRight, Direction.Right),
-            ((0, 0), (0, 0) + Direction.Right, Direction.Right),
-            ((0, 0), (0, 0) + Direction.DownRight, Direction.Down),
-            ((0, 0), (0, 0) + Direction.Down, Direction.Down),
-            ((0, 0), (0, 0) + Direction.DownLeft, Direction.Left),
-            ((0, 0), (0, 0) + Direction.Left, Direction.Left),
-            ((0, 0), (0, 0) + Direction.UpLeft, Direction.Up)
-        };
+            new (Point p1, Point p2, Direction d)[]
+            {
+                ((0, 0), (0, 0), Direction.None), ((0, 0), (0, 0) + Direction.Up, Direction.Up),
+                ((0, 0), (0, 0) + Direction.UpRight, Direction.Right),
+                ((0, 0), (0, 0) + Direction.Right, Direction.Right),
+                ((0, 0), (0, 0) + Direction.DownRight, Direction.Down),
+                ((0, 0), (0, 0) + Direction.Down, Direction.Down),
+                ((0, 0), (0, 0) + Direction.DownLeft, Direction.Left),
+                ((0, 0), (0, 0) + Direction.Left, Direction.Left), ((0, 0), (0, 0) + Direction.UpLeft, Direction.Up)
+            };
 
         public static IEnumerable<(Point, Point, Direction)> GetDirectionPairs
             => GetDirectionBasePairs.Concat(GetDirectionBasePairs.Select(i => (i.Item1 + 5, i.Item2 + 5, i.Item3)));
 
         public static IEnumerable<(Point, Point, Direction)> GetCardinalDirectionPairs
-            => GetCardinalDirectionBasePairs.Concat(GetCardinalDirectionBasePairs.Select(i => (i.Item1 + 5, i.Item2 + 5, i.Item3)));
+            => GetCardinalDirectionBasePairs.Concat(
+                GetCardinalDirectionBasePairs.Select(i => (i.Item1 + 5, i.Item2 + 5, i.Item3)));
 
         public static IEnumerable<(Direction.Types, Direction)> TypeDirectionConversion => TestUtils.Enumerable(
             (Direction.Types.None, Direction.None),
@@ -64,22 +66,24 @@ namespace SadRogue.Primitives.UnitTests
             (Direction.Types.UpLeft, Direction.UpLeft)
         );
 
-        public static IEnumerable<(Direction, Point, Point)> YIncreasesDeltaValues => TestUtils.Enumerable<(Direction, Point, Point)>(
-            (Direction.None, (0, 0), (0, 0)),
-            (Direction.Up, (0, -1), (0, 1)),
-            (Direction.UpRight, (1, -1), (1, 1)),
-            (Direction.Right, (1, 0), (1, 0)),
-            (Direction.DownRight, (1, 1), (1, -1)),
-            (Direction.Down, (0, 1), (0, -1)),
-            (Direction.DownLeft, (-1, 1), (-1, -1)),
-            (Direction.Left, (-1, 0), (-1, 0)),
-            (Direction.UpLeft, (-1, -1), (-1, 1))
-        );
+        public static IEnumerable<(Direction, Point, Point)> YIncreasesDeltaValues
+            => TestUtils.Enumerable<(Direction, Point, Point)>(
+                (Direction.None, (0, 0), (0, 0)),
+                (Direction.Up, (0, -1), (0, 1)),
+                (Direction.UpRight, (1, -1), (1, 1)),
+                (Direction.Right, (1, 0), (1, 0)),
+                (Direction.DownRight, (1, 1), (1, -1)),
+                (Direction.Down, (0, 1), (0, -1)),
+                (Direction.DownLeft, (-1, 1), (-1, -1)),
+                (Direction.Left, (-1, 0), (-1, 0)),
+                (Direction.UpLeft, (-1, -1), (-1, 1))
+            );
 
         public static IEnumerable<(Direction, bool)> IsCardinalPairs
             => AdjacencyRule.Cardinals.DirectionsOfNeighbors().Combinate(true.ToEnumerable())
-            .Concat(AdjacencyRule.Diagonals.DirectionsOfNeighbors().Combinate(false.ToEnumerable()))
-            .Append((Direction.None, false));
+                .Concat(AdjacencyRule.Diagonals.DirectionsOfNeighbors().Combinate(false.ToEnumerable()))
+                .Append((Direction.None, false));
+
         #endregion
 
 
@@ -89,6 +93,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(default, Direction.None);
 
         #region Equality/Inequality
+
         [Theory]
         [MemberDataEnumerable(nameof(ValidDirections))]
         public void TestValidEquality(Direction dir)
@@ -110,9 +115,7 @@ namespace SadRogue.Primitives.UnitTests
             Direction none = Direction.None;
             Assert.True(none == Direction.None);
             foreach (Direction i in ValidDirections)
-            {
                 Assert.False(Direction.None == i);
-            }
         }
 
         [Theory]
@@ -136,9 +139,7 @@ namespace SadRogue.Primitives.UnitTests
             Direction none = Direction.None;
             Assert.False(none != Direction.None);
             foreach (Direction i in ValidDirections)
-            {
                 Assert.True(Direction.None != i);
-            }
         }
 
         [Theory]
@@ -148,10 +149,9 @@ namespace SadRogue.Primitives.UnitTests
             Direction[] dirs = AllDirections;
 
             foreach (Direction dir in dirs)
-            {
                 Assert.NotEqual(dir == compareDir, dir != compareDir);
-            }
         }
+
         [Theory]
         [MemberDataEnumerable(nameof(AllDirections))]
         public void TestEqualityEquivalence(Direction compareDir)
@@ -164,9 +164,11 @@ namespace SadRogue.Primitives.UnitTests
                 Assert.Equal(dir == compareDir, dir.Equals((object)compareDir));
             }
         }
+
         #endregion
 
         #region Addition/Subtraction
+
         [Theory]
         [MemberDataTuple(nameof(PointDirPairs))]
         public void AddToPoint(Point start, Direction dir)
@@ -213,11 +215,9 @@ namespace SadRogue.Primitives.UnitTests
             Assert.False(start == -1, "Could not find direction in valid directions list.");
 
             Direction res = dir - value;
-            int index = start - (Math.Abs(value) % dirs.Length);
+            int index = start - Math.Abs(value) % dirs.Length;
             if (index < 0)
-            {
                 index = dirs.Length + index;
-            }
 
             Assert.Equal(dirs[index], res);
         }
@@ -277,30 +277,31 @@ namespace SadRogue.Primitives.UnitTests
                 startingDir--;
                 int index = start - i;
                 if (index < 0)
-                {
                     index = dirs.Length + index;
-                }
 
                 Assert.Equal(dirs[index], startingDir);
             }
 
             Assert.Equal(oldDir, startingDir);
         }
+
         #endregion
 
         #region DirectionTypeToDirectionConversion
+
         [Theory]
         [MemberDataTuple(nameof(TypeDirectionConversion))]
         public void DirectionTypeConversion(Direction.Types type, Direction expectedDir)
-        {
-            Assert.Equal(expectedDir, (Direction)type);
-        }
+            => Assert.Equal(expectedDir, (Direction)type);
+
         #endregion
 
         #region YIncreasesUpwardsToggles
+
         [Theory]
         [MemberDataTuple(nameof(YIncreasesDeltaValues))]
-        public void YIncreasesUpwardDeltaToggle(Direction dir, (int dx, int dy) expectedPreDeltas, (int dx, int dy) expectedPostDeltas)
+        public void YIncreasesUpwardDeltaToggle(Direction dir, (int dx, int dy) expectedPreDeltas,
+                                                (int dx, int dy) expectedPostDeltas)
         {
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
 
@@ -323,21 +324,23 @@ namespace SadRogue.Primitives.UnitTests
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
             Assert.True(dir == dir.Type);
             Assert.True(dir.Equals(dir.Type));
-            Assert.True(dir.Equals((object)((Direction)(dir.Type))));
+            Assert.True(dir.Equals((object)(Direction)dir.Type));
 
             Direction.SetYIncreasesUpwardsUnsafe(true);
             Assert.True(dir == dir.Type);
             Assert.True(dir.Equals(dir.Type));
-            Assert.True(dir.Equals((object)((Direction)(dir.Type))));
+            Assert.True(dir.Equals((object)(Direction)dir.Type));
 
             Direction.SetYIncreasesUpwardsUnsafe(false);
             Assert.True(dir == dir.Type);
             Assert.True(dir.Equals(dir.Type));
-            Assert.True(dir.Equals((object)((Direction)(dir.Type))));
+            Assert.True(dir.Equals((object)(Direction)dir.Type));
         }
+
         #endregion
 
         #region GetDirection/GetCardinalDirection
+
         [Fact]
         public void GetDirection()
         {
@@ -415,6 +418,7 @@ namespace SadRogue.Primitives.UnitTests
                 Assert.Equal(expectedDir, dir);
             }
         }
+
         #endregion
 
         [Theory]

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
@@ -6,7 +6,7 @@ using XUnit.ValueTuples;
 
 namespace SadRogue.Primitives.UnitTests
 {
-    // We must do these sequentially (not in paralell), as some of the tests change YIncreasesUpwards, which can very much mess with other threads using any function
+    // We must do these sequentially (not in parallel), as some of the tests change YIncreasesUpwards, which can very much mess with other threads using any function
     // that relies on directions.  There is a feature of XUnit that should technically allow these to be in the same assembly, but it seems to only separate the collection
     // from itself, and attempting to extrapolate which functions view directions is time consuming and the frequent switching of that flag is not something that should be done
     // in production anyway.  Thus anything that manipulates shared state will be in this assembly.
@@ -16,7 +16,7 @@ namespace SadRogue.Primitives.UnitTests
         public static Direction[] ValidDirections = AdjacencyRule.EightWay.DirectionsOfNeighborsClockwise().ToArray();
         public static Direction[] AllDirections => ValidDirections.Append(Direction.None).ToArray();
         public static Point[] TestPoints => new[] { new Point(1, 2), new Point(0, 0), new Point(-2, -5) };
-        public static IEnumerable<(Point, Direction)> CoordDirPairs => TestPoints.Combinate(AllDirections);
+        public static IEnumerable<(Point, Direction)> PointDirPairs => TestPoints.Combinate(AllDirections);
 
         public static IEnumerable<(Direction, int)> AddSubDirPairs => ValidDirections.Combinate(Enumerable.Range(0, 11));
 
@@ -33,7 +33,7 @@ namespace SadRogue.Primitives.UnitTests
             ((0, 0), (0, 0) + Direction.UpLeft, Direction.UpLeft)
         };
 
-        public static IEnumerable<(Point, Point, Direction)> GetCardinalDirectionBasePairs =>
+        private static IEnumerable<(Point, Point, Direction)> GetCardinalDirectionBasePairs =>
             new (Point p1, Point p2, Direction d)[] {
             ((0, 0), (0, 0), Direction.None),
             ((0, 0), (0, 0) + Direction.Up, Direction.Up),
@@ -143,7 +143,7 @@ namespace SadRogue.Primitives.UnitTests
 
         [Theory]
         [MemberDataEnumerable(nameof(AllDirections))]
-        public void TestEqualityInqeualityOpposite(Direction compareDir)
+        public void TestEqualityInequalityOpposite(Direction compareDir)
         {
             Direction[] dirs = AllDirections;
 
@@ -168,7 +168,7 @@ namespace SadRogue.Primitives.UnitTests
 
         #region Addition/Subtraction
         [Theory]
-        [MemberDataTuple(nameof(CoordDirPairs))]
+        [MemberDataTuple(nameof(PointDirPairs))]
         public void AddToPoint(Point start, Direction dir)
         {
             // Should be false to start with
@@ -223,7 +223,7 @@ namespace SadRogue.Primitives.UnitTests
         }
 
         [Theory]
-        [MemberDataTuple(nameof(CoordDirPairs))]
+        [MemberDataTuple(nameof(PointDirPairs))]
         public void SubFromPoint(Point start, Direction dir)
         {
             // Should be false to start with
@@ -321,18 +321,18 @@ namespace SadRogue.Primitives.UnitTests
         public void YIncreaseUpwardEquality(Direction dir)
         {
             Assert.False(Direction.YIncreasesUpward, "Direction.YIncreasesUpwards is expected to be false as default.");
-            Assert.True(dir == (Direction)dir.Type);
-            Assert.True(dir.Equals((Direction)dir.Type));
+            Assert.True(dir == dir.Type);
+            Assert.True(dir.Equals(dir.Type));
             Assert.True(dir.Equals((object)((Direction)(dir.Type))));
 
             Direction.SetYIncreasesUpwardsUnsafe(true);
-            Assert.True(dir == (Direction)dir.Type);
-            Assert.True(dir.Equals((Direction)dir.Type));
+            Assert.True(dir == dir.Type);
+            Assert.True(dir.Equals(dir.Type));
             Assert.True(dir.Equals((object)((Direction)(dir.Type))));
 
             Direction.SetYIncreasesUpwardsUnsafe(false);
-            Assert.True(dir == (Direction)dir.Type);
-            Assert.True(dir.Equals((Direction)dir.Type));
+            Assert.True(dir == dir.Type);
+            Assert.True(dir.Equals(dir.Type));
             Assert.True(dir.Equals((object)((Direction)(dir.Type))));
         }
         #endregion

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -23,7 +23,7 @@ namespace SadRogue.Primitives.UnitTests
             // Determine "top"
             int yToCheck = yIncreaseUpwards ? rect.MaxExtentY : rect.MinExtentY;
             // Get edge points
-            Point[] edgePoints = rect.TopEdgePositions().ToArray();
+            Point[] edgePoints = rect.PositionsOnSide(Direction.Up).ToArray();
             HashSet<Point> hashSet = new HashSet<Point>(edgePoints);
 
             // Verify no duplicates
@@ -43,7 +43,7 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(yIncreaseUpwards);
 
             // Get edge points
-            Point[] edgePoints = rect.RightEdgePositions().ToArray();
+            Point[] edgePoints = rect.PositionsOnSide(Direction.Right).ToArray();
             HashSet<Point> hashSet = new HashSet<Point>(edgePoints);
 
             // Verify no duplicates
@@ -65,7 +65,7 @@ namespace SadRogue.Primitives.UnitTests
             // Determine "bottom"
             int yToCheck = yIncreaseUpwards ? rect.MinExtentY : rect.MaxExtentY;
             // Get edge points
-            Point[] edgePoints = rect.BottomEdgePositions().ToArray();
+            Point[] edgePoints = rect.PositionsOnSide(Direction.Down).ToArray();
             HashSet<Point> hashSet = new HashSet<Point>(edgePoints);
 
             // Verify no duplicates
@@ -85,7 +85,7 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(yIncreaseUpwards);
 
             // Get edge points
-            Point[] edgePoints = rect.LeftEdgePositions().ToArray();
+            Point[] edgePoints = rect.PositionsOnSide(Direction.Left).ToArray();
             HashSet<Point> hashSet = new HashSet<Point>(edgePoints);
 
             // Verify no duplicates
@@ -108,11 +108,11 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(yIncreasesUpwards);
 
             // Get expected points that should return true
-            var expectedPoints = rect.TopEdgePositions().ToHashSet();
+            var expectedPoints = rect.PositionsOnSide(Direction.Up).ToHashSet();
 
             // Check that all points return the proper value
             foreach (var point in rect.Positions())
-                Assert.Equal(expectedPoints.Contains(point), rect.IsOnTopEdge(point));
+                Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Up));
 
             // Reset to false for next test
             Direction.SetYIncreasesUpwardsUnsafe(false);
@@ -126,11 +126,11 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(yIncreasesUpwards);
 
             // Get expected points that should return true
-            var expectedPoints = rect.RightEdgePositions().ToHashSet();
+            var expectedPoints = rect.PositionsOnSide(Direction.Right).ToHashSet();
 
             // Check that all points return the proper value
             foreach (var point in rect.Positions())
-                Assert.Equal(expectedPoints.Contains(point), rect.IsOnRightEdge(point));
+                Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Right));
 
             // Reset to false for next test
             Direction.SetYIncreasesUpwardsUnsafe(false);
@@ -144,11 +144,11 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(yIncreasesUpwards);
 
             // Get expected points that should return true
-            var expectedPoints = rect.BottomEdgePositions().ToHashSet();
+            var expectedPoints = rect.PositionsOnSide(Direction.Down).ToHashSet();
 
             // Check that all points return the proper value
             foreach (var point in rect.Positions())
-                Assert.Equal(expectedPoints.Contains(point), rect.IsOnBottomEdge(point));
+                Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Down));
 
             // Reset to false for next test
             Direction.SetYIncreasesUpwardsUnsafe(false);
@@ -162,11 +162,11 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(yIncreasesUpwards);
 
             // Get expected points that should return true
-            var expectedPoints = rect.LeftEdgePositions().ToHashSet();
+            var expectedPoints = rect.PositionsOnSide(Direction.Left).ToHashSet();
 
             // Check that all points return the proper value
             foreach (var point in rect.Positions())
-                Assert.Equal(expectedPoints.Contains(point), rect.IsOnLeftEdge(point));
+                Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Left));
 
             // Reset to false for next test
             Direction.SetYIncreasesUpwardsUnsafe(false);

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Xunit;
 using XUnit.ValueTuples;
 

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -8,12 +8,16 @@ namespace SadRogue.Primitives.UnitTests
     public class RectangleTests
     {
         #region Test Data
+
         public static Rectangle[] TestRectangles = new Rectangle[] { (0, 0, 10, 20), (1, 2, 15, 17), (5, 2, 18, 6) };
 
-        public static (Rectangle rect, bool yIncreaseUpwards)[] TestRectanglesWithYIncreasesUpwards = TestRectangles.Combinate(TestUtils.Enumerable(true, false)).ToArray();
+        public static (Rectangle rect, bool yIncreaseUpwards)[] TestRectanglesWithYIncreasesUpwards =
+            TestRectangles.Combinate(TestUtils.Enumerable(true, false)).ToArray();
+
         #endregion
 
         #region Test Side Points
+
         [Theory]
         [MemberDataTuple(nameof(TestRectanglesWithYIncreasesUpwards))]
         public void TopEdgePositions(Rectangle rect, bool yIncreaseUpwards)
@@ -97,9 +101,11 @@ namespace SadRogue.Primitives.UnitTests
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
         }
+
         #endregion
 
         #region Test Side Identification
+
         [Theory]
         [MemberDataTuple(nameof(TestRectanglesWithYIncreasesUpwards))]
         public void IsOnTopEdge(Rectangle rect, bool yIncreasesUpwards)
@@ -111,7 +117,7 @@ namespace SadRogue.Primitives.UnitTests
             var expectedPoints = rect.PositionsOnSide(Direction.Up).ToHashSet();
 
             // Check that all points return the proper value
-            foreach (var point in rect.Positions())
+            foreach (Point point in rect.Positions())
                 Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Up));
 
             // Reset to false for next test
@@ -129,7 +135,7 @@ namespace SadRogue.Primitives.UnitTests
             var expectedPoints = rect.PositionsOnSide(Direction.Right).ToHashSet();
 
             // Check that all points return the proper value
-            foreach (var point in rect.Positions())
+            foreach (Point point in rect.Positions())
                 Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Right));
 
             // Reset to false for next test
@@ -147,7 +153,7 @@ namespace SadRogue.Primitives.UnitTests
             var expectedPoints = rect.PositionsOnSide(Direction.Down).ToHashSet();
 
             // Check that all points return the proper value
-            foreach (var point in rect.Positions())
+            foreach (Point point in rect.Positions())
                 Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Down));
 
             // Reset to false for next test
@@ -165,12 +171,13 @@ namespace SadRogue.Primitives.UnitTests
             var expectedPoints = rect.PositionsOnSide(Direction.Left).ToHashSet();
 
             // Check that all points return the proper value
-            foreach (var point in rect.Positions())
+            foreach (Point point in rect.Positions())
                 Assert.Equal(expectedPoints.Contains(point), rect.IsOnSide(point, Direction.Left));
 
             // Reset to false for next test
             Direction.SetYIncreasesUpwardsUnsafe(false);
         }
+
         #endregion
     }
 }

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-
     <RootNamespace>SadRogue.Primitives.UnitTests</RootNamespace>
   </PropertyGroup>
 

--- a/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
+++ b/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
@@ -9,10 +9,7 @@ namespace SadRogue.Primitives.UnitTests
     /// </summary>
     public static class TestUtils
     {
-        public static void Fail(string message)
-        {
-            Assert.True(false, message);
-        }
+        public static void Fail(string message) => Assert.True(false, message);
 
         public static IEnumerable<T> ToEnumerable<T>(this T obj)
         {
@@ -22,8 +19,9 @@ namespace SadRogue.Primitives.UnitTests
         public static IEnumerable<(T1, T2)> Combinate<T1, T2>(this IEnumerable<T1> l1, IEnumerable<T2> l2)
             => from x in l1 from y in l2 select (x, y);
 
-        public static IEnumerable<(T1, T2, T3)> Combinate<T1, T2, T3>(this IEnumerable<(T1 i1, T2 i2)> tuples, IEnumerable<T3> l2)
-            => from tuple in tuples from z in l2 select(tuple.i1, tuple.i2, z);
+        public static IEnumerable<(T1, T2, T3)> Combinate<T1, T2, T3>(this IEnumerable<(T1 i1, T2 i2)> tuples,
+                                                                      IEnumerable<T3> l2)
+            => from tuple in tuples from z in l2 select (tuple.i1, tuple.i2, z);
 
         public static void AssertElementEquals<T>(params IReadOnlyList<T>[] lists)
         {

--- a/TheSadRogue.Primitives.UnitTests/DistanceTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/DistanceTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using SadRogue.Primitives;
 using Xunit;
 using XUnit.ValueTuples;
 
@@ -8,15 +7,15 @@ namespace SadRogue.Primitives.UnitTests
     public class DistanceTests
     {
         #region Testdata
-        public static Distance[] Distances => new Distance[] { Distance.Manhattan, Distance.Chebyshev, Distance.Euclidean };
+        public static Distance[] Distances => new[] { Distance.Manhattan, Distance.Chebyshev, Distance.Euclidean };
 
-        public static (Distance.Types, Distance)[] TypeDistanceConversion => new (Distance.Types, Distance)[]
+        public static (Distance.Types, Distance)[] TypeDistanceConversion => new[]
         { (Distance.Types.Chebyshev, Distance.Chebyshev), (Distance.Types.Euclidean, Distance.Euclidean), (Distance.Types.Manhattan, Distance.Manhattan) };
 
-        public static (Distance, AdjacencyRule)[] AdjacencyRuleConversionValues => new (Distance, AdjacencyRule)[]
+        public static (Distance, AdjacencyRule)[] AdjacencyRuleConversionValues => new[]
         { (Distance.Chebyshev, AdjacencyRule.EightWay), (Distance.Euclidean, AdjacencyRule.EightWay), (Distance.Manhattan, AdjacencyRule.Cardinals) };
 
-        public static (Distance, Radius)[] RadiusConversionValues => new (Distance, Radius)[]
+        public static (Distance, Radius)[] RadiusConversionValues => new[]
         { (Distance.Chebyshev, Radius.Square), (Distance.Euclidean, Radius.Circle), (Distance.Manhattan, Radius.Diamond) };
         #endregion
 

--- a/TheSadRogue.Primitives.UnitTests/DistanceTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/DistanceTests.cs
@@ -7,19 +7,31 @@ namespace SadRogue.Primitives.UnitTests
     public class DistanceTests
     {
         #region Testdata
+
         public static Distance[] Distances => new[] { Distance.Manhattan, Distance.Chebyshev, Distance.Euclidean };
 
         public static (Distance.Types, Distance)[] TypeDistanceConversion => new[]
-        { (Distance.Types.Chebyshev, Distance.Chebyshev), (Distance.Types.Euclidean, Distance.Euclidean), (Distance.Types.Manhattan, Distance.Manhattan) };
+        {
+            (Distance.Types.Chebyshev, Distance.Chebyshev), (Distance.Types.Euclidean, Distance.Euclidean),
+            (Distance.Types.Manhattan, Distance.Manhattan)
+        };
 
         public static (Distance, AdjacencyRule)[] AdjacencyRuleConversionValues => new[]
-        { (Distance.Chebyshev, AdjacencyRule.EightWay), (Distance.Euclidean, AdjacencyRule.EightWay), (Distance.Manhattan, AdjacencyRule.Cardinals) };
+        {
+            (Distance.Chebyshev, AdjacencyRule.EightWay), (Distance.Euclidean, AdjacencyRule.EightWay),
+            (Distance.Manhattan, AdjacencyRule.Cardinals)
+        };
 
         public static (Distance, Radius)[] RadiusConversionValues => new[]
-        { (Distance.Chebyshev, Radius.Square), (Distance.Euclidean, Radius.Circle), (Distance.Manhattan, Radius.Diamond) };
+        {
+            (Distance.Chebyshev, Radius.Square), (Distance.Euclidean, Radius.Circle),
+            (Distance.Manhattan, Radius.Diamond)
+        };
+
         #endregion
 
         #region Equality/Inequality
+
         [Theory]
         [MemberDataEnumerable(nameof(Distances))]
         public void TestEquality(Distance dist)
@@ -49,9 +61,7 @@ namespace SadRogue.Primitives.UnitTests
             Distance[] dists = Distances;
 
             foreach (Distance dist in dists)
-            {
                 Assert.NotEqual(dist == compareDist, dist != compareDist);
-            }
         }
 
         [Theory]
@@ -66,9 +76,11 @@ namespace SadRogue.Primitives.UnitTests
                 Assert.Equal(dist == compareDist, dist.Equals((object)compareDist));
             }
         }
+
         #endregion
 
         #region DistanceTypeToDistanceConversion
+
         [Theory]
         [MemberDataTuple(nameof(TypeDistanceConversion))]
         public void DistanceTypeConversion(Distance.Types type, Distance expectedDist)
@@ -76,9 +88,11 @@ namespace SadRogue.Primitives.UnitTests
             Distance dir = type;
             Assert.Equal(expectedDist, dir);
         }
+
         #endregion
 
         #region DistanceImplicitConversions
+
         [Theory]
         [MemberDataTuple(nameof(AdjacencyRuleConversionValues))]
         public void AdjacencyRuleConversion(Distance dist, AdjacencyRule expected) => Assert.Equal(expected, dist);
@@ -90,10 +104,13 @@ namespace SadRogue.Primitives.UnitTests
             Radius d = dist;
             Assert.Equal(expected, d);
         }
+
         #endregion
 
         #region DistanceCalculations
+
         // TODO: Test actual distance calculations
+
         #endregion
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
@@ -7,20 +7,31 @@ namespace SadRogue.Primitives.UnitTests
     public class RadiusTests
     {
         #region Testdata
+
         public static Radius[] Radiuses => new[] { Radius.Square, Radius.Circle, Radius.Diamond };
 
         public static (Radius.Types, Radius)[] TypeRadiusConversion => new[]
-        { (Radius.Types.Square, Radius.Square), (Radius.Types.Circle, Radius.Circle), (Radius.Types.Diamond,Radius.Diamond) };
+        {
+            (Radius.Types.Square, Radius.Square), (Radius.Types.Circle, Radius.Circle),
+            (Radius.Types.Diamond, Radius.Diamond)
+        };
 
         public static (Radius, AdjacencyRule)[] AdjacencyRuleConversionValues => new[]
-        { (Radius.Square, AdjacencyRule.EightWay), (Radius.Circle, AdjacencyRule.EightWay), (Radius.Diamond, AdjacencyRule.Cardinals) };
+        {
+            (Radius.Square, AdjacencyRule.EightWay), (Radius.Circle, AdjacencyRule.EightWay),
+            (Radius.Diamond, AdjacencyRule.Cardinals)
+        };
 
         public static (Radius, Distance)[] DistanceConversionValues => new[]
-        { (Radius.Square, Distance.Chebyshev), (Radius.Circle, Distance.Euclidean), (Radius.Diamond, Distance.Manhattan) };
+        {
+            (Radius.Square, Distance.Chebyshev), (Radius.Circle, Distance.Euclidean),
+            (Radius.Diamond, Distance.Manhattan)
+        };
 
         #endregion
 
         #region Equality/Inequality
+
         [Theory]
         [MemberDataEnumerable(nameof(Radiuses))]
         public void TestEquality(Radius rad)
@@ -50,9 +61,7 @@ namespace SadRogue.Primitives.UnitTests
             Radius[] rads = Radiuses;
 
             foreach (Radius rad in rads)
-            {
                 Assert.NotEqual(rad == compareRad, rad != compareRad);
-            }
         }
 
         [Theory]
@@ -67,9 +76,11 @@ namespace SadRogue.Primitives.UnitTests
                 Assert.Equal(rad == compareRad, rad.Equals((object)compareRad));
             }
         }
+
         #endregion
 
         #region DistanceTypeToDistanceConversion
+
         [Theory]
         [MemberDataTuple(nameof(TypeRadiusConversion))]
         public void RadiusTypeConversion(Radius.Types type, Radius expectedRad)
@@ -77,9 +88,11 @@ namespace SadRogue.Primitives.UnitTests
             Radius rad = type;
             Assert.Equal(expectedRad, rad);
         }
+
         #endregion
 
         #region DistanceImplicitConversions
+
         [Theory]
         [MemberDataTuple(nameof(AdjacencyRuleConversionValues))]
         public void AdjacencyRuleConversion(Radius dist, AdjacencyRule expected) => Assert.Equal(expected, dist);
@@ -91,6 +104,7 @@ namespace SadRogue.Primitives.UnitTests
             Distance r = rad;
             Assert.Equal(expected, r);
         }
+
         #endregion
 
         #region PositionsInRadius
@@ -103,7 +117,7 @@ namespace SadRogue.Primitives.UnitTests
             Point center = (25, 20);
             int radius = 10;
 
-            var dist = (Distance)shape;
+            Distance dist = (Distance)shape;
 
             var positions = shape.PositionsInRadius(center, radius).ToList();
             var positionsHash = positions.ToHashSet();
@@ -116,7 +130,8 @@ namespace SadRogue.Primitives.UnitTests
             Assert.All(positions, pos => Assert.True(area.Contains(pos)));
 
             // Positions returned should be exactly the ones within the radius
-            var positionsHashExpected = area.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
+            var positionsHashExpected =
+                area.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
             Assert.Equal(positionsHashExpected, positionsHash);
         }
 
@@ -129,7 +144,7 @@ namespace SadRogue.Primitives.UnitTests
             Point center = (5, 7);
             int radius = 10;
 
-            var dist = (Distance)shape;
+            Distance dist = (Distance)shape;
 
             var positions = shape.PositionsInRadius(center, radius, bounds).ToList();
             var positionsHash = positions.ToHashSet();
@@ -141,11 +156,13 @@ namespace SadRogue.Primitives.UnitTests
             Assert.All(positions, pos => Assert.True(bounds.Contains(pos)));
 
             // Positions returned should be exactly the ones within the radius
-            var positionsHashExpected = bounds.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
+            var positionsHashExpected =
+                bounds.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
             Assert.Equal(positionsHashExpected, positionsHash);
         }
 
         // TODO: Test PositionsInRadius w/context functions.
+
         #endregion
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -8,33 +8,33 @@ namespace SadRogue.Primitives.UnitTests
     public class RectangleTests
     {
         #region Test Data
+
         public static Rectangle[] EqualRectangles = new Rectangle[]
         {
-            new Rectangle(1, 2, 11, 17),
-            new Rectangle(new Point(1, 2), new Point(11, 18)),
+            new Rectangle(1, 2, 11, 17), new Rectangle(new Point(1, 2), new Point(11, 18)),
             new Rectangle(new Point(6, 10), 5, 8)
         };
 
         public static Rectangle[] DifferentRectangles = new Rectangle[]
         {
-            new Rectangle(1, 2, 10, 16),
-            new Rectangle(2, 3, 10, 16),
-            new Rectangle(new Point(0, 0), 5, 6)
+            new Rectangle(1, 2, 10, 16), new Rectangle(2, 3, 10, 16), new Rectangle(new Point(0, 0), 5, 6)
         };
 
-        public static IEnumerable<(Rectangle, Rectangle)> PairwiseEqualRects = EqualRectangles.Combinate(EqualRectangles);
+        public static IEnumerable<(Rectangle, Rectangle)> PairwiseEqualRects =
+            EqualRectangles.Combinate(EqualRectangles);
+
         #endregion
 
         #region Constructor Equivalence
+
         [Theory]
         [MemberDataTuple(nameof(PairwiseEqualRects))]
-        public void TestConstructorEquivalence(Rectangle r1, Rectangle r2)
-        {
-            Assert.Equal(r1, r2);
-        }
+        public void TestConstructorEquivalence(Rectangle r1, Rectangle r2) => Assert.Equal(r1, r2);
+
         #endregion
 
         #region Equality/Inequality
+
         [Theory]
         [MemberDataEnumerable(nameof(DifferentRectangles))]
         public void TestEquality(Rectangle rad)
@@ -65,13 +65,13 @@ namespace SadRogue.Primitives.UnitTests
             Rectangle[] rects = DifferentRectangles;
 
             foreach (Rectangle rect in rects)
-            {
                 Assert.NotEqual(rect == compareRect, rect != compareRect);
-            }
         }
+
         #endregion
 
         #region Tuple Conversions
+
         [Theory]
         [MemberDataEnumerable(nameof(DifferentRectangles))]
         public void TestTupleConversions(Rectangle rect)
@@ -84,9 +84,11 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(rect, rect1);
             Assert.Equal(rect1, rect2);
         }
+
         #endregion
 
         #region Tuple Equality
+
         [Theory]
         [MemberDataEnumerable(nameof(DifferentRectangles))]
         public void TestTupleEquality(Rectangle rect)
@@ -101,6 +103,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.True(rect.Equals(t1));
             Assert.True(rect.Equals(t2));
         }
+
         #endregion
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/Serialization/BinaryTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/BinaryTests.cs
@@ -29,8 +29,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             new ColorSerialized() { R = 12, G = 16, B = 45, A = 255 },
             new GradientStopSerialized()
             {
-                Color = new ColorSerialized() { R = 10, G = 20, B = 30, A = 40 },
-                Stop = 0.5f
+                Color = new ColorSerialized() { R = 10, G = 20, B = 30, A = 40 }, Stop = 0.5f
             },
             new GradientSerialized()
             {
@@ -38,13 +37,11 @@ namespace SadRogue.Primitives.UnitTests.Serialization
                 {
                     new GradientStopSerialized()
                     {
-                        Stop = 0f,
-                        Color = new ColorSerialized() { R = 156, G = 24, B = 97, A = 250 }
+                        Stop = 0f, Color = new ColorSerialized() { R = 156, G = 24, B = 97, A = 250 }
                     },
                     new GradientStopSerialized()
                     {
-                        Stop = 1f,
-                        Color = new ColorSerialized() { R = 100, G = 200, B = 50, A = 25 }
+                        Stop = 1f, Color = new ColorSerialized() { R = 100, G = 200, B = 50, A = 25 }
                     }
                 }
             },
@@ -57,10 +54,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
                 }
             },
             new PointSerialized() { X = 42, Y = 24 },
-            new RectangleSerialized() { X = 42, Y = 24, Width = 50, Height =  100 },
-            AdjacencyRule.Types.Cardinals, AdjacencyRule.Types.Diagonals, AdjacencyRule.Types.EightWay,
-            Direction.Types.Up, Direction.Types.Left, Direction.Types.DownRight,
-            Distance.Types.Euclidean, Distance.Types.Chebyshev, Distance.Types.Manhattan,
+            new RectangleSerialized() { X = 42, Y = 24, Width = 50, Height = 100 }, AdjacencyRule.Types.Cardinals,
+            AdjacencyRule.Types.Diagonals, AdjacencyRule.Types.EightWay, Direction.Types.Up, Direction.Types.Left,
+            Direction.Types.DownRight, Distance.Types.Euclidean, Distance.Types.Chebyshev, Distance.Types.Manhattan,
             Radius.Types.Square, Radius.Types.Circle, Radius.Types.Diamond
         };
 
@@ -74,9 +70,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
 
             var formatter = new BinaryFormatter();
             using (var stream = new FileStream(name, FileMode.Create, FileAccess.Write))
-            {
                 formatter.Serialize(stream, objToSerialize);
-            }
 
             object reSerialized;
             using (var stream = new FileStream(name, FileMode.Open, FileAccess.Read))

--- a/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
@@ -8,7 +8,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
     static class Comparisons
     {
         // Dictionary of object types mapping them to custom methods to use in order to determine equality.
-        private static Dictionary<Type, Func<object, object, bool>> _equalityMethods = new Dictionary<Type, Func<object, object, bool>>()
+        private static readonly Dictionary<Type, Func<object, object, bool>> _equalityMethods = new Dictionary<Type, Func<object, object, bool>>()
         {
             { typeof(AreaSerialized), AreaSerializedCompare },
             { typeof(GradientSerialized), GradientSerializedCompare },
@@ -16,7 +16,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         };
 
         public static Func<object, object, bool> GetComparisonFunc(object obj)
-            => _equalityMethods.GetValueOrDefault(obj.GetType(), (o1, o2) => o1.Equals(o2));
+            => _equalityMethods.GetValueOrDefault(obj.GetType(), (o1, o2) => o1.Equals(o2))!;
 
         // Compares to AreaSerialized instances
         private static bool AreaSerializedCompare(object o1, object o2)
@@ -28,9 +28,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         private static bool GradientSerializedCompare(object o1, object o2)
             => ElementWiseEquality(((GradientSerialized)o1).Stops, ((GradientSerialized)o2).Stops);
 
-        private static bool ElementWiseEquality<T>(IEnumerable<T> e1, IEnumerable<T> e2, Func<T, T, bool> compareFunc = null)
+        private static bool ElementWiseEquality<T>(IEnumerable<T> e1, IEnumerable<T> e2, Func<T, T, bool>? compareFunc = null)
         {
-            compareFunc ??= (o1, o2) => o1.Equals(o2);
+            compareFunc ??= (o1, o2) => o1?.Equals(o2) ?? o2 == null;
 
             var l1 = e1.ToList();
             var l2 = e2.ToList();

--- a/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
@@ -5,15 +5,16 @@ using SadRogue.Primitives.SerializedTypes;
 
 namespace SadRogue.Primitives.UnitTests.Serialization
 {
-    static class Comparisons
+    internal static class Comparisons
     {
         // Dictionary of object types mapping them to custom methods to use in order to determine equality.
-        private static readonly Dictionary<Type, Func<object, object, bool>> _equalityMethods = new Dictionary<Type, Func<object, object, bool>>()
-        {
-            { typeof(AreaSerialized), AreaSerializedCompare },
-            { typeof(GradientSerialized), GradientSerializedCompare },
-            { typeof(PaletteSerialized), PaletteSerializedCompare }
-        };
+        private static readonly Dictionary<Type, Func<object, object, bool>> _equalityMethods =
+            new Dictionary<Type, Func<object, object, bool>>()
+            {
+                { typeof(AreaSerialized), AreaSerializedCompare },
+                { typeof(GradientSerialized), GradientSerializedCompare },
+                { typeof(PaletteSerialized), PaletteSerializedCompare }
+            };
 
         public static Func<object, object, bool> GetComparisonFunc(object obj)
             => _equalityMethods.GetValueOrDefault(obj.GetType(), (o1, o2) => o1.Equals(o2))!;
@@ -28,7 +29,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         private static bool GradientSerializedCompare(object o1, object o2)
             => ElementWiseEquality(((GradientSerialized)o1).Stops, ((GradientSerialized)o2).Stops);
 
-        private static bool ElementWiseEquality<T>(IEnumerable<T> e1, IEnumerable<T> e2, Func<T, T, bool>? compareFunc = null)
+        private static bool ElementWiseEquality<T>(IEnumerable<T> e1, IEnumerable<T> e2,
+                                                   Func<T, T, bool>? compareFunc = null)
         {
             compareFunc ??= (o1, o2) => o1?.Equals(o2) ?? o2 == null;
 

--- a/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
@@ -13,21 +13,24 @@ namespace SadRogue.Primitives.UnitTests.Serialization
     public class DataContractTests
     {
         #region Test Data
+
         // Types that serialize to JSON objects via JSON .NET, so we can check which fields are serialized.
         public static IEnumerable<object> SerializableValuesJsonObjects = new object[]
         {
             // AdjacencyRules
             AdjacencyRule.Cardinals, AdjacencyRule.EightWay,
             // AreaSerialized
-            (AreaSerialized)new Area((1, 2), (3, 4), (5,6)),
+            (AreaSerialized)new Area((1, 2), (3, 4), (5, 6)),
             // BoundedRectangle
             new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
             // BoundedRectangleSerialized
-            (BoundedRectangleSerialized)new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
+            (BoundedRectangleSerialized)new BoundedRectangle(new Rectangle(1, 4, 10, 14),
+                new Rectangle(-10, -9, 100, 101)),
             // Colors
             new Color(.5f, .6f, .7f), new Color(120, 121, 122, 100), Color.AliceBlue,
             // ColorSerialized
-            (ColorSerialized)new Color(.5f, .6f, .7f), (ColorSerialized)new Color(120, 121, 122, 100), (ColorSerialized)Color.AliceBlue,
+            (ColorSerialized)new Color(.5f, .6f, .7f), (ColorSerialized)new Color(120, 121, 122, 100),
+            (ColorSerialized)Color.AliceBlue,
             // Directions
             Direction.Down, Direction.UpRight,
             // Distances
@@ -39,7 +42,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             // GradientSerialized
             (GradientSerialized)new Gradient(new Color(100, 101, 102, 103), new Color(200, 201, 202, 203)),
             // PaletteSerialized
-            (PaletteSerialized)new Palette(new[] {new Color(100, 101, 102, 103), new Color(150, 151, 152, 149)}),
+            (PaletteSerialized)new Palette(new[] { new Color(100, 101, 102, 103), new Color(150, 151, 152, 149) }),
             // Point
             new Point(-1, -5), new Point(4, 9),
             // PointSerialized
@@ -58,7 +61,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             // AdjacencyRule.Types
             AdjacencyRule.Types.Cardinals, AdjacencyRule.Types.Diagonals,
             // Area
-            new Area((1, 2), (3, 4), (5,6)),
+            new Area((1, 2), (3, 4), (5, 6)),
             // Direction.Types
             Direction.Types.Down, Direction.Types.Right,
             // Distance.Types
@@ -66,7 +69,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             // Gradient
             new Gradient(new Color(100, 101, 102, 103), new Color(200, 201, 202, 203)),
             // Palette
-            new Palette(new[] {new Color(100, 101, 102, 103), new Color(150, 151, 152, 149)}),
+            new Palette(new[] { new Color(100, 101, 102, 103), new Color(150, 151, 152, 149) }),
             // Radius.Types
             Radius.Types.Square, Radius.Types.Circle
         };
@@ -79,33 +82,31 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         // in its JSON object form.
         private static Dictionary<Type, string[]> typeSerializedFields = new Dictionary<Type, string[]>
         {
-            { typeof(AdjacencyRule),              new [] { "Type" } },
-            { typeof(AreaSerialized),             new [] { "Positions" } },
-            { typeof(BoundedRectangle),           new [] { "_area", "_boundingBox" } },
-            { typeof(BoundedRectangleSerialized), new [] { "Area", "Bounds"} },
-            { typeof(Color),                      new [] { "_packedValue" } },
-            { typeof(ColorSerialized),            new [] {"R", "G", "B", "A" } },
-            { typeof(Direction),                  new [] { "Type" } },
-            { typeof(Distance),                   new [] { "Type" } },
-            { typeof(GradientStop),               new [] { "Color", "Stop" } },
-            { typeof(GradientStopSerialized),     new [] { "Color", "Stop" } },
-            { typeof(GradientSerialized),         new [] { "Stops" } },
-            { typeof(PaletteSerialized),          new [] { "Colors" } },
-            { typeof(Point),                      new [] { "X", "Y" } },
-            { typeof(PointSerialized),            new [] { "X", "Y" } },
-            { typeof(Radius),                     new [] { "Type" } },
-            { typeof(Rectangle),                  new [] { "X", "Y", "Width", "Height" } },
-            { typeof(RectangleSerialized),        new [] { "X", "Y", "Width", "Height" } }
+            { typeof(AdjacencyRule), new[] { "Type" } },
+            { typeof(AreaSerialized), new[] { "Positions" } },
+            { typeof(BoundedRectangle), new[] { "_area", "_boundingBox" } },
+            { typeof(BoundedRectangleSerialized), new[] { "Area", "Bounds" } },
+            { typeof(Color), new[] { "_packedValue" } },
+            { typeof(ColorSerialized), new[] { "R", "G", "B", "A" } },
+            { typeof(Direction), new[] { "Type" } },
+            { typeof(Distance), new[] { "Type" } },
+            { typeof(GradientStop), new[] { "Color", "Stop" } },
+            { typeof(GradientStopSerialized), new[] { "Color", "Stop" } },
+            { typeof(GradientSerialized), new[] { "Stops" } },
+            { typeof(PaletteSerialized), new[] { "Colors" } },
+            { typeof(Point), new[] { "X", "Y" } },
+            { typeof(PointSerialized), new[] { "X", "Y" } },
+            { typeof(Radius), new[] { "Type" } },
+            { typeof(Rectangle), new[] { "X", "Y", "Width", "Height" } },
+            { typeof(RectangleSerialized), new[] { "X", "Y", "Width", "Height" } }
         };
+
         #endregion
 
         // Useful for viewing output
         private readonly ITestOutputHelper output;
 
-        public DataContractTests(ITestOutputHelper output)
-        {
-            this.output = output;
-        }
+        public DataContractTests(ITestOutputHelper output) => this.output = output;
 
         /// <summary>
         /// Tests that if we serialize an object to JSON, then deserialize it back to an object,
@@ -134,7 +135,6 @@ namespace SadRogue.Primitives.UnitTests.Serialization
 
             // Make sure the deserialized object is equivalent to the one we serialized
             Assert.True(equality(objToSerialize, deSerialized!));
-
         }
 
         /// <summary>

--- a/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
@@ -129,10 +129,11 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             output.WriteLine($"Json: {json}");
 
             // Deserialize to object
-            object deSerialized = JsonConvert.DeserializeObject(json, objType);
+            object? deSerialized = JsonConvert.DeserializeObject(json, objType);
+            Assert.NotNull(deSerialized);
 
             // Make sure the deserialized object is equivalent to the one we serialized
-            Assert.True(equality(objToSerialize, deSerialized));
+            Assert.True(equality(objToSerialize, deSerialized!));
 
         }
 

--- a/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
@@ -76,7 +76,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             SerializableValuesJsonObjects.Concat(SerializableValuesNonJsonObjects);
 
         // Dictionary of object types to an unordered but complete list of fields that each object type should have serialized
-        // in its JSON object form.  
+        // in its JSON object form.
         private static Dictionary<Type, string[]> typeSerializedFields = new Dictionary<Type, string[]>
         {
             { typeof(AdjacencyRule),              new [] { "Type" } },
@@ -109,9 +109,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
 
         /// <summary>
         /// Tests that if we serialize an object to JSON, then deserialize it back to an object,
-        /// that the deserialized object is equal to the one that we serialized.  If a custom equality method
-        /// has been specified in <see cref="equalityMethods"/>, that method is used to determine equality.
-        /// Otherwise, the object's <see cref="object.Equals(object?)"/> method is used.
+        /// that the deserialized object is equal to the one that we serialized.  Equality is compared
+        /// via <see cref="Comparisons.GetComparisonFunc"/>.
         /// </summary>
         /// <param name="objToSerialize"/>
         [Theory]

--- a/TheSadRogue.Primitives.UnitTests/Serialization/ImplicitConversionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/ImplicitConversionTests.cs
@@ -9,7 +9,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         public void AreaToAreaSerialized()
         {
             var original = new Area(TestUtils.Enumerable<Point>((1, 2), (3, 4), (5, 6)));
-            var expressive = (AreaSerialized)original;
+            AreaSerialized expressive = (AreaSerialized)original;
             var converted = (Area)expressive;
 
             Assert.Equal(original, converted);
@@ -19,7 +19,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         public void BoundedRectangleToBoundedRectangleSerialized()
         {
             var original = new BoundedRectangle((1, 2, 9, 11), (-1, -2, 100, 101));
-            var expressive = (BoundedRectangleSerialized)original;
+            BoundedRectangleSerialized expressive = (BoundedRectangleSerialized)original;
             var converted = (BoundedRectangle)expressive;
 
             Assert.Equal(original, converted);
@@ -28,9 +28,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void ColorToColorSerialized()
         {
-            var original = new Color(23, 25, 27, 67);
-            var expressive = (ColorSerialized)original;
-            var converted = (Color)expressive;
+            Color original = new Color(23, 25, 27, 67);
+            ColorSerialized expressive = (ColorSerialized)original;
+            Color converted = (Color)expressive;
 
             Assert.Equal(original, converted);
         }
@@ -39,8 +39,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         public void GradientToGradientSerialized()
         {
             var original = new Gradient(TestUtils.Enumerable(Color.AliceBlue, Color.Black, Color.Red),
-                                         TestUtils.Enumerable(0.0f, 0.5f, 1.0f));
-            var expressive = (GradientSerialized)original;
+                TestUtils.Enumerable(0.0f, 0.5f, 1.0f));
+            GradientSerialized expressive = (GradientSerialized)original;
             var converted = (Gradient)expressive;
 
             Assert.Equal(original, converted);
@@ -50,7 +50,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         public void PaletteToPaletteSerialized()
         {
             var original = new Palette(TestUtils.Enumerable(Color.AliceBlue, Color.Red, Color.Black, Color.Yellow));
-            var expressive = (PaletteSerialized)original;
+            PaletteSerialized expressive = (PaletteSerialized)original;
             var converted = (Palette)expressive;
 
             Assert.Equal(original, converted);
@@ -59,9 +59,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void PointToPointSerialized()
         {
-            var original = new Point(1, 2);
-            var expressive = (PointSerialized)original;
-            var converted = (Point)expressive;
+            Point original = new Point(1, 2);
+            PointSerialized expressive = (PointSerialized)original;
+            Point converted = (Point)expressive;
 
             Assert.Equal(original, converted);
         }
@@ -69,9 +69,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void RectangleToRectangleSerialized()
         {
-            var original = new Rectangle(1, 2, 34, 20);
-            var expressive = (RectangleSerialized)original;
-            var converted = (Rectangle)expressive;
+            Rectangle original = new Rectangle(1, 2, 34, 20);
+            RectangleSerialized expressive = (RectangleSerialized)original;
+            Rectangle converted = (Rectangle)expressive;
 
             Assert.Equal(original, converted);
         }
@@ -79,9 +79,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void AdjacencyRuleToType()
         {
-            var original = AdjacencyRule.Diagonals;
-            var expressive = (AdjacencyRule.Types)original;
-            var converted = (AdjacencyRule)expressive;
+            AdjacencyRule original = AdjacencyRule.Diagonals;
+            AdjacencyRule.Types expressive = (AdjacencyRule.Types)original;
+            AdjacencyRule converted = (AdjacencyRule)expressive;
 
             Assert.Equal(original, converted);
         }
@@ -89,9 +89,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void DirectionToType()
         {
-            var original = Direction.None;
-            var expressive = (Direction.Types)original;
-            var converted = (Direction)expressive;
+            Direction original = Direction.None;
+            Direction.Types expressive = (Direction.Types)original;
+            Direction converted = (Direction)expressive;
 
             Assert.Equal(original, converted);
         }
@@ -99,9 +99,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void DistanceToType()
         {
-            var original = Distance.Euclidean;
-            var expressive = (Distance.Types)original;
-            var converted = (Distance)expressive;
+            Distance original = Distance.Euclidean;
+            Distance.Types expressive = (Distance.Types)original;
+            Distance converted = (Distance)expressive;
 
             Assert.Equal(original, converted);
         }
@@ -109,9 +109,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         [Fact]
         public void RadiusToType()
         {
-            var original = Radius.Circle;
-            var expressive = (Radius.Types)original;
-            var converted = (Radius)expressive;
+            Radius original = Radius.Circle;
+            Radius.Types expressive = (Radius.Types)original;
+            Radius converted = (Radius)expressive;
 
             Assert.Equal(original, converted);
         }

--- a/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
+++ b/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-
     <RootNamespace>SadRogue.Primitives.UnitTests</RootNamespace>
   </PropertyGroup>
 

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -100,6 +100,8 @@ namespace SadRogue.Primitives
                     yield return Direction.DownLeft;
                     yield return Direction.DownRight;
                     break;
+                default:
+                    throw new NotSupportedException($"{nameof(DirectionsOfNeighbors)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
 
@@ -163,6 +165,8 @@ namespace SadRogue.Primitives
                         startingDirection++;
                     }
                     break;
+                default:
+                    throw new NotSupportedException($"{nameof(DirectionsOfNeighborsClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
 
@@ -226,6 +230,8 @@ namespace SadRogue.Primitives
                         startingDirection--;
                     }
                     break;
+                default:
+                    throw new NotSupportedException($"{nameof(DirectionsOfNeighborsCounterClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
 
@@ -347,20 +353,14 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator AdjacencyRule(Types type)
         {
-            switch (type)
+            return type switch
             {
-                case Types.Cardinals:
-                    return Cardinals;
-
-                case Types.Diagonals:
-                    return Diagonals;
-
-                case Types.EightWay:
-                    return EightWay;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Type)} type to {nameof(AdjacencyRule)} -- this is a bug!."); // Will not occur
-            }
+                Types.Cardinals => Cardinals,
+                Types.Diagonals => Diagonals,
+                Types.EightWay => EightWay,
+                _ => throw new NotSupportedException(
+                    $"Could not convert type {type} to {nameof(AdjacencyRule)} -- this is a bug!.")
+            };
         }
 
         /// <summary>

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -304,7 +304,7 @@ namespace SadRogue.Primitives
         /// True if <paramref name="obj"/> is an AdjacencyRule, and the two adjacency rules are equal, false otherwise.
         /// </returns>
         [Pure]
-        public override bool Equals(object obj) => obj is AdjacencyRule c && Equals(c);
+        public override bool Equals(object? obj) => obj is AdjacencyRule c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -63,8 +63,7 @@ namespace SadRogue.Primitives
         /// Enum value representing the method of determining adjacency -- useful for using
         /// <see cref="AdjacencyRule"/> types in switch statements.
         /// </summary>
-        [DataMember]
-        public readonly Types Type;
+        [DataMember] public readonly Types Type;
 
         /// <summary>
         /// Gets directions leading to neighboring locations, according to the current adjacency
@@ -101,7 +100,8 @@ namespace SadRogue.Primitives
                     yield return Direction.DownRight;
                     break;
                 default:
-                    throw new NotSupportedException($"{nameof(DirectionsOfNeighbors)} does not support AdjacencyRule type {Type} -- this is a bug!");
+                    throw new NotSupportedException(
+                        $"{nameof(DirectionsOfNeighbors)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
 
@@ -121,14 +121,10 @@ namespace SadRogue.Primitives
             {
                 case Types.Cardinals:
                     if (startingDirection == Direction.None)
-                    {
                         startingDirection = Direction.Up;
-                    }
 
                     if ((int)startingDirection.Type % 2 == 0)
-                    {
                         startingDirection++; // Make it a cardinal
-                    }
 
                     yield return startingDirection;
                     yield return startingDirection + 2;
@@ -138,14 +134,10 @@ namespace SadRogue.Primitives
 
                 case Types.Diagonals:
                     if (startingDirection == Direction.None)
-                    {
                         startingDirection = Direction.UpRight;
-                    }
 
                     if ((int)startingDirection.Type % 2 == 1)
-                    {
                         startingDirection++; // Make it a diagonal
-                    }
 
                     yield return startingDirection;
                     yield return startingDirection + 2;
@@ -155,18 +147,18 @@ namespace SadRogue.Primitives
 
                 case Types.EightWay:
                     if (startingDirection == Direction.None)
-                    {
                         startingDirection = Direction.Up;
-                    }
 
                     for (int i = 1; i <= 8; i++)
                     {
                         yield return startingDirection;
                         startingDirection++;
                     }
+
                     break;
                 default:
-                    throw new NotSupportedException($"{nameof(DirectionsOfNeighborsClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
+                    throw new NotSupportedException(
+                        $"{nameof(DirectionsOfNeighborsClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
 
@@ -186,14 +178,10 @@ namespace SadRogue.Primitives
             {
                 case Types.Cardinals:
                     if (startingDirection == Direction.None)
-                    {
                         startingDirection = Direction.Up;
-                    }
 
                     if ((int)startingDirection.Type % 2 == 0)
-                    {
                         startingDirection--; // Make it a cardinal
-                    }
 
                     yield return startingDirection;
                     yield return startingDirection - 2;
@@ -203,14 +191,10 @@ namespace SadRogue.Primitives
 
                 case Types.Diagonals:
                     if (startingDirection == Direction.None)
-                    {
                         startingDirection = Direction.UpLeft;
-                    }
 
                     if ((int)startingDirection.Type % 2 == 1)
-                    {
                         startingDirection--; // Make it a diagonal
-                    }
 
                     yield return startingDirection;
                     yield return startingDirection - 2;
@@ -220,18 +204,18 @@ namespace SadRogue.Primitives
 
                 case Types.EightWay:
                     if (startingDirection == Direction.None)
-                    {
                         startingDirection = Direction.Up;
-                    }
 
                     for (int i = 1; i <= 8; i++)
                     {
                         yield return startingDirection;
                         startingDirection--;
                     }
+
                     break;
                 default:
-                    throw new NotSupportedException($"{nameof(DirectionsOfNeighborsCounterClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
+                    throw new NotSupportedException(
+                        $"{nameof(DirectionsOfNeighborsCounterClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
 
@@ -245,9 +229,7 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> Neighbors(Point startingLocation)
         {
             foreach (Direction dir in DirectionsOfNeighbors())
-            {
                 yield return startingLocation + dir;
-            }
         }
 
         /// <summary>
@@ -267,9 +249,7 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> NeighborsClockwise(Point startingLocation, Direction startingDirection = default)
         {
             foreach (Direction dir in DirectionsOfNeighborsClockwise(startingDirection))
-            {
                 yield return startingLocation + dir;
-            }
         }
 
         /// <summary>
@@ -286,12 +266,11 @@ namespace SadRogue.Primitives
         /// </param>
         /// <returns>All neighbors of the given location.</returns>
         [Pure]
-        public IEnumerable<Point> NeighborsCounterClockwise(Point startingLocation, Direction startingDirection = default)
+        public IEnumerable<Point> NeighborsCounterClockwise(Point startingLocation,
+                                                            Direction startingDirection = default)
         {
             foreach (Direction dir in DirectionsOfNeighborsCounterClockwise(startingDirection))
-            {
                 yield return startingLocation + dir;
-            }
         }
 
         /// <summary>
@@ -351,23 +330,20 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="type"/>
         [Pure]
-        public static implicit operator AdjacencyRule(Types type)
+        public static implicit operator AdjacencyRule(Types type) => type switch
         {
-            return type switch
-            {
-                Types.Cardinals => Cardinals,
-                Types.Diagonals => Diagonals,
-                Types.EightWay => EightWay,
-                _ => throw new NotSupportedException(
-                    $"Could not convert type {type} to {nameof(AdjacencyRule)} -- this is a bug!.")
-            };
-        }
+            Types.Cardinals => Cardinals,
+            Types.Diagonals => Diagonals,
+            Types.EightWay => EightWay,
+            _ => throw new NotSupportedException(
+                $"Could not convert type {type} to {nameof(AdjacencyRule)} -- this is a bug!.")
+        };
 
         /// <summary>
-    /// Returns a string representation of the <see cref="AdjacencyRule"/>.
-    /// </summary>
-    /// <returns>A string representation of the <see cref="AdjacencyRule"/>.</returns>
-    [Pure]
+        /// Returns a string representation of the <see cref="AdjacencyRule"/>.
+        /// </summary>
+        /// <returns>A string representation of the <see cref="AdjacencyRule"/>.</returns>
+        [Pure]
         public override string ToString() => s_writeValues[(int)Type];
     }
 }

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -222,23 +222,23 @@ namespace SadRogue.Primitives
         /// <param name="position">The position to add.</param>
         public void Add(Point position)
         {
-            if (_positionsSet.Add(position))
-            {
-                _positions.Add(position);
+            if (!_positionsSet.Add(position))
+                return;
 
-                // Update bounds
-                if (position.X > _right)
-                    _right = position.X;
+            _positions.Add(position);
 
-                if (position.X < _left)
-                    _left = position.X;
+            // Update bounds
+            if (position.X > _right)
+                _right = position.X;
 
-                if (position.Y > _bottom)
-                    _bottom = position.Y;
+            if (position.X < _left)
+                _left = position.X;
 
-                if (position.Y < _top)
-                    _top = position.Y;
-            }
+            if (position.Y > _bottom)
+                _bottom = position.Y;
+
+            if (position.Y < _top)
+                _top = position.Y;
         }
 
         /// <summary>
@@ -355,7 +355,7 @@ namespace SadRogue.Primitives
         /// remove operations, it would be best to group them into 1 using <see cref="Remove(IEnumerable{Point})"/>.
         /// </summary>
         /// <param name="position">The position to remove.</param>
-        public void Remove(Point position) => Remove(YieldCoord(position));
+        public void Remove(Point position) => Remove(YieldPoint(position));
 
         /// <summary>
         /// Removes positions for which the given predicate returns true from the area.
@@ -468,19 +468,19 @@ namespace SadRogue.Primitives
             int rightLocal = int.MinValue, bottomLocal = int.MinValue;
 
             // Find new bounds
-            foreach (Point pos in _positions)
+            foreach ((int x, int y) in _positions)
             {
-                if (pos.X > rightLocal)
-                    rightLocal = pos.X;
+                if (x > rightLocal)
+                    rightLocal = x;
 
-                if (pos.X < leftLocal)
-                    leftLocal = pos.X;
+                if (x < leftLocal)
+                    leftLocal = x;
 
-                if (pos.Y > bottomLocal)
-                    bottomLocal = pos.Y;
+                if (y > bottomLocal)
+                    bottomLocal = y;
 
-                if (pos.Y < topLocal)
-                    topLocal = pos.Y;
+                if (y < topLocal)
+                    topLocal = y;
             }
 
             _left = leftLocal;
@@ -496,7 +496,7 @@ namespace SadRogue.Primitives
             rhs = temp;
         }
 
-        private static IEnumerable<Point> YieldCoord(Point item)
+        private static IEnumerable<Point> YieldPoint(Point item)
         {
             yield return item;
         }

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -16,8 +16,7 @@ namespace SadRogue.Primitives
     {
         private readonly HashSet<Point> _positionsSet;
 
-        [DataMember]
-        private readonly List<Point> _positions;
+        [DataMember] private readonly List<Point> _positions;
 
         private int _left, _top, _bottom, _right;
 
@@ -42,9 +41,7 @@ namespace SadRogue.Primitives
         /// <param name="initialPoints">Initial points to add to the area.</param>
         public Area(IEnumerable<Point> initialPoints)
             : this()
-        {
-            Add(initialPoints);
-        }
+            => Add(initialPoints);
 
         /// <summary>
         /// Constructor that takes initial points to add to the area.
@@ -62,9 +59,7 @@ namespace SadRogue.Primitives
             get
             {
                 if (_right < _left)
-                {
                     return Rectangle.Empty;
-                }
 
                 return new Rectangle(_left, _top, _right - _left + 1, _bottom - _top + 1);
             }
@@ -90,14 +85,12 @@ namespace SadRogue.Primitives
         /// <paramref name="area2"/>.</returns>
         public static Area GetDifference(IReadOnlyArea area1, IReadOnlyArea area2)
         {
-            var retVal = new Area();
+            Area retVal = new Area();
 
             foreach (Point pos in area1.Positions)
             {
                 if (area2.Contains(pos))
-                {
                     continue;
-                }
 
                 retVal.Add(pos);
             }
@@ -113,25 +106,17 @@ namespace SadRogue.Primitives
         /// <returns>An area containing exactly those positions contained in both of the given areas.</returns>
         public static Area GetIntersection(IReadOnlyArea area1, IReadOnlyArea area2)
         {
-            var retVal = new Area();
+            Area retVal = new Area();
 
             if (!area1.Bounds.Intersects(area2.Bounds))
-            {
                 return retVal;
-            }
 
             if (area1.Count > area2.Count)
-            {
                 Swap(ref area1, ref area2);
-            }
 
             foreach (Point pos in area1.Positions)
-            {
                 if (area2.Contains(pos))
-                {
                     retVal.Add(pos);
-                }
-            }
 
             return retVal;
         }
@@ -144,7 +129,7 @@ namespace SadRogue.Primitives
         /// <returns>An area containing only those positions in one or both of the given areas.</returns>
         public static Area GetUnion(IReadOnlyArea area1, IReadOnlyArea area2)
         {
-            var retVal = new Area();
+            Area retVal = new Area();
 
             retVal.Add(area1);
             retVal.Add(area2);
@@ -170,12 +155,10 @@ namespace SadRogue.Primitives
         /// </returns>
         public static Area operator +(Area lhs, Point rhs)
         {
-            var retVal = new Area();
+            Area retVal = new Area();
 
             foreach (Point pos in lhs.Positions)
-            {
                 retVal.Add(pos + rhs);
-            }
 
             return retVal;
         }
@@ -203,10 +186,8 @@ namespace SadRogue.Primitives
                 return false;
 
             foreach (Point pos in lhs.Positions)
-            {
                 if (!rhs.Contains(pos))
                     return false;
-            }
 
             return true;
         }
@@ -292,10 +273,8 @@ namespace SadRogue.Primitives
                 return false;
 
             foreach (Point pos in area.Positions)
-            {
                 if (!Contains(pos))
                     return false;
-            }
 
             return true;
         }
@@ -332,19 +311,15 @@ namespace SadRogue.Primitives
             if (Count <= area.Count)
             {
                 foreach (Point pos in Positions)
-                {
                     if (area.Contains(pos))
                         return true;
-                }
 
                 return false;
             }
 
             foreach (Point pos in area.Positions)
-            {
                 if (Contains(pos))
                     return true;
-            }
 
             return false;
         }
@@ -366,13 +341,9 @@ namespace SadRogue.Primitives
             bool recalculateBounds = false;
 
             foreach (Point pos in _positions.Where(predicate))
-            {
                 if (_positionsSet.Remove(pos))
-                {
                     if (pos.X == _left || pos.X == _right || pos.Y == _top || pos.Y == _bottom)
                         recalculateBounds = true;
-                }
-            }
 
             _positions.RemoveAll(c => predicate(c));
 
@@ -389,13 +360,9 @@ namespace SadRogue.Primitives
         {
             bool recalculateBounds = false;
             foreach (Point pos in positions)
-            {
                 if (_positionsSet.Remove(pos))
-                {
                     if (pos.X == _left || pos.X == _right || pos.Y == _top || pos.Y == _bottom)
                         recalculateBounds = true;
-                }
-            }
 
             _positions.RemoveAll(positions.Contains);
 
@@ -434,7 +401,7 @@ namespace SadRogue.Primitives
         /// <returns>A string representation of those coordinates in the area.</returns>
         public override string ToString()
         {
-            var result = new StringBuilder("[");
+            StringBuilder result = new StringBuilder("[");
             bool first = true;
             foreach (Point item in _positions)
             {
@@ -445,6 +412,7 @@ namespace SadRogue.Primitives
 
                 result.Append(item.ToString());
             }
+
             result.Append("]");
 
             return result.ToString();

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -308,7 +308,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// True if the object given is a area and contains exactly the same points, false otherwise.
         /// </returns>
-        public override bool Equals(object obj) => obj is Area area && this == area;
+        public override bool Equals(object? obj) => obj is Area area && this == area;
 
         /// <summary>
         /// Returns hash of the underlying set

--- a/TheSadRogue.Primitives/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/BoundedRectangle.cs
@@ -4,20 +4,18 @@ using System.Runtime.Serialization;
 namespace SadRogue.Primitives
 {
     /// <summary>
-	/// This class defines a 2D rectangular area, whose area is automatically "locked" to
-	/// being inside a rectangular bounding box as it is changed. A typical use might be
-	/// keeping track of a camera's view area.
-	/// </summary>
+    /// This class defines a 2D rectangular area, whose area is automatically "locked" to
+    /// being inside a rectangular bounding box as it is changed. A typical use might be
+    /// keeping track of a camera's view area.
+    /// </summary>
     [DataContract]
     public class BoundedRectangle : IEquatable<BoundedRectangle>
     {
-        [DataMember]
-        private Rectangle _area;
+        [DataMember] private Rectangle _area;
         // A bug in code cleanup will add the readonly modifier to this field even though it would break the BoundingBox property at compile-time,
         // unless we disable the warning for this line
 #pragma warning disable IDE0044
-        [DataMember]
-        private Rectangle _boundingBox;
+        [DataMember] private Rectangle _boundingBox;
 #pragma warning restore IDE0044
 
         /// <summary>
@@ -34,17 +32,14 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// The rectangle that is guaranteed to be contained completely within <see cref="BoundingBox"/>.
-        /// Use <see cref="SetArea(Rectangle)"/> to set the area.
+        /// The rectangle that is guaranteed to be contained completely within <see cref="BoundingBox" />.
+        /// Use <see cref="SetArea(Rectangle)" /> to set the area.
         /// </summary>
-        public ref readonly Rectangle Area
-        {
-            get => ref _area;
-        }
+        public ref readonly Rectangle Area => ref _area;
 
         /// <summary>
-        /// The rectangle which <see cref="Area"/> is automatically bounded to be within.  Use the
-        /// <see cref="SetBoundingBox(Rectangle)"/> property to set the bounding box.
+        /// The rectangle which <see cref="Area" /> is automatically bounded to be within.  Use the
+        /// <see cref="SetBoundingBox(Rectangle)" /> property to set the bounding box.
         /// </summary>
         public ref readonly Rectangle BoundingBox => ref _boundingBox;
 
@@ -53,52 +48,57 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">BoundedRectangle to compare.</param>
         /// <returns>True if the two BoundedRectangles are the same, false if not.</returns>
-        public bool Equals(BoundedRectangle other) => !ReferenceEquals(other, null) && _area == other._area && _boundingBox == other._boundingBox;
+        public bool Equals(BoundedRectangle? other)
+            => !ReferenceEquals(other, null) && _area == other._area && _boundingBox == other._boundingBox;
 
         /// <summary>
-        /// Same as operator == in this case; returns false if <paramref name="obj"/> is not a BoundedRectangle.
+        /// Same as operator == in this case; returns false if <paramref name="obj" /> is not a BoundedRectangle.
         /// </summary>
         /// <param name="obj">The object to compare the current BoundedRectangle to.</param>
         /// <returns>
-        /// True if <paramref name="obj"/> is a BoundedRectangle, and the two BoundedRectangles are the same, false otherwise.
+        /// True if <paramref name="obj" /> is a BoundedRectangle, and the two BoundedRectangles are the same, false otherwise.
         /// </returns>
-        public override bool Equals(object obj) => obj is BoundedRectangle c && Equals(c);
+        public override bool Equals(object? obj) => obj is BoundedRectangle c && Equals(c);
 
         /// <summary>
-        /// Returns a hash-map value for the current object.
+        /// Returns a hash-map value for the current object based on <see cref="Area"/> and <see cref="BoundingBox"/>.
+        /// If instances are being used in a hash table or dictionary, you MUST NOT change either of those properties
+        /// once it has been added to the collection.
         /// </summary>
-        /// <returns/>
-        public override int GetHashCode() => _area.GetHashCode() ^ _boundingBox.GetHashCode();
+        /// <returns />
+        public override int GetHashCode()
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
+            => _area.GetHashCode() ^
+               // ReSharper disable once NonReadonlyMemberInGetHashCode
+               _boundingBox.GetHashCode();
 
         /// <summary>
         /// True if the two BoundedRectangle objects are equivalent.
         /// </summary>
-        /// <param name="lhs"/>
-        /// <param name="rhs"/>
+        /// <param name="lhs" />
+        /// <param name="rhs" />
         /// <returns>True if the two BoundedRectangle objects are equivalent, false if not.</returns>
         public static bool operator ==(BoundedRectangle lhs, BoundedRectangle rhs) => lhs?.Equals(rhs) ?? rhs is null;
 
         /// <summary>
         /// True if the types are not equal.
         /// </summary>
-        /// <param name="lhs"/>
-        /// <param name="rhs"/>
+        /// <param name="lhs" />
+        /// <param name="rhs" />
         /// <returns>
         /// True if the types are not equal, false if they are both equal.
         /// </returns>
         public static bool operator !=(BoundedRectangle lhs, BoundedRectangle rhs) => !(lhs == rhs);
 
         /// <summary>
-        /// Forces the area given to conform to the <see cref="BoundingBox"/> specified and sets it to <see cref="Area"/>.
+        /// Forces the area given to conform to the <see cref="BoundingBox" /> specified and sets it to <see cref="Area" />.
         /// </summary>
         /// <param name="newArea">The new area to bound and set.</param>
         public void SetArea(Rectangle newArea)
         {
             _area = newArea;
             if (!_boundingBox.Contains(_area))
-            {
                 BoundLock();
-            }
         }
 
         /// <summary>
@@ -110,9 +110,7 @@ namespace SadRogue.Primitives
         {
             _boundingBox = newBoundingBox;
             if (!_boundingBox.Contains(_area))
-            {
                 BoundLock();
-            }
         }
 
         private void BoundLock()
@@ -120,34 +118,22 @@ namespace SadRogue.Primitives
             int x = _area.X, y = _area.Y, width = _area.Width, height = _area.Height;
 
             if (width > _boundingBox.Width)
-            {
                 width = _boundingBox.Width;
-            }
 
             if (height > _boundingBox.Height)
-            {
                 height = _boundingBox.Height;
-            }
 
             if (x < _boundingBox.X)
-            {
                 x = _boundingBox.X;
-            }
 
             if (y < _boundingBox.Y)
-            {
                 y = _boundingBox.Y;
-            }
 
             if (x > _boundingBox.MaxExtentX - width + 1)
-            {
                 x = _boundingBox.MaxExtentX - width + 1;
-            }
 
             if (y > _boundingBox.MaxExtentY - height + 1)
-            {
                 y = _boundingBox.MaxExtentY - height + 1;
-            }
 
             _area = new Rectangle(x, y, width, height);
         }

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -175,7 +175,6 @@ namespace SadRogue.Primitives
         /// The value is a 32-bit unsigned integer, with R in the least significant octet.
         /// </summary>
         /// <param name="packedValue">The packed value.</param>
-        [CLSCompliant(false)]
         public Color(uint packedValue) => _packedValue = packedValue;
 
         /// <summary>
@@ -377,7 +376,7 @@ namespace SadRogue.Primitives
         /// <param name="obj">The <see cref="Color"/> to compare.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
         [Pure]
-        public override bool Equals(object obj) => (obj is Color color) && Equals(color);
+        public override bool Equals(object? obj) => (obj is Color color) && Equals(color);
 
         #region Color Bank Ansi
         /// <summary>
@@ -1894,7 +1893,7 @@ namespace SadRogue.Primitives
         [Pure]
         public static Color FromHSL(float h, float s, float l)
         {
-            if (s == 0f)
+            if (Math.Abs(s) < 0.0000000001)
             {
                 return new Color(
                     (byte)(l * 255),
@@ -1919,9 +1918,9 @@ namespace SadRogue.Primitives
                 var_1 = 2 * l - var_2;
 
                 return new Color(
-                    (byte)(255 * Hue_2_RGB(var_1, var_2, h + (1 / 3))),
+                    (byte)(255 * Hue_2_RGB(var_1, var_2, h + (1f / 3))),
                     (byte)(255 * Hue_2_RGB(var_1, var_2, h)),
-                    (byte)(255 * Hue_2_RGB(var_1, var_2, h - (1 / 3)))
+                    (byte)(255 * Hue_2_RGB(var_1, var_2, h - (1f / 3)))
                     );
             }
         }
@@ -1950,7 +1949,7 @@ namespace SadRogue.Primitives
 
             if ((3 * vH) < 2)
             {
-                return (v1 + (v2 - v1) * ((2 / 3) - vH) * 6);
+                return (v1 + (v2 - v1) * ((2f / 3) - vH) * 6);
             }
 
             return (v1);
@@ -1968,7 +1967,6 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Gets or sets packed value of this <see cref="Color"/>.
         /// </summary>
-        [CLSCompliant(false)]
         public uint PackedValue => _packedValue;
 
 

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -167,8 +167,7 @@ namespace SadRogue.Primitives
         // Stored as RGBA with R in the least significant octet:
         // |-------|-------|-------|-------
         // A       B       G       R
-        [DataMember]
-        private readonly uint _packedValue;
+        [DataMember] private readonly uint _packedValue;
 
         /// <summary>
         /// Constructs an RGBA color from a packed value.
@@ -191,9 +190,7 @@ namespace SadRogue.Primitives
                 _packedValue = (color._packedValue & 0x00FFFFFF) | (clampedA << 24);
             }
             else
-            {
                 _packedValue = (color._packedValue & 0x00FFFFFF) | ((uint)alpha << 24);
-            }
         }
 
         /// <summary>
@@ -201,10 +198,10 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="color">A <see cref="Color"/> for RGB values of new <see cref="Color"/> instance.</param>
         /// <param name="alpha">Alpha component value from 0.0f to 1.0f.</param>
-        public Color(Color color, float alpha) :
+        public Color(Color color, float alpha)
+            :
             this(color, (int)(alpha * 255))
-        {
-        }
+        { }
 
         /// <summary>
         /// Constructs an RGBA color from scalars representing red, green and blue values. Alpha value will be opaque.
@@ -214,8 +211,7 @@ namespace SadRogue.Primitives
         /// <param name="b">Blue component value from 0.0f to 1.0f.</param>
         public Color(float r, float g, float b)
             : this((int)(r * 255), (int)(g * 255), (int)(b * 255))
-        {
-        }
+        { }
 
         /// <summary>
         /// Constructs an RGBA color from scalars representing red, green, blue and alpha values.
@@ -226,8 +222,7 @@ namespace SadRogue.Primitives
         /// <param name="alpha">Alpha component value from 0.0f to 1.0f.</param>
         public Color(float r, float g, float b, float alpha)
             : this((int)(r * 255), (int)(g * 255), (int)(b * 255), (int)(alpha * 255))
-        {
-        }
+        { }
 
         /// <summary>
         /// Constructs an RGBA color from scalars representing red, green and blue values. Alpha value will be opaque.
@@ -245,12 +240,10 @@ namespace SadRogue.Primitives
                 uint clampedG = (uint)MathHelpers.Clamp(g, byte.MinValue, byte.MaxValue);
                 uint clampedB = (uint)MathHelpers.Clamp(b, byte.MinValue, byte.MaxValue);
 
-                _packedValue |= (clampedB << 16) | (clampedG << 8) | (clampedR);
+                _packedValue |= (clampedB << 16) | (clampedG << 8) | clampedR;
             }
             else
-            {
-                _packedValue |= ((uint)b << 16) | ((uint)g << 8) | ((uint)r);
-            }
+                _packedValue |= ((uint)b << 16) | ((uint)g << 8) | (uint)r;
         }
 
         /// <summary>
@@ -269,12 +262,10 @@ namespace SadRogue.Primitives
                 uint clampedB = (uint)MathHelpers.Clamp(b, byte.MinValue, byte.MaxValue);
                 uint clampedA = (uint)MathHelpers.Clamp(alpha, byte.MinValue, byte.MaxValue);
 
-                _packedValue = (clampedA << 24) | (clampedB << 16) | (clampedG << 8) | (clampedR);
+                _packedValue = (clampedA << 24) | (clampedB << 16) | (clampedG << 8) | clampedR;
             }
             else
-            {
-                _packedValue = ((uint)alpha << 24) | ((uint)b << 16) | ((uint)g << 8) | ((uint)r);
-            }
+                _packedValue = ((uint)alpha << 24) | ((uint)b << 16) | ((uint)g << 8) | (uint)r;
         }
 
         /// <summary>
@@ -287,7 +278,8 @@ namespace SadRogue.Primitives
         /// <param name="g"></param>
         /// <param name="b"></param>
         /// <param name="alpha"></param>
-        public Color(byte r, byte g, byte b, byte alpha) => _packedValue = ((uint)alpha << 24) | ((uint)b << 16) | ((uint)g << 8) | (r);
+        public Color(byte r, byte g, byte b, byte alpha)
+            => _packedValue = ((uint)alpha << 24) | ((uint)b << 16) | ((uint)g << 8) | r;
 
         /// <summary>
         /// Gets or sets the blue component.
@@ -352,7 +344,7 @@ namespace SadRogue.Primitives
         /// <param name="b"><see cref="Color"/> instance on the right of the equal sign.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
         [Pure]
-        public static bool operator ==(Color a, Color b) => (a._packedValue == b._packedValue);
+        public static bool operator ==(Color a, Color b) => a._packedValue == b._packedValue;
 
         /// <summary>
         /// Compares whether two <see cref="Color"/> instances are not equal.
@@ -361,7 +353,7 @@ namespace SadRogue.Primitives
         /// <param name="b"><see cref="Color"/> instance on the right of the not equal sign.</param>
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
         [Pure]
-        public static bool operator !=(Color a, Color b) => (a._packedValue != b._packedValue);
+        public static bool operator !=(Color a, Color b) => a._packedValue != b._packedValue;
 
         /// <summary>
         /// Gets the hash code of this <see cref="Color"/>.
@@ -376,37 +368,45 @@ namespace SadRogue.Primitives
         /// <param name="obj">The <see cref="Color"/> to compare.</param>
         /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
         [Pure]
-        public override bool Equals(object? obj) => (obj is Color color) && Equals(color);
+        public override bool Equals(object? obj) => obj is Color color && Equals(color);
 
         #region Color Bank Ansi
+
         /// <summary>
         /// The black ansi color (0, 0, 0).
         /// </summary>
         public static Color AnsiBlack = new Color(0, 0, 0);
+
         /// <summary>
         /// The Red ansi color (170, 0, 0).
         /// </summary>
         public static Color AnsiRed = new Color(170, 0, 0);
+
         /// <summary>
         /// The Green ansi color 0, 170, 0).
         /// </summary>
         public static Color AnsiGreen = new Color(0, 170, 0);
+
         /// <summary>
         /// The Yellow ansi color (170, 85, 0).
         /// </summary>
         public static Color AnsiYellow = new Color(170, 85, 0);
+
         /// <summary>
         /// The Blue ansi color (0, 0, 170).
         /// </summary>
         public static Color AnsiBlue = new Color(0, 0, 170);
+
         /// <summary>
         /// The Magenta ansi color (170, 0, 170).
         /// </summary>
         public static Color AnsiMagenta = new Color(170, 0, 170);
+
         /// <summary>
         /// The Cyan ansi color (0, 170, 170).
         /// </summary>
         public static Color AnsiCyan = new Color(0, 170, 170);
+
         /// <summary>
         /// The White ansi color (170, 170, 170).
         /// </summary>
@@ -416,34 +416,42 @@ namespace SadRogue.Primitives
         /// The BlackBright ansi color (85, 85, 85).
         /// </summary>
         public static Color AnsiBlackBright = new Color(85, 85, 85);
+
         /// <summary>
         /// The RedBright ansi color (255, 85, 85).
         /// </summary>
         public static Color AnsiRedBright = new Color(255, 85, 85);
+
         /// <summary>
         /// The GreenBright ansi color (85, 255, 85).
         /// </summary>
         public static Color AnsiGreenBright = new Color(85, 255, 85);
+
         /// <summary>
         /// The YellowBright ansi color (255, 255, 85).
         /// </summary>
         public static Color AnsiYellowBright = new Color(255, 255, 85);
+
         /// <summary>
         /// The BlueBright ansi color (85, 85, 255).
         /// </summary>
         public static Color AnsiBlueBright = new Color(85, 85, 255);
+
         /// <summary>
         /// The MagentaBright ansi color (255, 85, 255).
         /// </summary>
         public static Color AnsiMagentaBright = new Color(255, 85, 255);
+
         /// <summary>
         /// The CyanBright ansi color (85, 255, 255).
         /// </summary>
         public static Color AnsiCyanBright = new Color(85, 255, 255);
+
         /// <summary>
         /// The WhiteBright ansi color (255, 255, 255).
         /// </summary>
         public static Color AnsiWhiteBright = new Color(255, 255, 255);
+
         #endregion
 
         #region Color Bank
@@ -1163,7 +1171,8 @@ namespace SadRogue.Primitives
         /// YellowGreen color (R:154,G:205,B:50,A:255).
         /// </summary>
         public static readonly Color YellowGreen;
-            #endregion
+
+        #endregion
 
         /// <summary>
         /// Gets the luma of an existing color.
@@ -1199,15 +1208,11 @@ namespace SadRogue.Primitives
 
 
             if (maxval == minval)
-            {
                 return 0.0f;
-            }
 
             int sum = maxval + minval;
             if (sum > 255)
-            {
                 sum = 510 - sum;
-            }
 
             return (float)(maxval - minval) / sum;
         }
@@ -1225,9 +1230,7 @@ namespace SadRogue.Primitives
 
 
             if (maxval == minval)
-            {
                 return 0.0f;
-            }
 
             float diff = maxval - minval;
             float rnorm = (maxval - R) / diff;
@@ -1237,24 +1240,16 @@ namespace SadRogue.Primitives
 
             float hue = 0.0f;
             if (R == maxval)
-            {
                 hue = 60.0f * (6.0f + bnorm - gnorm);
-            }
 
             if (G == maxval)
-            {
                 hue = 60.0f * (2.0f + rnorm - bnorm);
-            }
 
             if (B == maxval)
-            {
                 hue = 60.0f * (4.0f + gnorm - rnorm);
-            }
 
             if (hue > 360.0f)
-            {
                 hue -= 360.0f;
-            }
 
             return hue;
         }
@@ -1284,7 +1279,8 @@ namespace SadRogue.Primitives
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
         [Pure]
-        public static Color Multiply(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
+        public static Color Multiply(Color value, float scale) => new Color((int)(value.R * scale),
+            (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
         /// Creates an array of colors that includes the <paramref name="startingColor"/> and <paramref name="endingColor"/> and <paramref name="steps"/> of colors between them.
@@ -1326,65 +1322,49 @@ namespace SadRogue.Primitives
         public static Color FromHSL(float h, float s, float l)
         {
             if (Math.Abs(s) < 0.0000000001)
-            {
                 return new Color(
                     (byte)(l * 255),
                     (byte)(l * 255),
                     (byte)(l * 255)
-                    );
-            }
+                );
             else
             {
                 float var_2;
                 float var_1;
 
                 if (l < 0.5)
-                {
                     var_2 = l * (1 + s);
-                }
                 else
-                {
-                    var_2 = (l + s) - (s * l);
-                }
+                    var_2 = l + s - s * l;
 
                 var_1 = 2 * l - var_2;
 
                 return new Color(
-                    (byte)(255 * Hue_2_RGB(var_1, var_2, h + (1f / 3))),
+                    (byte)(255 * Hue_2_RGB(var_1, var_2, h + 1f / 3)),
                     (byte)(255 * Hue_2_RGB(var_1, var_2, h)),
-                    (byte)(255 * Hue_2_RGB(var_1, var_2, h - (1f / 3)))
-                    );
+                    (byte)(255 * Hue_2_RGB(var_1, var_2, h - 1f / 3))
+                );
             }
         }
 
         private static float Hue_2_RGB(float v1, float v2, float vH)
         {
             if (vH < 0)
-            {
                 vH += 1;
-            }
 
             if (vH > 1)
-            {
                 vH -= 1;
-            }
 
-            if ((6 * vH) < 1)
-            {
-                return (v1 + (v2 - v1) * 6 * vH);
-            }
+            if (6 * vH < 1)
+                return v1 + (v2 - v1) * 6 * vH;
 
-            if ((2 * vH) < 1)
-            {
-                return (v2);
-            }
+            if (2 * vH < 1)
+                return v2;
 
-            if ((3 * vH) < 2)
-            {
-                return (v1 + (v2 - v1) * ((2f / 3) - vH) * 6);
-            }
+            if (3 * vH < 2)
+                return v1 + (v2 - v1) * (2f / 3 - vH) * 6;
 
-            return (v1);
+            return v1;
         }
 
         /// <summary>
@@ -1394,7 +1374,8 @@ namespace SadRogue.Primitives
         /// <param name="scale">Multiplicator.</param>
         /// <returns>Multiplication result.</returns>
         [Pure]
-        public static Color operator *(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
+        public static Color operator *(Color value, float scale) => new Color((int)(value.R * scale),
+            (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
         /// Gets the packed value of this <see cref="Color"/>.
@@ -1403,11 +1384,11 @@ namespace SadRogue.Primitives
 
 
         internal string DebugDisplayString => string.Concat(
-                    R.ToString(), "  ",
-                    G.ToString(), "  ",
-                    B.ToString(), "  ",
-                    A.ToString()
-                );
+            R.ToString(), "  ",
+            G.ToString(), "  ",
+            B.ToString(), "  ",
+            A.ToString()
+        );
 
 
         /// <summary>
@@ -1440,7 +1421,8 @@ namespace SadRogue.Primitives
         /// <param name="a">Alpha component value.</param>
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
         [Pure]
-        public static Color FromNonPremultiplied(int r, int g, int b, int a) => new Color(r * a / 255, g * a / 255, b * a / 255, a);
+        public static Color FromNonPremultiplied(int r, int g, int b, int a)
+            => new Color(r * a / 255, g * a / 255, b * a / 255, a);
 
         #region IEquatable<Color> Members
 

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -447,1291 +447,723 @@ namespace SadRogue.Primitives
         #endregion
 
         #region Color Bank
+
         /// <summary>
         /// TransparentBlack color (R:0,G:0,B:0,A:0).
         /// </summary>
-        public static Color TransparentBlack
-        {
-            get;
-            private set;
-        }
+        public static readonly Color TransparentBlack;
 
         /// <summary>
         /// Transparent color (R:0,G:0,B:0,A:0).
         /// </summary>
-        public static Color Transparent
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Transparent;
 
         /// <summary>
         /// AliceBlue color (R:240,G:248,B:255,A:255).
         /// </summary>
-        public static Color AliceBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color AliceBlue;
 
         /// <summary>
         /// AntiqueWhite color (R:250,G:235,B:215,A:255).
         /// </summary>
-        public static Color AntiqueWhite
-        {
-            get;
-            private set;
-        }
+        public static readonly Color AntiqueWhite;
 
         /// <summary>
         /// Aqua color (R:0,G:255,B:255,A:255).
         /// </summary>
-        public static Color Aqua
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Aqua;
 
         /// <summary>
         /// Aquamarine color (R:127,G:255,B:212,A:255).
         /// </summary>
-        public static Color Aquamarine
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Aquamarine;
 
         /// <summary>
         /// Azure color (R:240,G:255,B:255,A:255).
         /// </summary>
-        public static Color Azure
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Azure;
 
         /// <summary>
         /// Beige color (R:245,G:245,B:220,A:255).
         /// </summary>
-        public static Color Beige
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Beige;
 
         /// <summary>
         /// Bisque color (R:255,G:228,B:196,A:255).
         /// </summary>
-        public static Color Bisque
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Bisque;
 
         /// <summary>
         /// Black color (R:0,G:0,B:0,A:255).
         /// </summary>
-        public static Color Black
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Black;
 
         /// <summary>
         /// BlanchedAlmond color (R:255,G:235,B:205,A:255).
         /// </summary>
-        public static Color BlanchedAlmond
-        {
-            get;
-            private set;
-        }
+        public static readonly Color BlanchedAlmond;
 
         /// <summary>
         /// Blue color (R:0,G:0,B:255,A:255).
         /// </summary>
-        public static Color Blue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Blue;
 
         /// <summary>
         /// BlueViolet color (R:138,G:43,B:226,A:255).
         /// </summary>
-        public static Color BlueViolet
-        {
-            get;
-            private set;
-        }
+        public static readonly Color BlueViolet;
 
         /// <summary>
         /// Brown color (R:165,G:42,B:42,A:255).
         /// </summary>
-        public static Color Brown
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Brown;
 
         /// <summary>
         /// BurlyWood color (R:222,G:184,B:135,A:255).
         /// </summary>
-        public static Color BurlyWood
-        {
-            get;
-            private set;
-        }
+        public static readonly Color BurlyWood;
 
         /// <summary>
         /// CadetBlue color (R:95,G:158,B:160,A:255).
         /// </summary>
-        public static Color CadetBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color CadetBlue;
 
         /// <summary>
         /// Chartreuse color (R:127,G:255,B:0,A:255).
         /// </summary>
-        public static Color Chartreuse
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Chartreuse;
 
         /// <summary>
         /// Chocolate color (R:210,G:105,B:30,A:255).
         /// </summary>
-        public static Color Chocolate
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Chocolate;
 
         /// <summary>
         /// Coral color (R:255,G:127,B:80,A:255).
         /// </summary>
-        public static Color Coral
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Coral;
 
         /// <summary>
         /// CornflowerBlue color (R:100,G:149,B:237,A:255).
         /// </summary>
-        public static Color CornflowerBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color CornflowerBlue;
 
         /// <summary>
         /// Cornsilk color (R:255,G:248,B:220,A:255).
         /// </summary>
-        public static Color Cornsilk
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Cornsilk;
 
         /// <summary>
         /// Crimson color (R:220,G:20,B:60,A:255).
         /// </summary>
-        public static Color Crimson
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Crimson;
 
         /// <summary>
         /// Cyan color (R:0,G:255,B:255,A:255).
         /// </summary>
-        public static Color Cyan
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Cyan;
 
         /// <summary>
         /// DarkBlue color (R:0,G:0,B:139,A:255).
         /// </summary>
-        public static Color DarkBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkBlue;
 
         /// <summary>
         /// DarkCyan color (R:0,G:139,B:139,A:255).
         /// </summary>
-        public static Color DarkCyan
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkCyan;
 
         /// <summary>
         /// DarkGoldenrod color (R:184,G:134,B:11,A:255).
         /// </summary>
-        public static Color DarkGoldenrod
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkGoldenrod;
 
         /// <summary>
         /// DarkGray color (R:169,G:169,B:169,A:255).
         /// </summary>
-        public static Color DarkGray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkGray;
 
         /// <summary>
         /// DarkGreen color (R:0,G:100,B:0,A:255).
         /// </summary>
-        public static Color DarkGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkGreen;
 
         /// <summary>
         /// DarkKhaki color (R:189,G:183,B:107,A:255).
         /// </summary>
-        public static Color DarkKhaki
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkKhaki;
 
         /// <summary>
         /// DarkMagenta color (R:139,G:0,B:139,A:255).
         /// </summary>
-        public static Color DarkMagenta
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkMagenta;
 
         /// <summary>
         /// DarkOliveGreen color (R:85,G:107,B:47,A:255).
         /// </summary>
-        public static Color DarkOliveGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkOliveGreen;
 
         /// <summary>
         /// DarkOrange color (R:255,G:140,B:0,A:255).
         /// </summary>
-        public static Color DarkOrange
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkOrange;
 
         /// <summary>
         /// DarkOrchid color (R:153,G:50,B:204,A:255).
         /// </summary>
-        public static Color DarkOrchid
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkOrchid;
 
         /// <summary>
         /// DarkRed color (R:139,G:0,B:0,A:255).
         /// </summary>
-        public static Color DarkRed
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkRed;
 
         /// <summary>
         /// DarkSalmon color (R:233,G:150,B:122,A:255).
         /// </summary>
-        public static Color DarkSalmon
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkSalmon;
 
         /// <summary>
         /// DarkSeaGreen color (R:143,G:188,B:139,A:255).
         /// </summary>
-        public static Color DarkSeaGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkSeaGreen;
 
         /// <summary>
         /// DarkSlateBlue color (R:72,G:61,B:139,A:255).
         /// </summary>
-        public static Color DarkSlateBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkSlateBlue;
 
         /// <summary>
         /// DarkSlateGray color (R:47,G:79,B:79,A:255).
         /// </summary>
-        public static Color DarkSlateGray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkSlateGray;
 
         /// <summary>
         /// DarkTurquoise color (R:0,G:206,B:209,A:255).
         /// </summary>
-        public static Color DarkTurquoise
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkTurquoise;
 
         /// <summary>
         /// DarkViolet color (R:148,G:0,B:211,A:255).
         /// </summary>
-        public static Color DarkViolet
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DarkViolet;
 
         /// <summary>
         /// DeepPink color (R:255,G:20,B:147,A:255).
         /// </summary>
-        public static Color DeepPink
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DeepPink;
 
         /// <summary>
         /// DeepSkyBlue color (R:0,G:191,B:255,A:255).
         /// </summary>
-        public static Color DeepSkyBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DeepSkyBlue;
 
         /// <summary>
         /// DimGray color (R:105,G:105,B:105,A:255).
         /// </summary>
-        public static Color DimGray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DimGray;
 
         /// <summary>
         /// DodgerBlue color (R:30,G:144,B:255,A:255).
         /// </summary>
-        public static Color DodgerBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color DodgerBlue;
 
         /// <summary>
         /// Firebrick color (R:178,G:34,B:34,A:255).
         /// </summary>
-        public static Color Firebrick
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Firebrick;
 
         /// <summary>
         /// FloralWhite color (R:255,G:250,B:240,A:255).
         /// </summary>
-        public static Color FloralWhite
-        {
-            get;
-            private set;
-        }
+        public static readonly Color FloralWhite;
 
         /// <summary>
         /// ForestGreen color (R:34,G:139,B:34,A:255).
         /// </summary>
-        public static Color ForestGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color ForestGreen;
 
         /// <summary>
         /// Fuchsia color (R:255,G:0,B:255,A:255).
         /// </summary>
-        public static Color Fuchsia
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Fuchsia;
 
         /// <summary>
         /// Gainsboro color (R:220,G:220,B:220,A:255).
         /// </summary>
-        public static Color Gainsboro
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Gainsboro;
 
         /// <summary>
         /// GhostWhite color (R:248,G:248,B:255,A:255).
         /// </summary>
-        public static Color GhostWhite
-        {
-            get;
-            private set;
-        }
+        public static readonly Color GhostWhite;
+
         /// <summary>
         /// Gold color (R:255,G:215,B:0,A:255).
         /// </summary>
-        public static Color Gold
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Gold;
 
         /// <summary>
         /// Goldenrod color (R:218,G:165,B:32,A:255).
         /// </summary>
-        public static Color Goldenrod
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Goldenrod;
 
         /// <summary>
         /// Gray color (R:128,G:128,B:128,A:255).
         /// </summary>
-        public static Color Gray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Gray;
 
         /// <summary>
         /// Green color (R:0,G:128,B:0,A:255).
         /// </summary>
-        public static Color Green
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Green;
 
         /// <summary>
         /// GreenYellow color (R:173,G:255,B:47,A:255).
         /// </summary>
-        public static Color GreenYellow
-        {
-            get;
-            private set;
-        }
+        public static readonly Color GreenYellow;
 
         /// <summary>
         /// Honeydew color (R:240,G:255,B:240,A:255).
         /// </summary>
-        public static Color Honeydew
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Honeydew;
 
         /// <summary>
         /// HotPink color (R:255,G:105,B:180,A:255).
         /// </summary>
-        public static Color HotPink
-        {
-            get;
-            private set;
-        }
+        public static readonly Color HotPink;
 
         /// <summary>
         /// IndianRed color (R:205,G:92,B:92,A:255).
         /// </summary>
-        public static Color IndianRed
-        {
-            get;
-            private set;
-        }
+        public static readonly Color IndianRed;
 
         /// <summary>
         /// Indigo color (R:75,G:0,B:130,A:255).
         /// </summary>
-        public static Color Indigo
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Indigo;
 
         /// <summary>
         /// Ivory color (R:255,G:255,B:240,A:255).
         /// </summary>
-        public static Color Ivory
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Ivory;
 
         /// <summary>
         /// Khaki color (R:240,G:230,B:140,A:255).
         /// </summary>
-        public static Color Khaki
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Khaki;
 
         /// <summary>
         /// Lavender color (R:230,G:230,B:250,A:255).
         /// </summary>
-        public static Color Lavender
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Lavender;
 
         /// <summary>
         /// LavenderBlush color (R:255,G:240,B:245,A:255).
         /// </summary>
-        public static Color LavenderBlush
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LavenderBlush;
 
         /// <summary>
         /// LawnGreen color (R:124,G:252,B:0,A:255).
         /// </summary>
-        public static Color LawnGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LawnGreen;
 
         /// <summary>
         /// LemonChiffon color (R:255,G:250,B:205,A:255).
         /// </summary>
-        public static Color LemonChiffon
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LemonChiffon;
 
         /// <summary>
         /// LightBlue color (R:173,G:216,B:230,A:255).
         /// </summary>
-        public static Color LightBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightBlue;
 
         /// <summary>
         /// LightCoral color (R:240,G:128,B:128,A:255).
         /// </summary>
-        public static Color LightCoral
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightCoral;
 
         /// <summary>
         /// LightCyan color (R:224,G:255,B:255,A:255).
         /// </summary>
-        public static Color LightCyan
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightCyan;
 
         /// <summary>
         /// LightGoldenrodYellow color (R:250,G:250,B:210,A:255).
         /// </summary>
-        public static Color LightGoldenrodYellow
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightGoldenrodYellow;
 
         /// <summary>
         /// LightGray color (R:211,G:211,B:211,A:255).
         /// </summary>
-        public static Color LightGray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightGray;
 
         /// <summary>
         /// LightGreen color (R:144,G:238,B:144,A:255).
         /// </summary>
-        public static Color LightGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightGreen;
 
         /// <summary>
         /// LightPink color (R:255,G:182,B:193,A:255).
         /// </summary>
-        public static Color LightPink
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightPink;
 
         /// <summary>
         /// LightSalmon color (R:255,G:160,B:122,A:255).
         /// </summary>
-        public static Color LightSalmon
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightSalmon;
 
         /// <summary>
         /// LightSeaGreen color (R:32,G:178,B:170,A:255).
         /// </summary>
-        public static Color LightSeaGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightSeaGreen;
 
         /// <summary>
         /// LightSkyBlue color (R:135,G:206,B:250,A:255).
         /// </summary>
-        public static Color LightSkyBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightSkyBlue;
 
         /// <summary>
         /// LightSlateGray color (R:119,G:136,B:153,A:255).
         /// </summary>
-        public static Color LightSlateGray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightSlateGray;
 
         /// <summary>
         /// LightSteelBlue color (R:176,G:196,B:222,A:255).
         /// </summary>
-        public static Color LightSteelBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightSteelBlue;
 
         /// <summary>
         /// LightYellow color (R:255,G:255,B:224,A:255).
         /// </summary>
-        public static Color LightYellow
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LightYellow;
 
         /// <summary>
         /// Lime color (R:0,G:255,B:0,A:255).
         /// </summary>
-        public static Color Lime
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Lime;
 
         /// <summary>
         /// LimeGreen color (R:50,G:205,B:50,A:255).
         /// </summary>
-        public static Color LimeGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color LimeGreen;
 
         /// <summary>
         /// Linen color (R:250,G:240,B:230,A:255).
         /// </summary>
-        public static Color Linen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Linen;
 
         /// <summary>
         /// Magenta color (R:255,G:0,B:255,A:255).
         /// </summary>
-        public static Color Magenta
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Magenta;
 
         /// <summary>
         /// Maroon color (R:128,G:0,B:0,A:255).
         /// </summary>
-        public static Color Maroon
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Maroon;
 
         /// <summary>
         /// MediumAquamarine color (R:102,G:205,B:170,A:255).
         /// </summary>
-        public static Color MediumAquamarine
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumAquamarine;
+
 
         /// <summary>
         /// MediumBlue color (R:0,G:0,B:205,A:255).
         /// </summary>
-        public static Color MediumBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumBlue;
 
         /// <summary>
         /// MediumOrchid color (R:186,G:85,B:211,A:255).
         /// </summary>
-        public static Color MediumOrchid
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumOrchid;
 
         /// <summary>
         /// MediumPurple color (R:147,G:112,B:219,A:255).
         /// </summary>
-        public static Color MediumPurple
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumPurple;
 
         /// <summary>
         /// MediumSeaGreen color (R:60,G:179,B:113,A:255).
         /// </summary>
-        public static Color MediumSeaGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumSeaGreen;
 
         /// <summary>
         /// MediumSlateBlue color (R:123,G:104,B:238,A:255).
         /// </summary>
-        public static Color MediumSlateBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumSlateBlue;
 
         /// <summary>
         /// MediumSpringGreen color (R:0,G:250,B:154,A:255).
         /// </summary>
-        public static Color MediumSpringGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumSpringGreen;
 
         /// <summary>
         /// MediumTurquoise color (R:72,G:209,B:204,A:255).
         /// </summary>
-        public static Color MediumTurquoise
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumTurquoise;
 
         /// <summary>
         /// MediumVioletRed color (R:199,G:21,B:133,A:255).
         /// </summary>
-        public static Color MediumVioletRed
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MediumVioletRed;
 
         /// <summary>
         /// MidnightBlue color (R:25,G:25,B:112,A:255).
         /// </summary>
-        public static Color MidnightBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MidnightBlue;
 
         /// <summary>
         /// MintCream color (R:245,G:255,B:250,A:255).
         /// </summary>
-        public static Color MintCream
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MintCream;
 
         /// <summary>
         /// MistyRose color (R:255,G:228,B:225,A:255).
         /// </summary>
-        public static Color MistyRose
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MistyRose;
 
         /// <summary>
         /// Moccasin color (R:255,G:228,B:181,A:255).
         /// </summary>
-        public static Color Moccasin
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Moccasin;
 
         /// <summary>
         /// MonoGame orange theme color (R:231,G:60,B:0,A:255).
         /// </summary>
-        public static Color MonoGameOrange
-        {
-            get;
-            private set;
-        }
+        public static readonly Color MonoGameOrange;
 
         /// <summary>
         /// NavajoWhite color (R:255,G:222,B:173,A:255).
         /// </summary>
-        public static Color NavajoWhite
-        {
-            get;
-            private set;
-        }
+        public static readonly Color NavajoWhite;
 
         /// <summary>
         /// Navy color (R:0,G:0,B:128,A:255).
         /// </summary>
-        public static Color Navy
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Navy;
 
         /// <summary>
         /// OldLace color (R:253,G:245,B:230,A:255).
         /// </summary>
-        public static Color OldLace
-        {
-            get;
-            private set;
-        }
+        public static readonly Color OldLace;
 
         /// <summary>
         /// Olive color (R:128,G:128,B:0,A:255).
         /// </summary>
-        public static Color Olive
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Olive;
 
         /// <summary>
         /// OliveDrab color (R:107,G:142,B:35,A:255).
         /// </summary>
-        public static Color OliveDrab
-        {
-            get;
-            private set;
-        }
+        public static readonly Color OliveDrab;
 
         /// <summary>
         /// Orange color (R:255,G:165,B:0,A:255).
         /// </summary>
-        public static Color Orange
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Orange;
 
         /// <summary>
         /// OrangeRed color (R:255,G:69,B:0,A:255).
         /// </summary>
-        public static Color OrangeRed
-        {
-            get;
-            private set;
-        }
+        public static readonly Color OrangeRed;
 
         /// <summary>
         /// Orchid color (R:218,G:112,B:214,A:255).
         /// </summary>
-        public static Color Orchid
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Orchid;
 
         /// <summary>
         /// PaleGoldenrod color (R:238,G:232,B:170,A:255).
         /// </summary>
-        public static Color PaleGoldenrod
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PaleGoldenrod;
 
         /// <summary>
         /// PaleGreen color (R:152,G:251,B:152,A:255).
         /// </summary>
-        public static Color PaleGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PaleGreen;
 
         /// <summary>
         /// PaleTurquoise color (R:175,G:238,B:238,A:255).
         /// </summary>
-        public static Color PaleTurquoise
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PaleTurquoise;
+
         /// <summary>
         /// PaleVioletRed color (R:219,G:112,B:147,A:255).
         /// </summary>
-        public static Color PaleVioletRed
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PaleVioletRed;
 
         /// <summary>
         /// PapayaWhip color (R:255,G:239,B:213,A:255).
         /// </summary>
-        public static Color PapayaWhip
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PapayaWhip;
 
         /// <summary>
         /// PeachPuff color (R:255,G:218,B:185,A:255).
         /// </summary>
-        public static Color PeachPuff
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PeachPuff;
 
         /// <summary>
         /// Peru color (R:205,G:133,B:63,A:255).
         /// </summary>
-        public static Color Peru
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Peru;
 
         /// <summary>
         /// Pink color (R:255,G:192,B:203,A:255).
         /// </summary>
-        public static Color Pink
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Pink;
 
         /// <summary>
         /// Plum color (R:221,G:160,B:221,A:255).
         /// </summary>
-        public static Color Plum
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Plum;
 
         /// <summary>
         /// PowderBlue color (R:176,G:224,B:230,A:255).
         /// </summary>
-        public static Color PowderBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color PowderBlue;
 
         /// <summary>
         ///  Purple color (R:128,G:0,B:128,A:255).
         /// </summary>
-        public static Color Purple
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Purple;
 
         /// <summary>
         /// Red color (R:255,G:0,B:0,A:255).
         /// </summary>
-        public static Color Red
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Red;
 
         /// <summary>
         /// RosyBrown color (R:188,G:143,B:143,A:255).
         /// </summary>
-        public static Color RosyBrown
-        {
-            get;
-            private set;
-        }
+        public static readonly Color RosyBrown;
 
         /// <summary>
         /// RoyalBlue color (R:65,G:105,B:225,A:255).
         /// </summary>
-        public static Color RoyalBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color RoyalBlue;
 
         /// <summary>
         /// SaddleBrown color (R:139,G:69,B:19,A:255).
         /// </summary>
-        public static Color SaddleBrown
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SaddleBrown;
 
         /// <summary>
         /// Salmon color (R:250,G:128,B:114,A:255).
         /// </summary>
-        public static Color Salmon
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Salmon;
 
         /// <summary>
         /// SandyBrown color (R:244,G:164,B:96,A:255).
         /// </summary>
-        public static Color SandyBrown
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SandyBrown;
 
         /// <summary>
         /// SeaGreen color (R:46,G:139,B:87,A:255).
         /// </summary>
-        public static Color SeaGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SeaGreen;
 
         /// <summary>
         /// SeaShell color (R:255,G:245,B:238,A:255).
         /// </summary>
-        public static Color SeaShell
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SeaShell;
 
         /// <summary>
         /// Sienna color (R:160,G:82,B:45,A:255).
         /// </summary>
-        public static Color Sienna
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Sienna;
 
         /// <summary>
         /// Silver color (R:192,G:192,B:192,A:255).
         /// </summary>
-        public static Color Silver
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Silver;
 
         /// <summary>
         /// SkyBlue color (R:135,G:206,B:235,A:255).
         /// </summary>
-        public static Color SkyBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SkyBlue;
 
         /// <summary>
         /// SlateBlue color (R:106,G:90,B:205,A:255).
         /// </summary>
-        public static Color SlateBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SlateBlue;
 
         /// <summary>
         /// SlateGray color (R:112,G:128,B:144,A:255).
         /// </summary>
-        public static Color SlateGray
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SlateGray;
 
         /// <summary>
         /// Snow color (R:255,G:250,B:250,A:255).
         /// </summary>
-        public static Color Snow
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Snow;
 
         /// <summary>
         /// SpringGreen color (R:0,G:255,B:127,A:255).
         /// </summary>
-        public static Color SpringGreen
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SpringGreen;
 
         /// <summary>
         /// SteelBlue color (R:70,G:130,B:180,A:255).
         /// </summary>
-        public static Color SteelBlue
-        {
-            get;
-            private set;
-        }
+        public static readonly Color SteelBlue;
 
         /// <summary>
         /// Tan color (R:210,G:180,B:140,A:255).
         /// </summary>
-        public static Color Tan
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Tan;
 
         /// <summary>
         /// Teal color (R:0,G:128,B:128,A:255).
         /// </summary>
-        public static Color Teal
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Teal;
 
         /// <summary>
         /// Thistle color (R:216,G:191,B:216,A:255).
         /// </summary>
-        public static Color Thistle
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Thistle;
 
         /// <summary>
         /// Tomato color (R:255,G:99,B:71,A:255).
         /// </summary>
-        public static Color Tomato
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Tomato;
 
         /// <summary>
         /// Turquoise color (R:64,G:224,B:208,A:255).
         /// </summary>
-        public static Color Turquoise
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Turquoise;
 
         /// <summary>
         /// Violet color (R:238,G:130,B:238,A:255).
         /// </summary>
-        public static Color Violet
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Violet;
 
         /// <summary>
         /// Wheat color (R:245,G:222,B:179,A:255).
         /// </summary>
-        public static Color Wheat
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Wheat;
 
         /// <summary>
         /// White color (R:255,G:255,B:255,A:255).
         /// </summary>
-        public static Color White
-        {
-            get;
-            private set;
-        }
+        public static readonly Color White;
 
         /// <summary>
         /// WhiteSmoke color (R:245,G:245,B:245,A:255).
         /// </summary>
-        public static Color WhiteSmoke
-        {
-            get;
-            private set;
-        }
+        public static readonly Color WhiteSmoke;
 
         /// <summary>
         /// Yellow color (R:255,G:255,B:0,A:255).
         /// </summary>
-        public static Color Yellow
-        {
-            get;
-            private set;
-        }
+        public static readonly Color Yellow;
 
         /// <summary>
         /// YellowGreen color (R:154,G:205,B:50,A:255).
         /// </summary>
-        public static Color YellowGreen
-        {
-            get;
-            private set;
-        }
-        #endregion
+        public static readonly Color YellowGreen;
+            #endregion
 
         /// <summary>
         /// Gets the luma of an existing color.
@@ -1965,7 +1397,7 @@ namespace SadRogue.Primitives
         public static Color operator *(Color value, float scale) => new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
 
         /// <summary>
-        /// Gets or sets packed value of this <see cref="Color"/>.
+        /// Gets the packed value of this <see cref="Color"/>.
         /// </summary>
         public uint PackedValue => _packedValue;
 

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -204,7 +204,7 @@ namespace SadRogue.Primitives
         /// True if <paramref name="obj"/> is a Direction, and the two directions are equal, false otherwise.
         /// </returns>
         [Pure]
-        public override bool Equals(object obj) => obj is Direction c && Equals(c);
+        public override bool Equals(object? obj) => obj is Direction c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -75,6 +75,7 @@ namespace SadRogue.Primitives
             /// Type for <see cref="Direction.None"/>.
             /// </summary>
             None,
+
             /// <summary>
             /// Type for <see cref="Direction.Up"/>.
             /// </summary>
@@ -185,8 +186,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Enum type corresponding to direction being represented.
         /// </summary>
-        [DataMember]
-        public readonly Types Type;
+        [DataMember] public readonly Types Type;
 
         /// <summary>
         /// True if the given direction has the same Type the current one.
@@ -245,23 +245,20 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="type"/>
         [Pure]
-        public static implicit operator Direction(Types type)
+        public static implicit operator Direction(Types type) => type switch
         {
-            return type switch
-            {
-                Types.Up => Up,
-                Types.UpRight => UpRight,
-                Types.Right => Right,
-                Types.DownRight => DownRight,
-                Types.Down => Down,
-                Types.DownLeft => DownLeft,
-                Types.Left => Left,
-                Types.UpLeft => UpLeft,
-                Types.None => None,
-                _ => throw new Exception(
-                    $"Could not convert {nameof(Type)} instance to {nameof(Direction)} -- this is a bug!.")
-            };
-        }
+            Types.Up => Up,
+            Types.UpRight => UpRight,
+            Types.Right => Right,
+            Types.DownRight => DownRight,
+            Types.Down => Down,
+            Types.DownLeft => DownLeft,
+            Types.Left => Left,
+            Types.UpLeft => UpLeft,
+            Types.None => None,
+            _ => throw new Exception(
+                $"Could not convert {nameof(Type)} instance to {nameof(Direction)} -- this is a bug!.")
+        };
 
         // Do not change manually outside of YIncreasesUpwards functionality
         internal static int s_yMult;
@@ -277,7 +274,7 @@ namespace SadRogue.Primitives
             {
                 s_initYInc = true;
                 s_yIncreasesUpward = newValue;
-                s_yMult = (s_yIncreasesUpward) ? -1 : 1;
+                s_yMult = s_yIncreasesUpward ? -1 : 1;
 
                 s_deltaVals[(int)Types.Up] = (0, -1 * s_yMult);
                 s_deltaVals[(int)Types.Down] = (0, 1 * s_yMult);
@@ -299,7 +296,8 @@ namespace SadRogue.Primitives
         /// The cardinal direction that most closely matches the heading indicated by the given line.
         /// </returns>
         [Pure]
-        public static Direction GetCardinalDirection(Point start, Point end) => GetCardinalDirection(new Point(end.X - start.X, end.Y - start.Y));
+        public static Direction GetCardinalDirection(Point start, Point end)
+            => GetCardinalDirection(new Point(end.X - start.X, end.Y - start.Y));
 
         /// <summary>
         /// Returns the cardinal direction that most closely matches the degree heading of a line
@@ -320,9 +318,7 @@ namespace SadRogue.Primitives
             int dy = deltaChange.Y;
 
             if (dx == 0 && dy == 0)
-            {
                 return None;
-            }
 
             dy *= s_yMult;
 
@@ -332,24 +328,16 @@ namespace SadRogue.Primitives
             degree %= 360; // Normalize angle to 0-360
 
             if (degree < 45.0)
-            {
                 return Up;
-            }
 
             if (degree < 135.0)
-            {
                 return Right;
-            }
 
             if (degree < 225.0)
-            {
                 return Down;
-            }
 
             if (degree < 315.0)
-            {
                 return Left;
-            }
 
             return Up;
         }
@@ -364,7 +352,8 @@ namespace SadRogue.Primitives
         /// The direction that most closely matches the heading indicated by the given line.
         /// </returns>
         [Pure]
-        public static Direction GetDirection(Point start, Point end) => GetDirection(new Point(end.X - start.X, end.Y - start.Y));
+        public static Direction GetDirection(Point start, Point end)
+            => GetDirection(new Point(end.X - start.X, end.Y - start.Y));
 
 
         /// <summary>
@@ -385,9 +374,7 @@ namespace SadRogue.Primitives
             int dy = deltaChange.Y;
 
             if (dx == 0 && dy == 0)
-            {
                 return None;
-            }
 
             dy *= s_yMult;
 
@@ -397,44 +384,28 @@ namespace SadRogue.Primitives
             degree %= 360; // Normalize angle to 0-360
 
             if (degree < 22.5)
-            {
                 return Up;
-            }
 
             if (degree < 67.5)
-            {
                 return UpRight;
-            }
 
             if (degree < 112.5)
-            {
                 return Right;
-            }
 
             if (degree < 157.5)
-            {
                 return DownRight;
-            }
 
             if (degree < 202.5)
-            {
                 return Down;
-            }
 
             if (degree < 247.5)
-            {
                 return DownLeft;
-            }
 
             if (degree < 292.5)
-            {
                 return Left;
-            }
 
             if (degree < 337.5)
-            {
                 return UpLeft;
-            }
 
             return Up;
         }
@@ -448,7 +419,8 @@ namespace SadRogue.Primitives
         /// The given direction moved counter-clockwise <paramref name="i"/> times.
         /// </returns>
         [Pure]
-        public static Direction operator -(Direction d, int i) => (d == None) ? None : (Direction)s_validTypes[WrapAround((int)d.Type - i - 1, 8)];
+        public static Direction operator -(Direction d, int i)
+            => d == None ? None : (Direction)s_validTypes[WrapAround((int)d.Type - i - 1, 8)];
 
         /// <summary>
         /// Moves the direction counter-clockwise by one.
@@ -456,7 +428,8 @@ namespace SadRogue.Primitives
         /// <param name="d"/>
         /// <returns>The direction one unit counterclockwise of <paramref name="d"/>.</returns>
         [Pure]
-        public static Direction operator --(Direction d) => (d == None) ? None : (Direction)s_validTypes[WrapAround((int)d.Type - 2, 8)];
+        public static Direction operator --(Direction d)
+            => d == None ? None : (Direction)s_validTypes[WrapAround((int)d.Type - 2, 8)];
 
         /// <summary>
         /// Moves the direction clockwise <paramref name="i"/> times.
@@ -467,7 +440,8 @@ namespace SadRogue.Primitives
         /// The given direction moved clockwise <paramref name="i"/> times.
         /// </returns>
         [Pure]
-        public static Direction operator +(Direction d, int i) => (d == None) ? None : (Direction)s_validTypes[WrapAround((int)d.Type + i - 1, 8)];
+        public static Direction operator +(Direction d, int i)
+            => d == None ? None : (Direction)s_validTypes[WrapAround((int)d.Type + i - 1, 8)];
 
         /// <summary>
         /// Moves the direction clockwise by one.
@@ -475,7 +449,8 @@ namespace SadRogue.Primitives
         /// <param name="d"/>
         /// <returns>The direction one unit clockwise of <paramref name="d"/>.</returns>
         [Pure]
-        public static Direction operator ++(Direction d) => (d == None) ? None : (Direction)s_validTypes[WrapAround((int)d.Type, 8)];
+        public static Direction operator ++(Direction d)
+            => d == None ? None : (Direction)s_validTypes[WrapAround((int)d.Type, 8)];
 
         /// <summary>
         /// Returns true if the current direction is a cardinal direction.
@@ -492,6 +467,7 @@ namespace SadRogue.Primitives
         public override string ToString() => s_writeVals[(int)Type];
 
         #region Tuple Compatibility
+
         /// <summary>
         /// Translates the given position by one unit in the given direction.
         /// </summary>
@@ -501,7 +477,9 @@ namespace SadRogue.Primitives
         /// Tuple (tuple.y + d.DeltaX, tuple.y + d.DeltaY).
         /// </returns>
         [Pure]
-        public static (int x, int y) operator +((int x, int y) tuple, Direction d) => (tuple.x + d.DeltaX, tuple.y + d.DeltaY);
+        public static (int x, int y) operator +((int x, int y) tuple, Direction d)
+            => (tuple.x + d.DeltaX, tuple.y + d.DeltaY);
+
         #endregion
 
         private static int WrapAround(int num, int wrapTo) => (num % wrapTo + wrapTo) % wrapTo;

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -247,38 +247,20 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator Direction(Types type)
         {
-            switch (type)
+            return type switch
             {
-                case Types.Up:
-                    return Up;
-
-                case Types.UpRight:
-                    return UpRight;
-
-                case Types.Right:
-                    return Right;
-
-                case Types.DownRight:
-                    return DownRight;
-
-                case Types.Down:
-                    return Down;
-
-                case Types.DownLeft:
-                    return DownLeft;
-
-                case Types.Left:
-                    return Left;
-
-                case Types.UpLeft:
-                    return UpLeft;
-
-                case Types.None:
-                    return None;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Type)} instance to {nameof(Direction)} -- this is a bug!."); // Will not occur
-            }
+                Types.Up => Up,
+                Types.UpRight => UpRight,
+                Types.Right => Right,
+                Types.DownRight => DownRight,
+                Types.Down => Down,
+                Types.DownLeft => DownLeft,
+                Types.Left => Left,
+                Types.UpLeft => UpLeft,
+                Types.None => None,
+                _ => throw new Exception(
+                    $"Could not convert {nameof(Type)} instance to {nameof(Direction)} -- this is a bug!.")
+            };
         }
 
         // Do not change manually outside of YIncreasesUpwards functionality

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -95,7 +95,7 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// Allows implicit casting to the <see cref="AdjacencyRule"/> type. 
+        /// Allows implicit casting to the <see cref="AdjacencyRule"/> type.
         /// </summary>
         /// <remarks>
         /// The adjacency rule corresponding to the definition of a adjacency according to the
@@ -229,7 +229,7 @@ namespace SadRogue.Primitives
         /// True if <paramref name="obj"/> is a Distance, and the two distance calculations are equal, false otherwise.
         /// </returns>
         [Pure]
-        public override bool Equals(object obj) => obj is Distance c && Equals(c);
+        public override bool Equals(object? obj) => obj is Distance c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -37,8 +37,7 @@ namespace SadRogue.Primitives
         /// Enum value representing the method of calcuating distance -- useful for using
         /// Distance types in switch statements.
         /// </summary>
-        [DataMember]
-        public readonly Types Type;
+        [DataMember] public readonly Types Type;
 
         private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
@@ -76,16 +75,13 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="distance"/>
         [Pure]
-        public static implicit operator Radius(Distance distance)
+        public static implicit operator Radius(Distance distance) => distance.Type switch
         {
-            return distance.Type switch
-            {
-                Types.Manhattan => Radius.Diamond,
-                Types.Euclidean => Radius.Circle,
-                Types.Chebyshev => Radius.Square,
-                _ => throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!")
-            };
-        }
+            Types.Manhattan => Radius.Diamond,
+            Types.Euclidean => Radius.Circle,
+            Types.Chebyshev => Radius.Square,
+            _ => throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!")
+        };
 
         /// <summary>
         /// Allows implicit casting to the <see cref="AdjacencyRule"/> type.
@@ -96,17 +92,14 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="distance"/>
         [Pure]
-        public static implicit operator AdjacencyRule(Distance distance)
+        public static implicit operator AdjacencyRule(Distance distance) => distance.Type switch
         {
-            return distance.Type switch
-            {
-                Types.Manhattan => AdjacencyRule.Cardinals,
-                Types.Chebyshev => AdjacencyRule.EightWay,
-                Types.Euclidean => AdjacencyRule.EightWay,
-                _ => throw new Exception(
-                    $"Could not convert {nameof(Distance)} to {nameof(AdjacencyRule)} -- this is a bug!")
-            };
-        }
+            Types.Manhattan => AdjacencyRule.Cardinals,
+            Types.Chebyshev => AdjacencyRule.EightWay,
+            Types.Euclidean => AdjacencyRule.EightWay,
+            _ => throw new Exception(
+                $"Could not convert {nameof(Distance)} to {nameof(AdjacencyRule)} -- this is a bug!")
+        };
 
         /// <summary>
         /// Implicitly converts a Distance to its corresponding <see cref="Type"/>.
@@ -120,16 +113,13 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="type"/>
         [Pure]
-        public static implicit operator Distance(Types type)
+        public static implicit operator Distance(Types type) => type switch
         {
-            return type switch
-            {
-                Types.Manhattan => Manhattan,
-                Types.Euclidean => Euclidean,
-                Types.Chebyshev => Chebyshev,
-                _ => throw new Exception($"Could not convert {nameof(Types)} to {nameof(Distance)} -- this is a bug!")
-            };
-        }
+            Types.Manhattan => Manhattan,
+            Types.Euclidean => Euclidean,
+            Types.Chebyshev => Chebyshev,
+            _ => throw new Exception($"Could not convert {nameof(Types)} to {nameof(Distance)} -- this is a bug!")
+        };
 
         /// <summary>
         /// Returns the distance between the two (2D) points specified.

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -78,20 +78,13 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator Radius(Distance distance)
         {
-            switch (distance.Type)
+            return distance.Type switch
             {
-                case Types.Manhattan:
-                    return Radius.Diamond;
-
-                case Types.Euclidean:
-                    return Radius.Circle;
-
-                case Types.Chebyshev:
-                    return Radius.Square;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!"); // Will not occur
-            }
+                Types.Manhattan => Radius.Diamond,
+                Types.Euclidean => Radius.Circle,
+                Types.Chebyshev => Radius.Square,
+                _ => throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!")
+            };
         }
 
         /// <summary>
@@ -105,18 +98,14 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator AdjacencyRule(Distance distance)
         {
-            switch (distance.Type)
+            return distance.Type switch
             {
-                case Types.Manhattan:
-                    return AdjacencyRule.Cardinals;
-
-                case Types.Chebyshev:
-                case Types.Euclidean:
-                    return AdjacencyRule.EightWay;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Distance)} to {nameof(AdjacencyRule)} -- this is a bug!"); // Will not occur
-            }
+                Types.Manhattan => AdjacencyRule.Cardinals,
+                Types.Chebyshev => AdjacencyRule.EightWay,
+                Types.Euclidean => AdjacencyRule.EightWay,
+                _ => throw new Exception(
+                    $"Could not convert {nameof(Distance)} to {nameof(AdjacencyRule)} -- this is a bug!")
+            };
         }
 
         /// <summary>
@@ -133,20 +122,13 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator Distance(Types type)
         {
-            switch (type)
+            return type switch
             {
-                case Types.Manhattan:
-                    return Manhattan;
-
-                case Types.Euclidean:
-                    return Euclidean;
-
-                case Types.Chebyshev:
-                    return Chebyshev;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Types)} to {nameof(Distance)} -- this is a bug!"); // Will not occur
-            }
+                Types.Manhattan => Manhattan,
+                Types.Euclidean => Euclidean,
+                Types.Chebyshev => Chebyshev,
+                _ => throw new Exception($"Could not convert {nameof(Types)} to {nameof(Distance)} -- this is a bug!")
+            };
         }
 
         /// <summary>
@@ -195,22 +177,14 @@ namespace SadRogue.Primitives
             dx = Math.Abs(dx);
             dy = Math.Abs(dy);
 
-            double radius = 0;
-            switch (Type)
+            return Type switch
             {
-                case Types.Chebyshev:
-                    radius = Math.Max(dx, dy); // Radius is the longest axial distance
-                    break;
-
-                case Types.Manhattan:
-                    radius = dx + dy; // Simply manhattan distance
-                    break;
-
-                case Types.Euclidean:
-                    radius = Math.Sqrt(dx * dx + dy * dy); // Spherical radius
-                    break;
-            }
-            return radius;
+                Types.Chebyshev => Math.Max(dx, dy), // Radius is the longest axial distance
+                Types.Manhattan => dx + dy, // Simply manhattan distance
+                Types.Euclidean => Math.Sqrt(dx * dx + dy * dy), // Spherical radius
+                _ => throw new NotSupportedException(
+                    $"{nameof(Calculate)} does not support distance calculation {this}: this is a bug!")
+            };
         }
 
         /// <summary>

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -192,7 +192,7 @@ namespace SadRogue.Primitives
             float lerpTotal = 0f;
 
             returnArray[0] = Stops[0].Color;
-            returnArray[count - 1] = Stops[Stops.Length - 1].Color;
+            returnArray[count - 1] = Stops[^1].Color;
 
             for (int i = 1; i < count - 1; i++)
             {

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -34,21 +34,47 @@ namespace SadRogue.Primitives
             Stop = stop;
         }
 
+        /// <summary>
+        /// Compares two gradient stops based on their color and stop value.
+        /// </summary>
+        /// <param name="lhs"/>
+        /// <param name="rhs"/>
+        /// <returns>True if the gradients have the same color and stop; false otherwise.</returns>
         [Pure]
         public static bool operator ==(GradientStop lhs, GradientStop rhs)
-            => lhs.Color == rhs.Color && lhs.Stop == rhs.Stop;
+            => lhs.Color == rhs.Color && Math.Abs(lhs.Stop - rhs.Stop) < 0.0000000001;
 
+        /// <summary>
+        /// Compares two gradient stops based on their color and stop value.
+        /// </summary>
+        /// <param name="lhs"/>
+        /// <param name="rhs"/>
+        /// <returns>True if the gradients have different color or stop values, false otherwise.</returns>
         [Pure]
         public static bool operator !=(GradientStop lhs, GradientStop rhs) => !(lhs == rhs);
 
+        /// <summary>
+        /// Gets a hash code based upon the stop's color and stop values.
+        /// </summary>
+        /// <returns>A hash code based upon the stop's color and stop values.</returns>
         [Pure]
         public override int GetHashCode() => Color.GetHashCode() ^ Stop.GetHashCode();
 
+        /// <summary>
+        /// Returns true if <paramref name="obj"/> is a gradient stop with the same color and stop value.
+        /// </summary>
+        /// <param name="obj"/>
+        /// <returns>True if <paramref name="obj"/> is a gradient stop with the same color and stop value.</returns>
         [Pure]
-        public override bool Equals(object obj) => obj is GradientStop g && this == g;
+        public override bool Equals(object? obj) => obj is GradientStop g && this == g;
 
+        /// <summary>
+        /// Compares this gradient stop to the one given.
+        /// </summary>
+        /// <param name="g"/>
+        /// <returns>True if this gradient stop and the specified one have the same color and stop values; false otherwise.</returns>
         [Pure]
-        public bool Equals(GradientStop g) => Color == g.Color && Stop == g.Stop;
+        public bool Equals(GradientStop g) => Color == g.Color && Math.Abs(Stop - g.Stop) < 0.0000000001;
     }
 
     /// <summary>
@@ -103,10 +129,9 @@ namespace SadRogue.Primitives
                     throw new ArgumentException("At least one color must be provided on this constructor.");
                 case 1:
                 {
-                    Color color = colors[0];
-                    colors = new Color[2];
-                    colors[0] = color;
-                    colors[1] = color;
+                    Stops = new GradientStop[2];
+                    Stops[0] = new GradientStop(colors[0], 0f);
+                    Stops[1] = new GradientStop(colors[0], 1f);
                     break;
                 }
                 default:
@@ -226,7 +251,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="obj"/>
         /// <returns>True if the object is a gradient that contains precisely the same stops; false otherwise</returns>
-        public override bool Equals(object obj) => obj is Gradient gradient && this == gradient;
+        public override bool Equals(object? obj) => obj is Gradient gradient && this == gradient;
 
         /// <summary>
         /// Returns a hash code based on the gradient's stops.

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -3,7 +3,7 @@
 namespace SadRogue.Primitives
 {
     /// <summary>
-    /// Read-only interface for an arbitry 2D area.
+    /// Read-only interface for an arbitrary 2D area.
     /// </summary>
     public interface IReadOnlyArea
     {

--- a/TheSadRogue.Primitives/MathHelpers.cs
+++ b/TheSadRogue.Primitives/MathHelpers.cs
@@ -39,14 +39,10 @@ namespace SadRogue.Primitives
         public static int Clamp(int value, int min, int max)
         {
             if (value < min)
-            {
                 value = min;
-            }
 
             if (value > max)
-            {
                 value = max;
-            }
 
             return value;
         }
@@ -62,14 +58,10 @@ namespace SadRogue.Primitives
         public static float Clamp(float value, float min, float max)
         {
             if (value < min)
-            {
                 value = min;
-            }
 
             if (value > max)
-            {
                 value = max;
-            }
 
             return value;
         }
@@ -85,14 +77,10 @@ namespace SadRogue.Primitives
         public static double Clamp(double value, double min, double max)
         {
             if (value < min)
-            {
                 value = min;
-            }
 
             if (value > max)
-            {
                 value = max;
-            }
 
             return value;
         }
@@ -129,13 +117,9 @@ namespace SadRogue.Primitives
         public static float Wrap(float value, float min, float max)
         {
             if (value < min)
-            {
                 value = max - (min - value) % (max - min);
-            }
             else
-            {
                 value = min + (value - min) % (max - min);
-            }
 
             return value;
         }

--- a/TheSadRogue.Primitives/Palette.cs
+++ b/TheSadRogue.Primitives/Palette.cs
@@ -11,8 +11,7 @@ namespace SadRogue.Primitives
     [DataContract]
     public class Palette : IEnumerable<Color>
     {
-        [DataMember]
-        private readonly Color[] _colors;
+        [DataMember] private readonly Color[] _colors;
 
         /// <summary>
         /// How many colors the palette has.
@@ -39,9 +38,7 @@ namespace SadRogue.Primitives
             _colors = new Color[colors];
 
             for (int i = 0; i < colors; i++)
-            {
                 _colors[i] = new Color();
-            }
         }
 
         /// <summary>
@@ -113,7 +110,8 @@ namespace SadRogue.Primitives
             int currentDistance;
             for (int i = 0; i < _colors.Length; i++)
             {
-                currentDistance = Math.Abs(_colors[i].R - color.R) + Math.Abs(_colors[i].G - color.G) + Math.Abs(_colors[i].B - color.B);
+                currentDistance = Math.Abs(_colors[i].R - color.R) + Math.Abs(_colors[i].G - color.G) +
+                                  Math.Abs(_colors[i].B - color.B);
 
                 if (currentDistance < lowestDistance)
                 {
@@ -121,6 +119,7 @@ namespace SadRogue.Primitives
                     lowestDistanceIndex = i;
                 }
             }
+
             return lowestDistanceIndex;
         }
 
@@ -155,7 +154,7 @@ namespace SadRogue.Primitives
         /// <param name="p1"/>
         /// <param name="p2"/>
         /// <returns>True if the two palettes hold identical colors in the same order; false otherwise.</returns>
-        public static bool operator==(Palette p1, Palette p2)
+        public static bool operator ==(Palette p1, Palette p2)
         {
             if (ReferenceEquals(p1, p2))
                 return true;

--- a/TheSadRogue.Primitives/Palette.cs
+++ b/TheSadRogue.Primitives/Palette.cs
@@ -57,7 +57,7 @@ namespace SadRogue.Primitives
         {
             Color lostColor = _colors[0];
             Array.Copy(_colors, 1, _colors, 0, _colors.Length - 1);
-            _colors[_colors.Length - 1] = lostColor;
+            _colors[^1] = lostColor;
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace SadRogue.Primitives
         /// </summary>
         public void ShiftRight()
         {
-            Color lostColor = _colors[_colors.Length - 1];
+            Color lostColor = _colors[^1];
             Array.Copy(_colors, 0, _colors, 1, _colors.Length - 1);
             _colors[0] = lostColor;
         }

--- a/TheSadRogue.Primitives/Palette.cs
+++ b/TheSadRogue.Primitives/Palette.cs
@@ -141,7 +141,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="obj"/>
         /// <returns>True if the given object is a Palette and its colors are identical and in the same order; false otherwise.</returns>
-        public override bool Equals(object obj) => obj is Palette palette && this == palette;
+        public override bool Equals(object? obj) => obj is Palette palette && this == palette;
 
         /// <summary>
         /// Returns hash code based on the colors.

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -125,8 +125,8 @@ namespace SadRogue.Primitives
         /// <param name="c2">The second point.</param>
         /// <returns>The midpoint between <paramref name="c1"/> and <paramref name="c2"/>.</returns>
         [Pure]
-        public static Point Midpoint(Point c1, Point c2) =>
-            new Point((int)Math.Round((c1.X + c2.X) / 2.0f, MidpointRounding.AwayFromZero), (int)Math.Round((c1.Y + c2.Y) / 2.0f, MidpointRounding.AwayFromZero));
+        public static Point Midpoint(Point c1, Point c2)
+            => new Point((int)Math.Round((c1.X + c2.X) / 2.0f, MidpointRounding.AwayFromZero), (int)Math.Round((c1.Y + c2.Y) / 2.0f, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Returns the coordinate (c1.X - c2.X, c1.Y - c2.Y).

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -32,14 +32,12 @@ namespace SadRogue.Primitives
         /// <summary>
         /// X-value of the position.
         /// </summary>
-        [DataMember]
-        public readonly int X;
+        [DataMember] public readonly int X;
 
         /// <summary>
         /// Y-value of the position.
         /// </summary>
-        [DataMember]
-        public readonly int Y;
+        [DataMember] public readonly int Y;
 
         /// <summary>
         /// Constructor.
@@ -115,7 +113,8 @@ namespace SadRogue.Primitives
         /// values -- basically the distance formula without the square root.
         /// </returns>
         [Pure]
-        public static double EuclideanDistanceMagnitude(Point deltaChange) => deltaChange.X * deltaChange.X + deltaChange.Y * deltaChange.Y;
+        public static double EuclideanDistanceMagnitude(Point deltaChange)
+            => deltaChange.X * deltaChange.X + deltaChange.Y * deltaChange.Y;
 
 
         /// <summary>
@@ -126,7 +125,8 @@ namespace SadRogue.Primitives
         /// <returns>The midpoint between <paramref name="c1"/> and <paramref name="c2"/>.</returns>
         [Pure]
         public static Point Midpoint(Point c1, Point c2)
-            => new Point((int)Math.Round((c1.X + c2.X) / 2.0f, MidpointRounding.AwayFromZero), (int)Math.Round((c1.Y + c2.Y) / 2.0f, MidpointRounding.AwayFromZero));
+            => new Point((int)Math.Round((c1.X + c2.X) / 2.0f, MidpointRounding.AwayFromZero),
+                (int)Math.Round((c1.Y + c2.Y) / 2.0f, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Returns the coordinate (c1.X - c2.X, c1.Y - c2.Y).
@@ -144,7 +144,8 @@ namespace SadRogue.Primitives
         /// <param name="direction"/>
         /// <returns>The coordinate (point.X - direction.DeltaX, point.Y - direction.DeltaY).</returns>
         [Pure]
-        public static Point operator -(Point point, Direction direction) => new Point(point.X - direction.DeltaX, point.Y - direction.DeltaY);
+        public static Point operator -(Point point, Direction direction)
+            => new Point(point.X - direction.DeltaX, point.Y - direction.DeltaY);
 
         /// <summary>
         /// Subtracts scalar <paramref name="i"/> from the x and y values of <paramref name="c"/>.
@@ -196,7 +197,8 @@ namespace SadRogue.Primitives
         /// </returns>
         [Pure]
         public static Point operator *(Point c, double i) =>
-            new Point((int)Math.Round(c.X * i, MidpointRounding.AwayFromZero), (int)Math.Round(c.Y * i, MidpointRounding.AwayFromZero));
+            new Point((int)Math.Round(c.X * i, MidpointRounding.AwayFromZero),
+                (int)Math.Round(c.Y * i, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides the x/y components of <paramref name="c1"/> by the x/y components of <paramref name="c2"/>, rounding each resulting
@@ -207,7 +209,8 @@ namespace SadRogue.Primitives
         /// <returns>Position (c1.X / c2.X, c1.Y / c2.Y), with each value rounded to the nearest integer.</returns>
         [Pure]
         public static Point operator /(Point c1, Point c2) =>
-            new Point((int)Math.Round(c1.X / (double)c2.X, MidpointRounding.AwayFromZero), (int)Math.Round(c1.Y / (double)c2.Y, MidpointRounding.AwayFromZero));
+            new Point((int)Math.Round(c1.X / (double)c2.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(c1.Y / (double)c2.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides the x and y of <paramref name="c"/> by <paramref name="i"/>, rounding resulting values
@@ -218,7 +221,8 @@ namespace SadRogue.Primitives
         /// <returns>(c.X / <paramref name="i"/>, c.Y / <paramref name="i"/>), with the resulting values rounded to the nearest integer.</returns>
         [Pure]
         public static Point operator /(Point c, double i) =>
-            new Point((int)Math.Round(c.X / i, MidpointRounding.AwayFromZero), (int)Math.Round(c.Y / i, MidpointRounding.AwayFromZero));
+            new Point((int)Math.Round(c.X / i, MidpointRounding.AwayFromZero),
+                (int)Math.Round(c.Y / i, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Returns the position (c1.X + c2.X, c1.Y + c2.Y).
@@ -378,6 +382,7 @@ namespace SadRogue.Primitives
         public bool Equals(Point other) => X == other.X && Y == other.Y;
 
         #region TupleCompatibility
+
         /// <summary>
         /// Adds support for C# Deconstruction syntax.
         /// </summary>
@@ -397,6 +402,7 @@ namespace SadRogue.Primitives
         /// <returns />
         [Pure]
         public static implicit operator (int x, int y)(Point c) => (c.X, c.Y);
+
         /// <summary>
         /// Implicitly converts a tuple of two integers to an equivalent Point.
         /// </summary>
@@ -413,6 +419,7 @@ namespace SadRogue.Primitives
         /// <returns>A tuple (tuple.x + c.X, tuple.y + c.Y).</returns>
         [Pure]
         public static (int x, int y) operator +((int x, int y) tuple, Point c) => (tuple.x + c.X, tuple.y + c.Y);
+
         /// <summary>
         /// Adds the x and y values of a tuple of two integers to a Point.
         /// </summary>
@@ -430,6 +437,7 @@ namespace SadRogue.Primitives
         /// <returns>A tuple (tuple.x - c.X, tuple.y - c.Y).</returns>
         [Pure]
         public static (int x, int y) operator -((int x, int y) tuple, Point c) => (tuple.x - c.X, tuple.y - c.Y);
+
         /// <summary>
         /// Subtracts the x and y values of a tuple of two integers from a Point.
         /// </summary>
@@ -465,7 +473,8 @@ namespace SadRogue.Primitives
         /// <returns>Position (tuple.x / c.X, tuple.y / c.Y), with each value rounded to the nearest integer.</returns>
         [Pure]
         public static (int x, int y) operator /((int x, int y) tuple, Point c)
-            => new Point((int)Math.Round(tuple.x / (double)c.X, MidpointRounding.AwayFromZero), (int)Math.Round(tuple.y / (double)c.Y, MidpointRounding.AwayFromZero));
+            => new Point((int)Math.Round(tuple.x / (double)c.X, MidpointRounding.AwayFromZero),
+                (int)Math.Round(tuple.y / (double)c.Y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// Divides the x/y values of a Point by the x/y values of a tuple of two integers, rounding to the nearest integer.
@@ -475,7 +484,8 @@ namespace SadRogue.Primitives
         /// <returns>Position (c.X / tuple.x, c.Y / tuple.y), with each value rounded to the nearest integer.</returns>
         [Pure]
         public static (int x, int y) operator /(Point c, (int x, int y) tuple)
-            => new Point((int)Math.Round(c.X / (double)tuple.x, MidpointRounding.AwayFromZero), (int)Math.Round(c.Y / (double)tuple.y, MidpointRounding.AwayFromZero));
+            => new Point((int)Math.Round(c.X / (double)tuple.x, MidpointRounding.AwayFromZero),
+                (int)Math.Round(c.Y / (double)tuple.y, MidpointRounding.AwayFromZero));
 
         /// <summary>
         /// True if the two point's x and y values are equal.
@@ -524,7 +534,7 @@ namespace SadRogue.Primitives
         /// <returns>True if the two positions are equal, false if not.</returns>
         [Pure]
         public bool Equals((int x, int y) other) => X == other.x && Y == other.y;
+
         #endregion
     }
 }
-

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -303,7 +303,7 @@ namespace SadRogue.Primitives
         /// True if <paramref name="obj"/> is a Coord instance, and the two positions are equal, false otherwise.
         /// </returns>
         [Pure]
-        public override bool Equals(object obj) => obj is Point c && Equals(c);
+        public override bool Equals(object? obj) => obj is Point c && Equals(c);
 
         /// <summary>
         /// Returns a hash code for the Point. The important parts: it should be fairly fast and it

--- a/TheSadRogue.Primitives/PointExtensions.cs
+++ b/TheSadRogue.Primitives/PointExtensions.cs
@@ -31,7 +31,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="self"/>
         /// <param name="dir"/>
-        /// <returns>Position (c.X + d.DeltaX, c.Y + d.DeltaY)</returns>
+        /// <returns>Position (self.X + dir.DeltaX, self.Y + dir.DeltaY)</returns>
         [Pure]
         public static Point Add(this Point self, Direction dir) => self + dir;
 
@@ -52,6 +52,15 @@ namespace SadRogue.Primitives
         /// <returns>Position (self.X - i, self.Y - i).</returns>
         [Pure]
         public static Point Subtract(this Point self, int i) => self - i;
+
+        /// <summary>
+        /// Translates the current position by one unit in the opposite of the given direction.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="dir"/>
+        /// <returns>Position (self.X - dir.DeltaX, self.Y - dir.DeltaY)</returns>
+        [Pure]
+        public static Point Subtract(this Point self, Direction dir) => self - dir;
 
         /// <summary>
         /// Multiplies the current Point's x/y values by the given Point's x/y values.

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -230,18 +230,13 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator AdjacencyRule(Radius radius)
         {
-            switch (radius.Type)
+            return radius.Type switch
             {
-                case Types.Circle:
-                case Types.Square:
-                    return AdjacencyRule.EightWay;
-
-                case Types.Diamond:
-                    return AdjacencyRule.Cardinals;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!"); // Will not occur
-            }
+                Types.Circle => AdjacencyRule.EightWay,
+                Types.Square => AdjacencyRule.EightWay,
+                Types.Diamond => AdjacencyRule.Cardinals,
+                _ => throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!")
+            };
         }
 
         /// <summary>
@@ -255,20 +250,13 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator Distance(Radius radius)
         {
-            switch (radius.Type)
+            return radius.Type switch
             {
-                case Types.Circle:
-                    return Distance.Euclidean;
-
-                case Types.Diamond:
-                    return Distance.Manhattan;
-
-                case Types.Square:
-                    return Distance.Chebyshev;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Radius)} to {nameof(Distance)} -- this is a bug!"); // Will not occur
-            }
+                Types.Circle => Distance.Euclidean,
+                Types.Diamond => Distance.Manhattan,
+                Types.Square => Distance.Chebyshev,
+                _ => throw new Exception($"Could not convert {nameof(Radius)} to {nameof(Distance)} -- this is a bug!")
+            };
         }
 
         /// <summary>
@@ -285,20 +273,13 @@ namespace SadRogue.Primitives
         [Pure]
         public static implicit operator Radius(Types type)
         {
-            switch (type)
+            return type switch
             {
-                case Types.Circle:
-                    return Circle;
-
-                case Types.Diamond:
-                    return Diamond;
-
-                case Types.Square:
-                    return Square;
-
-                default:
-                    throw new Exception($"Could not convert {nameof(Types)} to {nameof(Radius)} -- this is a bug!"); // Will not occur
-            }
+                Types.Circle => Circle,
+                Types.Diamond => Diamond,
+                Types.Square => Square,
+                _ => throw new Exception($"Could not convert {nameof(Types)} to {nameof(Radius)} -- this is a bug!")
+            };
         }
 
         /// <summary>

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -42,8 +42,7 @@ namespace SadRogue.Primitives
         /// Enum value representing the radius shape -- useful for using Radius types in switch
         /// statements.
         /// </summary>
-        [DataMember]
-        public readonly Types Type;
+        [DataMember] public readonly Types Type;
 
         private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
@@ -69,7 +68,7 @@ namespace SadRogue.Primitives
             /// <summary>
             /// Type for Radius.CIRCLE.
             /// </summary>
-            Circle,
+            Circle
         };
 
         /// <summary>
@@ -131,13 +130,9 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> PositionsInRadius(RadiusLocationContext context)
         {
             if (context._newlyInitialized)
-            {
                 context._newlyInitialized = false;
-            }
             else
-            {
                 Array.Clear(context._inQueue, 0, context._inQueue.Length);
-            }
 
             int startArrayIndex = context._inQueue.GetLength(0) / 2;
             Point topLeft = context.Center - context.Radius;
@@ -164,9 +159,7 @@ namespace SadRogue.Primitives
                     if (distCalc.Calculate(context.Center, neighbor) > context.Radius ||
                         context._inQueue[localNeighbor.X, localNeighbor.Y] ||
                         context.Bounds != Rectangle.Empty && !context.Bounds.Contains(neighbor))
-                    {
                         continue;
-                    }
 
                     q.Enqueue(neighbor);
                     context._inQueue[localNeighbor.X, localNeighbor.Y] = true;
@@ -228,16 +221,13 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="radius">Radius type being casted.</param>
         [Pure]
-        public static implicit operator AdjacencyRule(Radius radius)
+        public static implicit operator AdjacencyRule(Radius radius) => radius.Type switch
         {
-            return radius.Type switch
-            {
-                Types.Circle => AdjacencyRule.EightWay,
-                Types.Square => AdjacencyRule.EightWay,
-                Types.Diamond => AdjacencyRule.Cardinals,
-                _ => throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!")
-            };
-        }
+            Types.Circle => AdjacencyRule.EightWay,
+            Types.Square => AdjacencyRule.EightWay,
+            Types.Diamond => AdjacencyRule.Cardinals,
+            _ => throw new Exception($"Could not convert {nameof(Distance)} to {nameof(Radius)} -- this is a bug!")
+        };
 
         /// <summary>
         /// Allows implicit casting to the <see cref="Distance"/> type.
@@ -248,16 +238,13 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="radius">Radius type being casted.</param>
         [Pure]
-        public static implicit operator Distance(Radius radius)
+        public static implicit operator Distance(Radius radius) => radius.Type switch
         {
-            return radius.Type switch
-            {
-                Types.Circle => Distance.Euclidean,
-                Types.Diamond => Distance.Manhattan,
-                Types.Square => Distance.Chebyshev,
-                _ => throw new Exception($"Could not convert {nameof(Radius)} to {nameof(Distance)} -- this is a bug!")
-            };
-        }
+            Types.Circle => Distance.Euclidean,
+            Types.Diamond => Distance.Manhattan,
+            Types.Square => Distance.Chebyshev,
+            _ => throw new Exception($"Could not convert {nameof(Radius)} to {nameof(Distance)} -- this is a bug!")
+        };
 
         /// <summary>
         /// Implicitly converts a Radius to its corresponding <see cref="Type"/>.
@@ -271,16 +258,13 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="type"/>
         [Pure]
-        public static implicit operator Radius(Types type)
+        public static implicit operator Radius(Types type) => type switch
         {
-            return type switch
-            {
-                Types.Circle => Circle,
-                Types.Diamond => Diamond,
-                Types.Square => Square,
-                _ => throw new Exception($"Could not convert {nameof(Types)} to {nameof(Radius)} -- this is a bug!")
-            };
-        }
+            Types.Circle => Circle,
+            Types.Diamond => Diamond,
+            Types.Square => Square,
+            _ => throw new Exception($"Could not convert {nameof(Types)} to {nameof(Radius)} -- this is a bug!")
+        };
 
         /// <summary>
         /// Returns a string representation of the Radius.
@@ -356,6 +340,7 @@ namespace SadRogue.Primitives
         /// <param name="center">The starting center-point of the radius.</param>
         /// <param name="radius">The starting length of the radius.</param>
         public RadiusLocationContext(Point center, int radius)
-            : this(center, radius, Rectangle.Empty) { }
+            : this(center, radius, Rectangle.Empty)
+        { }
     }
 }

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -79,7 +79,7 @@ namespace SadRogue.Primitives
         /// If you are getting postions for a radius of the same size frequently, it may be more performant to instead
         /// construct a <see cref="RadiusLocationContext"/> to represent it, and pass that to
         /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
-        /// 
+        ///
         /// The positions returned are all guaranteed to be within the <paramref name="bounds"/> specified.  As well,
         /// they are guaranteed to be in order from least distance from center to most distance if either
         /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
@@ -100,7 +100,7 @@ namespace SadRogue.Primitives
         /// If you are getting postions for a radius of the same size frequently, it may be more performant to instead
         /// construct a <see cref="RadiusLocationContext"/> to represent it, and pass that to
         /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
-        /// 
+        ///
         /// The positions returned are guaranteed to be in order from least distance from center to most distance if either
         /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
         /// </remarks>
@@ -120,7 +120,7 @@ namespace SadRogue.Primitives
         /// <remarks>
         /// The positions returned are all guaranteed to be within the <see cref="RadiusLocationContext.Bounds"/> specified in the context, unless
         /// the bounds are unspecified, in which case no bound restriction results.
-        /// 
+        ///
         /// As well, they are guaranteed to be in order from least distance from center to most distance if either
         /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
         /// </remarks>
@@ -190,7 +190,7 @@ namespace SadRogue.Primitives
         /// True if <paramref name="obj"/> is a Radius, and the two radius shapes are equal, false otherwise.
         /// </returns>
         [Pure]
-        public override bool Equals(object obj) => obj is Radius c && Equals(c);
+        public override bool Equals(object? obj) => obj is Radius c && Equals(c);
 
         /// <summary>
         /// Returns a hash-map value for the current object.
@@ -310,7 +310,7 @@ namespace SadRogue.Primitives
 
     /// <summary>
     /// A context representing information necessary to get all the positions in a radius via functions like
-    /// <see cref="Radius.PositionsInRadius(RadiusLocationContext)"/>.  Storing a context and re-using it may be
+    /// <see cref="SadRogue.Primitives.Radius.PositionsInRadius(RadiusLocationContext)"/>.  Storing a context and re-using it may be
     /// more performant in cases where you're getting the positions in a radius of the same size many times,
     /// even if the location center point or shape of the radius is changing.
     /// </summary>

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -72,18 +72,17 @@ namespace SadRogue.Primitives
         /// The center coordinate of the rectangle, rounded up if the exact center is between two
         /// positions. The center of a rectangle with width/height 1 is its <see cref="Position"/>.
         /// </summary>
-        public Point Center => new Point(X + (Width / 2), Y + (Height / 2));
+        public Point Center => new Point(X + Width / 2, Y + Height / 2);
 
         /// <summary>
         /// The height of the rectangle.
         /// </summary>
-        [DataMember]
-        public readonly int Height;
+        [DataMember] public readonly int Height;
 
         /// <summary>
         /// Whether or not this rectangle is empty (has width and height of 0).
         /// </summary>
-        public bool IsEmpty => (Width == 0 && Height == 0);
+        public bool IsEmpty => Width == 0 && Height == 0;
 
         /// <summary>
         /// The maximum X and Y coordinates that are included in the rectangle.
@@ -134,20 +133,17 @@ namespace SadRogue.Primitives
         /// <summary>
         /// The width of the rectangle.
         /// </summary>
-        [DataMember]
-        public readonly int Width;
+        [DataMember] public readonly int Width;
 
         /// <summary>
         /// X-coordinate of position of the rectangle.
         /// </summary>
-        [DataMember]
-        public readonly int X;
+        [DataMember] public readonly int X;
 
         /// <summary>
         /// Y-coordinate of position of the rectangle.
         /// </summary>
-        [DataMember]
-        public readonly int Y;
+        [DataMember] public readonly int Y;
 
         /// <summary>
         /// Creates a rectangle with the given minimum and maximum extents. Effectively a
@@ -173,7 +169,8 @@ namespace SadRogue.Primitives
         /// </param>
         /// <returns>A new rectangle with the given center point and radius values.</returns>
         [Pure]
-        public static Rectangle WithRadius(Point center, int horizontalRadius, int verticalRadius) => new Rectangle(center, horizontalRadius, verticalRadius);
+        public static Rectangle WithRadius(Point center, int horizontalRadius, int verticalRadius)
+            => new Rectangle(center, horizontalRadius, verticalRadius);
 
         /// <summary>
         /// Creates a rectangle with the given position and size. Effectively a constructor, but with
@@ -184,7 +181,8 @@ namespace SadRogue.Primitives
         /// <param name="height">Height of the rectangle.</param>
         /// <returns>A new rectangle at the given position with the given width and height.</returns>
         [Pure]
-        public static Rectangle WithPositionAndSize(Point position, int width, int height) => new Rectangle(position.X, position.Y, width, height);
+        public static Rectangle WithPositionAndSize(Point position, int width, int height)
+            => new Rectangle(position.X, position.Y, width, height);
 
         /// <summary>
         /// Creates a rectangle with the given position and size. Effectively a constructor, but with
@@ -194,7 +192,8 @@ namespace SadRogue.Primitives
         /// <param name="size">The size of the rectangle, in form (width, height).</param>
         /// <returns>A new rectangle at the given position with the given size.</returns>
         [Pure]
-        public static Rectangle WithPositionAndSize(Point position, Point size) => new Rectangle(position.X, position.Y, size.X, size.Y);
+        public static Rectangle WithPositionAndSize(Point position, Point size)
+            => new Rectangle(position.X, position.Y, size.X, size.Y);
 
         /// <summary>
         /// Gets an <see cref="Primitives.Area"/> representing every location in <paramref name="rect1"/> that
@@ -212,9 +211,7 @@ namespace SadRogue.Primitives
             foreach (Point pos in rect1.Positions())
             {
                 if (rect2.Contains(pos))
-                {
                     continue;
-                }
 
                 retVal.Add(pos);
             }
@@ -235,20 +232,12 @@ namespace SadRogue.Primitives
             var retVal = new Area();
 
             for (int x = r1.X; x <= r1.MaxExtentX; x++)
-            {
-                for (int y = r1.Y; y <= r1.MaxExtentY; y++)
-                {
-                    retVal.Add(new Point(x, y));
-                }
-            }
+            for (int y = r1.Y; y <= r1.MaxExtentY; y++)
+                retVal.Add(new Point(x, y));
 
             for (int x = r2.X; x <= r2.MaxExtentX; x++)
-            {
-                for (int y = r2.Y; y <= r2.MaxExtentY; y++)
-                {
-                    retVal.Add(new Point(x, y));
-                }
-            }
+            for (int y = r2.Y; y <= r2.MaxExtentY; y++)
+                retVal.Add(new Point(x, y));
 
             return retVal;
         }
@@ -296,7 +285,8 @@ namespace SadRogue.Primitives
             int x = Math.Min(r1.X, r2.X);
             int y = Math.Min(r1.Y, r2.Y);
 
-            return new Rectangle(x, y, Math.Max(r1.X + r1.Width, r2.X + r2.Width) - x, Math.Max(r1.Y + r1.Height, r2.Y + r2.Height) - y);
+            return new Rectangle(x, y, Math.Max(r1.X + r1.Width, r2.X + r2.Width) - x,
+                Math.Max(r1.Y + r1.Height, r2.Y + r2.Height) - y);
         }
 
         /// <summary>
@@ -317,7 +307,8 @@ namespace SadRogue.Primitives
         /// true if the area of the two rectangles encompass the exact same area, false otherwise.
         /// </returns>
         [Pure]
-        public static bool operator ==(Rectangle r1, Rectangle r2) => r1.X == r2.X && r1.Y == r2.Y && r1.Width == r2.Width && r1.Height == r2.Height;
+        public static bool operator ==(Rectangle r1, Rectangle r2)
+            => r1.X == r2.X && r1.Y == r2.Y && r1.Width == r2.Width && r1.Height == r2.Height;
 
         /// <summary>
         /// Creates and returns a new rectangle that is the same size as the current one, but with
@@ -330,7 +321,7 @@ namespace SadRogue.Primitives
         /// </returns>
         [Pure]
         public Rectangle WithCenter(Point center)
-            => new Rectangle(center.X - (Width / 2), center.Y - (Height / 2), Width, Height);
+            => new Rectangle(center.X - Width / 2, center.Y - Height / 2, Width, Height);
 
         /// <summary>
         /// Creates and returns a new rectangle whose position is the same as the current one, but
@@ -373,7 +364,8 @@ namespace SadRogue.Primitives
         /// <param name="position">The position to check.</param>
         /// <returns>Whether or not the specified point is considered within the rectangle.</returns>
         [Pure]
-        public bool Contains(Point position) => (position.X >= X && position.X < (X + Width) && position.Y >= Y && position.Y < (Y + Height));
+        public bool Contains(Point position)
+            => position.X >= X && position.X < X + Width && position.Y >= Y && position.Y < Y + Height;
 
         /// <summary>
         /// Returns whether or not the specified rectangle is considered completely contained within
@@ -384,7 +376,8 @@ namespace SadRogue.Primitives
         /// True if the given rectangle is completely contained within the current one, false otherwise.
         /// </returns>
         [Pure]
-        public bool Contains(Rectangle other) => (X <= other.X && other.X + other.Width <= X + Width && Y <= other.Y && other.Y + other.Height <= Y + Height);
+        public bool Contains(Rectangle other) => X <= other.X && other.X + other.Width <= X + Width && Y <= other.Y &&
+                                                 other.Y + other.Height <= Y + Height;
 
         /// <summary>
         /// Compares based upon whether or not the areas contained within the rectangle are identical
@@ -395,7 +388,8 @@ namespace SadRogue.Primitives
         /// true if the area of the two rectangles encompass the exact same area, false otherwise.
         /// </returns>
         [Pure]
-        public bool Equals(Rectangle other) => (X == other.X && Y == other.Y && Width == other.Width && Height == other.Height);
+        public bool Equals(Rectangle other)
+            => X == other.X && Y == other.Y && Width == other.Width && Height == other.Height;
 
         /// <summary>
         /// Compares to an arbitrary object.
@@ -419,14 +413,16 @@ namespace SadRogue.Primitives
         /// <returns>A new rectangle, expanded appropriately.</returns>
         [Pure]
         public Rectangle Expand(int horizontalChange, int verticalChange)
-            => new Rectangle(X - horizontalChange, Y - verticalChange, Width + (2 * horizontalChange), Height + (2 * verticalChange));
+            => new Rectangle(X - horizontalChange, Y - verticalChange, Width + 2 * horizontalChange,
+                Height + 2 * verticalChange);
 
         /// <summary>
         /// Simple hashing.
         /// </summary>
         /// <returns>Hash code for rectangle.</returns>
         [Pure]
-        public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode() ^ Width.GetHashCode() ^ Height.GetHashCode();
+        public override int GetHashCode()
+            => X.GetHashCode() ^ Y.GetHashCode() ^ Width.GetHashCode() ^ Height.GetHashCode();
 
         /// <summary>
         /// Returns whether or not the given rectangle intersects the current one.
@@ -434,7 +430,8 @@ namespace SadRogue.Primitives
         /// <param name="other">The rectangle to check.</param>
         /// <returns>True if the given rectangle intersects with the current one, false otherwise.</returns>
         [Pure]
-        public bool Intersects(Rectangle other) => (other.X < X + Width && X < other.X + other.Width && other.Y < Y + Height && Y < other.Y + other.Height);
+        public bool Intersects(Rectangle other) => other.X < X + Width && X < other.X + other.Width &&
+                                                   other.Y < Y + Height && Y < other.Y + other.Height;
 
         /// <summary>
         /// Creates and returns a new rectangle that has its <see cref="Position"/> moved to the given position.
@@ -481,12 +478,8 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> Positions()
         {
             for (int y = Y; y <= MaxExtentY; y++)
-            {
-                for (int x = X; x <= MaxExtentX; x++)
-                {
-                    yield return new Point(x, y);
-                }
-            }
+            for (int x = X; x <= MaxExtentX; x++)
+                yield return new Point(x, y);
         }
 
         /// <summary>
@@ -629,21 +622,26 @@ namespace SadRogue.Primitives
             => new Rectangle(X, Y + dy, Width, Height);
 
         #region Tuple Compatibility
+
         #region (x, y, width, height)
+
         /// <summary>
         /// Implicitly converts a GoRogue Rectangle to an equivalent tuple of 4 integers (x, y, width, height).
         /// </summary>
         /// <param name="rect" />
         /// <returns />
         [Pure]
-        public static implicit operator (int x, int y, int width, int height)(Rectangle rect) => (rect.X, rect.Y, rect.Width, rect.Height);
+        public static implicit operator (int x, int y, int width, int height)(Rectangle rect)
+            => (rect.X, rect.Y, rect.Width, rect.Height);
+
         /// <summary>
         /// Implicitly converts a tuple of 4 integers (x, y, width, height) to an equivalent GoRogue Rectangle.
         /// </summary>
         /// <param name="tuple" />
         /// <returns />
         [Pure]
-        public static implicit operator Rectangle((int x, int y, int width, int height) tuple) => new Rectangle(tuple.x, tuple.y, tuple.width, tuple.height);
+        public static implicit operator Rectangle((int x, int y, int width, int height) tuple)
+            => new Rectangle(tuple.x, tuple.y, tuple.width, tuple.height);
 
         /// <summary>
         /// Adds support for C# Deconstruction syntax.
@@ -668,7 +666,8 @@ namespace SadRogue.Primitives
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
         [Pure]
-        public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2) => r1.X == r2.x && r1.Y == r2.y && r1.Width == r2.width && r1.Height == r2.height;
+        public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2)
+            => r1.X == r2.x && r1.Y == r2.y && r1.Width == r2.width && r1.Height == r2.height;
 
         /// <summary>
         /// True if any of the rectangles' x/y/width/height values are not equal.
@@ -688,7 +687,8 @@ namespace SadRogue.Primitives
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
         [Pure]
-        public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2) => r1.x == r2.X && r1.y == r2.Y && r1.width == r2.Width && r1.height == r2.Height;
+        public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2)
+            => r1.x == r2.X && r1.y == r2.Y && r1.width == r2.Width && r1.height == r2.Height;
 
         /// <summary>
         /// True if any of the rectangles' x/y/width/height values are not equal.
@@ -709,22 +709,28 @@ namespace SadRogue.Primitives
         [Pure]
         public bool Equals((int x, int y, int width, int height) other)
             => X == other.x && Y == other.y && Width == other.width && Height == other.height;
+
         #endregion
+
         #region (minExtent, maxExtent)
+
         /// <summary>
         /// Implicitly converts a GoRogue Rectangle to an equivalent tuple of 2 Points (minExtent, maxExtent).
         /// </summary>
         /// <param name="rect" />
         /// <returns />
         [Pure]
-        public static implicit operator (Point minExtent, Point maxExtent)(Rectangle rect) => (rect.MinExtent, rect.MaxExtent);
+        public static implicit operator (Point minExtent, Point maxExtent)(Rectangle rect)
+            => (rect.MinExtent, rect.MaxExtent);
+
         /// <summary>
         /// Implicitly converts a tuple of 2 Points (minExtent, maxExtent) to an equivalent GoRogue Rectangle.
         /// </summary>
         /// <param name="tuple" />
         /// <returns />
         [Pure]
-        public static implicit operator Rectangle((Point minExtent, Point maxExtent) tuple) => new Rectangle(tuple.minExtent, tuple.maxExtent);
+        public static implicit operator Rectangle((Point minExtent, Point maxExtent) tuple)
+            => new Rectangle(tuple.minExtent, tuple.maxExtent);
 
         /// <summary>
         /// Adds support for C# Deconstruction syntax.
@@ -745,7 +751,8 @@ namespace SadRogue.Primitives
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
         [Pure]
-        public static bool operator ==(Rectangle r1, (Point minExtent, Point maxExtent) r2) => r1.MinExtent == r2.minExtent && r1.MaxExtent == r2.maxExtent;
+        public static bool operator ==(Rectangle r1, (Point minExtent, Point maxExtent) r2)
+            => r1.MinExtent == r2.minExtent && r1.MaxExtent == r2.maxExtent;
 
         /// <summary>
         /// True if any of the rectangles' x/y/width/height values are not equal.
@@ -765,7 +772,8 @@ namespace SadRogue.Primitives
         /// <param name="r2"></param>
         /// <returns>True if the two rectangles are equal, false if not.</returns>
         [Pure]
-        public static bool operator ==((Point minExtent, Point maxExtent) r1, Rectangle r2) => r1.minExtent == r2.MinExtent && r1.maxExtent == r2.MaxExtent;
+        public static bool operator ==((Point minExtent, Point maxExtent) r1, Rectangle r2)
+            => r1.minExtent == r2.MinExtent && r1.maxExtent == r2.MaxExtent;
 
         /// <summary>
         /// True if any of the rectangles' x/y/width/height values are not equal.
@@ -786,7 +794,9 @@ namespace SadRogue.Primitives
         [Pure]
         public bool Equals((Point minExtent, Point maxExtent) other)
             => MinExtent == other.minExtent && MaxExtent == other.maxExtent;
+
         #endregion
+
         #endregion
 
         /// <summary>
@@ -797,24 +807,22 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> PerimeterPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
-            {
                 yield return new Point(x, MinExtentY); // Minimum y-side perimeter
-            }
 
-            for (int y = MinExtentY + 1; y <= MaxExtentY; y++) // Start offset 1, since last loop returned the corner piece
-            {
+            for (int y = MinExtentY + 1;
+                y <= MaxExtentY;
+                y++) // Start offset 1, since last loop returned the corner piece
                 yield return new Point(MaxExtentX, y);
-            }
 
-            for (int x = MaxExtentX - 1; x >= MinExtentX; x--) // Again skip 1 because last loop returned the corner piece
-            {
+            for (int x = MaxExtentX - 1;
+                x >= MinExtentX;
+                x--) // Again skip 1 because last loop returned the corner piece
                 yield return new Point(x, MaxExtentY);
-            }
 
-            for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--) // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
-            {
+            for (int y = MaxExtentY - 1;
+                y >= MinExtentY + 1;
+                y--) // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
                 yield return new Point(MinExtentX, y);
-            }
         }
 
         /// <summary>
@@ -824,19 +832,17 @@ namespace SadRogue.Primitives
         /// <param name="side"/>
         /// <returns>True if the given position lies along the given edge of the rectangle, false otherwise.</returns>
         [Pure]
-        public bool IsOnSide(Point point, Direction side)
+        public bool IsOnSide(Point point, Direction side) => side.Type switch
         {
-            return side.Type switch
-            {
-                Direction.Types.Up => point.X >= MinExtentX && point.X <= MaxExtentX && point.Y ==
-                                      ((Direction.YIncreasesUpward) ? MaxExtentY : MinExtentY),
-                Direction.Types.Down => point.X >= MinExtentX && point.X <= MaxExtentX && point.Y ==
-                                        ((Direction.YIncreasesUpward) ? MinExtentY : MaxExtentY),
-                Direction.Types.Left => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MinExtentX,
-                Direction.Types.Right => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MaxExtentX,
-                _ => throw new ArgumentException($"{side} is not a valid side.  Sides must be cardinal directions.", nameof(side))
-            };
-        }
+            Direction.Types.Up => point.X >= MinExtentX && point.X <= MaxExtentX && point.Y ==
+            (Direction.YIncreasesUpward ? MaxExtentY : MinExtentY),
+            Direction.Types.Down => point.X >= MinExtentX && point.X <= MaxExtentX && point.Y ==
+            (Direction.YIncreasesUpward ? MinExtentY : MaxExtentY),
+            Direction.Types.Left => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MinExtentX,
+            Direction.Types.Right => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MaxExtentX,
+            _ => throw new ArgumentException($"{side} is not a valid side.  Sides must be cardinal directions.",
+                nameof(side))
+        };
 
         /// <summary>
         /// Gets all positions that reside on the min-y line of the rectangle.
@@ -846,9 +852,7 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MinYPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
-            {
                 yield return new Point(x, MinExtentY);
-            }
         }
 
         /// <summary>
@@ -859,9 +863,7 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MaxYPositions()
         {
             for (int x = MinExtentX; x <= MaxExtentX; x++)
-            {
                 yield return new Point(x, MaxExtentY);
-            }
         }
 
         /// <summary>
@@ -872,9 +874,7 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MinXPositions()
         {
             for (int y = MinExtentY; y <= MaxExtentY; y++)
-            {
                 yield return new Point(MinExtentX, y);
-            }
         }
 
         /// <summary>
@@ -885,9 +885,7 @@ namespace SadRogue.Primitives
         public IEnumerable<Point> MaxXPositions()
         {
             for (int y = MinExtentY; y <= MaxExtentY; y++)
-            {
                 yield return new Point(MaxExtentX, y);
-            }
         }
 
         /// <summary>
@@ -897,16 +895,13 @@ namespace SadRogue.Primitives
         /// <param name="side">Side to get positions for.</param>
         /// <returns>IEnumerable of all positions that line on the inner perimeter of the rectangle on the given side.</returns>
         [Pure]
-        public IEnumerable<Point> PositionsOnSide(Direction side)
+        public IEnumerable<Point> PositionsOnSide(Direction side) => side.Type switch
         {
-            return side.Type switch
-            {
-                Direction.Types.Up => (Direction.YIncreasesUpward) ? MaxYPositions() : MinYPositions(),
-                Direction.Types.Right => MaxXPositions(),
-                Direction.Types.Down => (Direction.YIncreasesUpward) ? MinYPositions() : MaxYPositions(),
-                Direction.Types.Left => MinXPositions(),
-                _ => throw new Exception("Cannot retrieve positions on a non-cardinal side of a rectangle.")
-            };
-        }
+            Direction.Types.Up => Direction.YIncreasesUpward ? MaxYPositions() : MinYPositions(),
+            Direction.Types.Right => MaxXPositions(),
+            Direction.Types.Down => Direction.YIncreasesUpward ? MinYPositions() : MaxYPositions(),
+            Direction.Types.Left => MinXPositions(),
+            _ => throw new Exception("Cannot retrieve positions on a non-cardinal side of a rectangle.")
+        };
     }
 }

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -811,101 +811,32 @@ namespace SadRogue.Primitives
                 yield return new Point(x, MaxExtentY);
             }
 
-            for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--) // Skip 1 on both ends, becuase last loop returned one corner, first loop returned the other
+            for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--) // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
             {
                 yield return new Point(MinExtentX, y);
             }
         }
 
         /// <summary>
-        /// Returns all positions on the top edge of the rectangle.
-        /// </summary>
-        /// <returns>All positions on the top edge of the rectangle.</returns>
-        [Pure]
-        public IEnumerable<Point> TopEdgePositions()
-        {
-            int topY = (Direction.YIncreasesUpward) ? MaxExtentY : MinExtentY;
-
-            for (int i = MinExtentX; i <= MaxExtentX; i++)
-                yield return new Point(i, topY);
-        }
-
-        /// <summary>
-        /// Returns all positions on the right edge of the rectangle.
-        /// </summary>
-        /// <returns>All positions on the right edge of the rectangle.</returns>
-        [Pure]
-        public IEnumerable<Point> RightEdgePositions()
-        {
-            for (int i = MinExtentY; i <= MaxExtentY; i++)
-                yield return new Point(MaxExtentX, i);
-        }
-
-        /// <summary>
-        /// Returns all positions on the bottom edge of the rectangle.
-        /// </summary>
-        /// <returns>All positions on the bottom edge of the rectangle.</returns>
-        [Pure]
-        public IEnumerable<Point> BottomEdgePositions()
-        {
-            int botY = (Direction.YIncreasesUpward) ? MinExtentY : MaxExtentY;
-
-            for (int i = MinExtentX; i <= MaxExtentX; i++)
-                yield return new Point(i, botY);
-        }
-
-        /// <summary>
-        /// Returns all positions on the left edge of the rectangle.
-        /// </summary>
-        /// <returns>All positions on the left edge of the rectangle.</returns>
-        [Pure]
-        public IEnumerable<Point> LeftEdgePositions()
-        {
-            for (int i = MinExtentY; i <= MaxExtentY; i++)
-                yield return new Point(MinExtentX, i);
-        }
-
-        /// <summary>
-        /// Returns whether or not the given position lies on the top edge of the rectangle.
+        /// Returns whether or not the given position lines on the given edge of the rectangle.
         /// </summary>
         /// <param name="point"/>
-        /// <returns>True if the given position lies along the top edge of the rectangle, false otherwise.</returns>
+        /// <param name="side"/>
+        /// <returns>True if the given position lies along the given edge of the rectangle, false otherwise.</returns>
         [Pure]
-        public bool IsOnTopEdge(Point point)
+        public bool IsOnSide(Point point, Direction side)
         {
-            int topY = (Direction.YIncreasesUpward) ? MaxExtentY : MinExtentY;
-            return (point.X >= MinExtentX && point.X <= MaxExtentX && point.Y == topY);
+            return side.Type switch
+            {
+                Direction.Types.Up => point.X >= MinExtentX && point.X <= MaxExtentX && point.Y ==
+                                      ((Direction.YIncreasesUpward) ? MaxExtentY : MinExtentY),
+                Direction.Types.Down => point.X >= MinExtentX && point.X <= MaxExtentX && point.Y ==
+                                        ((Direction.YIncreasesUpward) ? MinExtentY : MaxExtentY),
+                Direction.Types.Left => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MinExtentX,
+                Direction.Types.Right => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MaxExtentX,
+                _ => throw new ArgumentException($"{side} is not a valid side.  Sides must be cardinal directions.", nameof(side))
+            };
         }
-
-        /// <summary>
-        /// Returns whether or not the given position lies on the right edge of the rectangle.
-        /// </summary>
-        /// <param name="point"/>
-        /// <returns>True if the given position lies along the right edge of the rectangle, false otherwise.</returns>
-        [Pure]
-        public bool IsOnRightEdge(Point point) => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MaxExtentX;
-
-        /// <summary>
-        /// Returns whether or not the given position lies on the bottom edge of the rectangle.
-        /// </summary>
-        /// <param name="point"/>
-        /// <returns>True if the given position lies along the bottom edge of the rectangle, false otherwise.</returns>
-        [Pure]
-        public bool IsOnBottomEdge(Point point)
-        {
-            int topY = (Direction.YIncreasesUpward) ? MinExtentY : MaxExtentY;
-            return (point.X >= MinExtentX && point.X <= MaxExtentX && point.Y == topY);
-        }
-
-        /// <summary>
-        /// Returns whether or not the given position lies on the left edge of the rectangle.
-        /// </summary>
-        /// <param name="point"/>
-        /// <returns>True if the given position lies along the left edge of the rectangle, false otherwise.</returns>
-        [Pure]
-        public bool IsOnLeftEdge(Point point) => point.Y >= MinExtentY && point.Y <= MaxExtentY && point.X == MinExtentX;
-
-
 
         /// <summary>
         /// Gets all positions that reside on the min-y line of the rectangle.

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -405,7 +405,7 @@ namespace SadRogue.Primitives
         /// true if the object specified is a rectangle instance and encompasses the same area, false otherwise.
         /// </returns>
         [Pure]
-        public override bool Equals(object obj) => obj is Rectangle && this == (Rectangle)obj;
+        public override bool Equals(object? obj) => obj is Rectangle && this == (Rectangle)obj;
 
         /// <summary>
         /// Returns a new rectangle, expanded to include the additional specified rows/columns.

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -968,19 +968,14 @@ namespace SadRogue.Primitives
         [Pure]
         public IEnumerable<Point> PositionsOnSide(Direction side)
         {
-            switch (side.Type)
+            return side.Type switch
             {
-                case Direction.Types.Up:
-                    return (Direction.YIncreasesUpward) ? MaxYPositions() : MinYPositions();
-                case Direction.Types.Right:
-                    return MaxXPositions();
-                case Direction.Types.Down:
-                    return (Direction.YIncreasesUpward) ? MinYPositions() : MaxYPositions();
-                case Direction.Types.Left:
-                    return MinXPositions();
-                default:
-                    throw new Exception("Cannot retrieve positions on a non-cardinal side of a rectangle.");
-            }
+                Direction.Types.Up => (Direction.YIncreasesUpward) ? MaxYPositions() : MinYPositions(),
+                Direction.Types.Right => MaxXPositions(),
+                Direction.Types.Down => (Direction.YIncreasesUpward) ? MinYPositions() : MaxYPositions(),
+                Direction.Types.Left => MinXPositions(),
+                _ => throw new Exception("Cannot retrieve positions on a non-cardinal side of a rectangle.")
+            };
         }
     }
 }

--- a/TheSadRogue.Primitives/SerializedTypes/Area.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Area.cs
@@ -10,11 +10,24 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct AreaSerialized
     {
+        /// <summary>
+        /// Positions in the area.
+        /// </summary>
         public List<PointSerialized> Positions;
 
+        /// <summary>
+        /// Converts <see cref="AreaSerialized"/> to <see cref="Area"/>.
+        /// </summary>
+        /// <param name="serialized"/>
+        /// <returns/>
         public static implicit operator Area(AreaSerialized serialized)
             => new Area(serialized.Positions.Select(pos => (Point)pos));
 
+        /// <summary>
+        /// Converts <see cref="Area"/> to <see cref="AreaSerialized"/>.
+        /// </summary>
+        /// <param name="area"/>
+        /// <returns/>
         public static implicit operator AreaSerialized(Area area)
             => new AreaSerialized() { Positions = area.Positions.Select(p => (PointSerialized)p).ToList() };
     }

--- a/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs
@@ -24,11 +24,7 @@ namespace SadRogue.Primitives.SerializedTypes
         /// <param name="rect"/>
         /// <returns/>
         public static implicit operator BoundedRectangleSerialized(BoundedRectangle rect) =>
-            new BoundedRectangleSerialized()
-        {
-            Area = rect.Area,
-            Bounds = rect.BoundingBox
-        };
+            new BoundedRectangleSerialized() { Area = rect.Area, Bounds = rect.BoundingBox };
 
         /// <summary>
         /// Converts <see cref="BoundedRectangleSerialized"/> to <see cref="BoundedRectangle"/>.

--- a/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs
@@ -8,9 +8,21 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct BoundedRectangleSerialized
     {
+        /// <summary>
+        /// Area the rectangle encompasses.
+        /// </summary>
         public RectangleSerialized Area;
+
+        /// <summary>
+        /// Bounds the area is restricted to.
+        /// </summary>
         public RectangleSerialized Bounds;
 
+        /// <summary>
+        /// Converts <see cref="BoundedRectangle"/> to <see cref="BoundedRectangleSerialized"/>.
+        /// </summary>
+        /// <param name="rect"/>
+        /// <returns/>
         public static implicit operator BoundedRectangleSerialized(BoundedRectangle rect) =>
             new BoundedRectangleSerialized()
         {
@@ -18,6 +30,11 @@ namespace SadRogue.Primitives.SerializedTypes
             Bounds = rect.BoundingBox
         };
 
+        /// <summary>
+        /// Converts <see cref="BoundedRectangleSerialized"/> to <see cref="BoundedRectangle"/>.
+        /// </summary>
+        /// <param name="rect"/>
+        /// <returns/>
         public static implicit operator BoundedRectangle(BoundedRectangleSerialized rect) =>
             new BoundedRectangle(rect.Area, rect.Bounds);
     }

--- a/TheSadRogue.Primitives/SerializedTypes/Color.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Color.cs
@@ -8,13 +8,35 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct ColorSerialized
     {
+        /// <summary>
+        /// "R" value for the color.
+        /// </summary>
         public byte R;
+        /// <summary>
+        /// "G" value for the color.
+        /// </summary>
         public byte G;
+        /// <summary>
+        /// "B" value for the color.
+        /// </summary>
         public byte B;
+        /// <summary>
+        /// Alpha-value for the color.
+        /// </summary>
         public byte A;
 
+        /// <summary>
+        /// Converts <see cref="Color"/> to <see cref="ColorSerialized"/>.
+        /// </summary>
+        /// <param name="color"/>
+        /// <returns/>
         public static implicit operator ColorSerialized(Color color) => new ColorSerialized() { R = color.R, G = color.G, B = color.B, A = color.A };
 
+        /// <summary>
+        /// Converts <see cref="ColorSerialized"/> to <see cref="Color"/>.
+        /// </summary>
+        /// <param name="color"/>
+        /// <returns/>
         public static implicit operator Color(ColorSerialized color) => new Color(color.R, color.G, color.B, color.A);
     }
 }

--- a/TheSadRogue.Primitives/SerializedTypes/Color.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Color.cs
@@ -12,14 +12,17 @@ namespace SadRogue.Primitives.SerializedTypes
         /// "R" value for the color.
         /// </summary>
         public byte R;
+
         /// <summary>
         /// "G" value for the color.
         /// </summary>
         public byte G;
+
         /// <summary>
         /// "B" value for the color.
         /// </summary>
         public byte B;
+
         /// <summary>
         /// Alpha-value for the color.
         /// </summary>
@@ -30,7 +33,8 @@ namespace SadRogue.Primitives.SerializedTypes
         /// </summary>
         /// <param name="color"/>
         /// <returns/>
-        public static implicit operator ColorSerialized(Color color) => new ColorSerialized() { R = color.R, G = color.G, B = color.B, A = color.A };
+        public static implicit operator ColorSerialized(Color color)
+            => new ColorSerialized() { R = color.R, G = color.G, B = color.B, A = color.A };
 
         /// <summary>
         /// Converts <see cref="ColorSerialized"/> to <see cref="Color"/>.

--- a/TheSadRogue.Primitives/SerializedTypes/Gradient.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Gradient.cs
@@ -14,6 +14,7 @@ namespace SadRogue.Primitives.SerializedTypes
         /// Color of the stop.
         /// </summary>
         public ColorSerialized Color;
+
         /// <summary>
         /// Location where the stop is used.
         /// </summary>
@@ -24,7 +25,8 @@ namespace SadRogue.Primitives.SerializedTypes
         /// </summary>
         /// <param name="serialized"/>
         /// <returns/>
-        public static implicit operator GradientStop(GradientStopSerialized serialized) => new GradientStop(serialized.Color, serialized.Stop);
+        public static implicit operator GradientStop(GradientStopSerialized serialized)
+            => new GradientStop(serialized.Color, serialized.Stop);
 
         /// <summary>
         /// Converts from <see cref="GradientStop"/> to <see cref="GradientStopSerialized"/>.
@@ -32,7 +34,7 @@ namespace SadRogue.Primitives.SerializedTypes
         /// <param name="stop"/>
         /// <returns/>
         public static implicit operator GradientStopSerialized(GradientStop stop) =>
-            new GradientStopSerialized() {Color = stop.Color, Stop = stop.Stop};
+            new GradientStopSerialized() { Color = stop.Color, Stop = stop.Stop };
     }
 
     /// <summary>
@@ -53,7 +55,6 @@ namespace SadRogue.Primitives.SerializedTypes
         /// <returns/>
         public static implicit operator Gradient(GradientSerialized serialized)
         {
-
             var colors = serialized.Stops.Select(stop => (Color)stop.Color).ToArray();
             var stops = serialized.Stops.Select(stop => stop.Stop);
 

--- a/TheSadRogue.Primitives/SerializedTypes/Gradient.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Gradient.cs
@@ -10,11 +10,27 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct GradientStopSerialized
     {
+        /// <summary>
+        /// Color of the stop.
+        /// </summary>
         public ColorSerialized Color;
+        /// <summary>
+        /// Location where the stop is used.
+        /// </summary>
         public float Stop;
 
+        /// <summary>
+        /// Converts from <see cref="GradientStopSerialized"/> to <see cref="GradientStop"/>.
+        /// </summary>
+        /// <param name="serialized"/>
+        /// <returns/>
         public static implicit operator GradientStop(GradientStopSerialized serialized) => new GradientStop(serialized.Color, serialized.Stop);
 
+        /// <summary>
+        /// Converts from <see cref="GradientStop"/> to <see cref="GradientStopSerialized"/>.
+        /// </summary>
+        /// <param name="stop"/>
+        /// <returns/>
         public static implicit operator GradientStopSerialized(GradientStop stop) =>
             new GradientStopSerialized() {Color = stop.Color, Stop = stop.Stop};
     }
@@ -25,8 +41,16 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct GradientSerialized
     {
+        /// <summary>
+        /// Colors/stop locations that describe the gradient.
+        /// </summary>
         public List<GradientStopSerialized> Stops;
 
+        /// <summary>
+        /// Converts <see cref="GradientSerialized"/> to <see cref="Gradient"/>.
+        /// </summary>
+        /// <param name="serialized"/>
+        /// <returns/>
         public static implicit operator Gradient(GradientSerialized serialized)
         {
 
@@ -36,6 +60,11 @@ namespace SadRogue.Primitives.SerializedTypes
             return new Gradient(colors, stops);
         }
 
+        /// <summary>
+        /// Converts <see cref="Gradient"/> to <see cref="GradientSerialized"/>.
+        /// </summary>
+        /// <param name="gradient"/>
+        /// <returns/>
         public static implicit operator GradientSerialized(Gradient gradient)
             => new GradientSerialized()
             {

--- a/TheSadRogue.Primitives/SerializedTypes/Palette.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Palette.cs
@@ -10,10 +10,23 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct PaletteSerialized
     {
+        /// <summary>
+        /// Colors in the palette.
+        /// </summary>
         public List<ColorSerialized> Colors;
 
+        /// <summary>
+        /// Converts from <see cref="PaletteSerialized"/> to <see cref="Palette"/>.
+        /// </summary>
+        /// <param name="serialized"/>
+        /// <returns/>
         public static implicit operator Palette(PaletteSerialized serialized) => new Palette(serialized.Colors.Select(colorSerialized => (Color)colorSerialized));
 
+        /// <summary>
+        /// Converts from <see cref="Palette"/> to <see cref="PaletteSerialized"/>.
+        /// </summary>
+        /// <param name="palette"/>
+        /// <returns/>
         public static implicit operator PaletteSerialized(Palette palette) =>
             new PaletteSerialized() { Colors = palette.Select(color => (ColorSerialized)color).ToList() };
     }

--- a/TheSadRogue.Primitives/SerializedTypes/Palette.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Palette.cs
@@ -20,7 +20,8 @@ namespace SadRogue.Primitives.SerializedTypes
         /// </summary>
         /// <param name="serialized"/>
         /// <returns/>
-        public static implicit operator Palette(PaletteSerialized serialized) => new Palette(serialized.Colors.Select(colorSerialized => (Color)colorSerialized));
+        public static implicit operator Palette(PaletteSerialized serialized)
+            => new Palette(serialized.Colors.Select(colorSerialized => (Color)colorSerialized));
 
         /// <summary>
         /// Converts from <see cref="Palette"/> to <see cref="PaletteSerialized"/>.
@@ -30,6 +31,4 @@ namespace SadRogue.Primitives.SerializedTypes
         public static implicit operator PaletteSerialized(Palette palette) =>
             new PaletteSerialized() { Colors = palette.Select(color => (ColorSerialized)color).ToList() };
     }
-
-
 }

--- a/TheSadRogue.Primitives/SerializedTypes/Point.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Point.cs
@@ -8,11 +8,30 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct PointSerialized
     {
+        /// <summary>
+        /// X-coordinate of the point.
+        /// </summary>
         public int X;
+
+        /// <summary>
+        /// Y-coordinate of the point.
+        /// </summary>
         public int Y;
 
-        public static implicit operator PointSerialized(Point point) => new PointSerialized() { X = point.X, Y = point.Y };
+        /// <summary>
+        /// Converts from <see cref="Point"/> to <see cref="PointSerialized"/>.
+        /// </summary>
+        /// <param name="point"/>
+        /// <returns/>
+        public static implicit operator PointSerialized(Point point)
+            => new PointSerialized() { X = point.X, Y = point.Y };
 
-        public static implicit operator Point(PointSerialized point) => new Point(point.X, point.Y);
+        /// <summary>
+        /// Converts from <see cref="PointSerialized"/> to <see cref="Point"/>.
+        /// </summary>
+        /// <param name="serialized"/>
+        /// <returns/>
+        public static implicit operator Point(PointSerialized serialized)
+            => new Point(serialized.X, serialized.Y);
     }
 }

--- a/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
@@ -8,11 +8,28 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct RectangleSerialized
     {
+        /// <summary>
+        /// X-coordinate of the minimum extent of the rectangle.
+        /// </summary>
         public int X;
+        /// <summary>
+        /// Y-coordinate of the minimum extent of the rectangle.
+        /// </summary>
         public int Y;
+        /// <summary>
+        /// Width of the rectangle.
+        /// </summary>
         public int Width;
+        /// <summary>
+        /// Height of the rectangle.
+        /// </summary>
         public int Height;
 
+        /// <summary>
+        /// Converts from <see cref="Rectangle"/> to <see cref="RectangleSerialized"/>.
+        /// </summary>
+        /// <param name="rect"/>
+        /// <returns/>
         public static implicit operator RectangleSerialized(Rectangle rect) => new RectangleSerialized()
         {
             X = rect.X,
@@ -21,6 +38,12 @@ namespace SadRogue.Primitives.SerializedTypes
             Height = rect.Height
         };
 
-        public static implicit operator Rectangle(RectangleSerialized rect) => new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
+        /// <summary>
+        /// Converts from <see cref="RectangleSerialized"/> to <see cref="Rectangle"/>.
+        /// </summary>
+        /// <param name="rect"/>
+        /// <returns/>
+        public static implicit operator Rectangle(RectangleSerialized rect)
+            => new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
     }
 }

--- a/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
@@ -12,14 +12,17 @@ namespace SadRogue.Primitives.SerializedTypes
         /// X-coordinate of the minimum extent of the rectangle.
         /// </summary>
         public int X;
+
         /// <summary>
         /// Y-coordinate of the minimum extent of the rectangle.
         /// </summary>
         public int Y;
+
         /// <summary>
         /// Width of the rectangle.
         /// </summary>
         public int Width;
+
         /// <summary>
         /// Height of the rectangle.
         /// </summary>
@@ -32,10 +35,7 @@ namespace SadRogue.Primitives.SerializedTypes
         /// <returns/>
         public static implicit operator RectangleSerialized(Rectangle rect) => new RectangleSerialized()
         {
-            X = rect.X,
-            Y = rect.Y,
-            Width = rect.Width,
-            Height = rect.Height
+            X = rect.X, Y = rect.Y, Width = rect.Width, Height = rect.Height
         };
 
         /// <summary>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
 	<!-- Basic package info -->
-  <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
-  <RootNamespace>SadRogue.Primitives</RootNamespace>
-  <LangVersion>8.0</LangVersion>
-  <Nullable>enable</Nullable>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <RootNamespace>SadRogue.Primitives</RootNamespace>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
 	<Version>1.0.0-alpha4</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
 	<!-- Basic package info -->
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>SadRogue.Primitives</RootNamespace>
+  <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+  <RootNamespace>SadRogue.Primitives</RootNamespace>
+  <LangVersion>8.0</LangVersion>
+  <Nullable>enable</Nullable>
 	<Version>1.0.0-alpha4</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
@@ -41,8 +43,8 @@
   
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
-    <Copy SourceFiles="$(OutputPath)..\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\..\nuget" />
   </Target>
   
   <!-- Run InheritDoc on the final builds. -->

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha4</Version>
+	<Version>1.0.0-alpha5</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -15,7 +15,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
-	<PackageReleaseNotes>Added Pure attributes to appropriate struct functions.  Marked appropriate structs as readonly.  Fixed bug in PositionsInRadius.  Fixed serialization.</PackageReleaseNotes>
+	<PackageReleaseNotes>Updated to C# 8 and .NET Standard 2.1.  Multi-targeted to .NET Core 3.1.  Added missing docstrings.  Removed duplicate XEdgePositions functions, and refactored IsOnXEdge functions to match API.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
- Updated projects to .NET Standard 2.1, C#8, and to enable nullable reference types.
    - Cleaned up code to use new features such as switch expressions, etc.
- Multi-targeted the primitives library and related projects to .NET Standard 2.1 and .NET Core 3.1
    - In combination with the last item, fixes #37 
- Added missing docstrings
    - All functions are now documented.
- Added missing `Subtract(SomeTypeOfPoint, Direction) functions to match the new operator defined by Point a few PRs ago
- Removed duplicate `XEdgePositions` functions from `Rectangle` (fixes #32)
    - Also modified the `IsOnEdge` positions to be a single function `IsOnSide` that takes a side, to match the `PositionsOnSide` API
- Various code cleanup/reformatting
    - Modified read-only properties in `Color` that define color bank to be `readonly` fields
    - Auto-formatted code
    - WARNING: Last commit changes many files in project because of auto-code cleanup.  The second to last commit may make an easier diff to evaluate statically.

