### PR TITLE
Bumped Helper Package Versions

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha2</Version>
+	<Version>1.0.0-alpha3</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -15,7 +15,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-	<PackageReleaseNotes>Added Pure attribute to appropriate struct functions.  Updated SadRogue.Primitives version.</PackageReleaseNotes>
+	<PackageReleaseNotes>Upgraded/multi-targeted to .NET Standard 2.1/.NET Core 3.1.  Updated SadRogue.Primitives version.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -39,8 +39,8 @@
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.0.7" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha4" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1375-develop" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha5" />
   </ItemGroup>
   
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -6,16 +6,16 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha2</Version>
+	<Version>1.0.0-alpha3</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2019 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+	<Copyright>Copyright © 2020 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with SFML's equivalents.</Description>
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>Added Pure attribute to appropriate struct functions.  Updated SadRogue.Primitives version.</PackageReleaseNotes>
+	<PackageReleaseNotes>Upgraded/multi-targeted to .NET Standard 2.1/.NET Core 3.1.  Updated SadRogue.Primitives version.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -28,19 +28,19 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="SFML.Graphics" Version="2.5.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha4" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha5" />
   </ItemGroup>
   
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -28,12 +28,12 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.xml</DocumentationFile>
   </PropertyGroup>
   
   <!-- Dependencies -->


### PR DESCRIPTION
- Bumped compatibility package versions, and pointed them at the new version of the primitives library
- Fixed minor bug with XML docs output in primitives library
- Changed MonoGame compatibility package to reference DesktopGL 3.8-develop, to match SadConsole v9 and avoid the use of unlisted packages.