### PR TITLE
Added rotation methods to points.

### DIFF
--- a/TheSadRogue.Primitives.UnitTests/PointTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/PointTests.cs
@@ -45,7 +45,7 @@ namespace SadRogue.Primitives.UnitTests
         [MemberData(nameof(AroundOtherData))]
         public void RotateAroundOtherPointTest(Point original, Point axis, double degrees, Point expected)
         {
-            Point answer = original.Rotate(axis, degrees);
+            Point answer = original.Rotate(degrees, axis);
             Assert.Equal(expected, answer);
             AssertEquidistant(expected, answer, axis);
         }

--- a/TheSadRogue.Primitives.UnitTests/PointTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/PointTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace SadRogue.Primitives.UnitTests
+{
+    public class PointTests
+    {
+        public static readonly IEnumerable<object[]> AroundZeroZeroData = new List<object[]>()
+        {
+            // { Point to rotate, degrees of rotation, expected result }
+            new object[] { new Point(5,0), 22.5, new Point(5,2) },
+            new object[] { new Point(5,0), 45, new Point(4,4) },
+            new object[] { new Point(5,0), 90, new Point(0,5) },
+            new object[] { new Point(5,0), 107.3, new Point(-1,5) },
+            new object[] { new Point(13,71), 16.75, new Point(-8, 72) },
+            new object[] { new Point(13,71), 137.999, new Point(-57,-44) },
+            new object[] { new Point(13,71), 456.2, new Point(-72,5) },
+            new object[] { new Point(13,71), 0, new Point(13,71) },
+        };
+
+        public static readonly IEnumerable<object[]> AroundOtherData = new List<object[]>()
+        {
+            // { Point to Rotate, Point around which to rotate, degree of rotation, expected result }
+            new object[] { new Point(5,0), new Point(0,5), 22.5, new Point(7,2) },
+            new object[] { new Point(5,0), new Point(5,5), 45, new Point(9,1) },
+            new object[] { new Point(5,0), new Point(8,16), 90, new Point(24,13) },
+            new object[] { new Point(5,0), new Point(13,17), 107.3, new Point(32,14) },
+            new object[] { new Point(13,71), new Point(-100,1), 16.75, new Point(-12, 101) },
+            new object[] { new Point(13,71), new Point(-81,-81), 137.999, new Point(-253,-131) },
+            new object[] { new Point(13,71), new Point(100,157), 456.2, new Point(195,80) },
+            new object[] { new Point(13,71), new Point(13,71), 222, new Point(13,71) },
+        };
+
+        [Theory]
+        [MemberData(nameof(AroundZeroZeroData))]
+        public void RotateAroundZeroZeroTest(Point original, double degrees, Point expected)
+        {
+            Point answer = original.Rotate(degrees);
+            Assert.Equal(expected, answer);
+            AssertEquidistant(expected, answer, (0,0));
+        }
+
+        [Theory]
+        [MemberData(nameof(AroundOtherData))]
+        public void RotateAroundOtherPointTest(Point original, Point axis, double degrees, Point expected)
+        {
+            Point answer = original.Rotate(axis, degrees);
+            Assert.Equal(expected, answer);
+            AssertEquidistant(expected, answer, axis);
+        }
+
+        private void AssertEquidistant(Point expected, Point pointUnderTest, Point center)
+        {
+            expected -= center;
+            pointUnderTest -= center;
+            double expectedDistance = Math.Sqrt(expected.X * expected.X + expected.Y * expected.Y);
+            double distanceUnderTest = Math.Sqrt(pointUnderTest.X * pointUnderTest.X + pointUnderTest.Y * pointUnderTest.Y);
+            Assert.True(expectedDistance > distanceUnderTest - 0.001 && expectedDistance < distanceUnderTest + 0.001);
+        }
+    }
+}

--- a/TheSadRogue.Primitives/MathHelpers.cs
+++ b/TheSadRogue.Primitives/MathHelpers.cs
@@ -36,7 +36,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="degAngle">Angle in degrees.</param>
         /// <returns>The given angle in radians.</returns>
-        public static double ToRadian(double degAngle) => Math.PI * DegreesToRadiansConstant;
+        public static double ToRadian(double degAngle) => degAngle * DegreesToRadiansConstant;
 
         /// <summary>
         /// Restricts a value to a specified range.

--- a/TheSadRogue.Primitives/MathHelpers.cs
+++ b/TheSadRogue.Primitives/MathHelpers.cs
@@ -15,18 +15,28 @@ namespace SadRogue.Primitives
         public const double DegreePctOfCircle = 0.002777777777777778;
 
         /// <summary>
+        /// Pi / 180. Used to speed up calculations related to circles.
+        /// </summary>
+        public const double DegreesToRadiansConstant = Math.PI / 180;
+
+        /// <summary>
+        /// 180 / Pi. Used to speed up calculations related to circles.
+        /// </summary>
+        public const double RadiansToDegreesConstant = 180 / Math.PI;
+
+        /// <summary>
         /// Converts given angle from radians to degrees.
         /// </summary>
         /// <param name="radAngle">Angle in radians.</param>
         /// <returns>The given angle in degrees.</returns>
-        public static double ToDegree(double radAngle) => radAngle * (180.0 / Math.PI);
+        public static double ToDegree(double radAngle) => radAngle * RadiansToDegreesConstant;
 
         /// <summary>
         /// Converts given angle from degrees to radians.
         /// </summary>
         /// <param name="degAngle">Angle in degrees.</param>
         /// <returns>The given angle in radians.</returns>
-        public static double ToRadian(double degAngle) => Math.PI * degAngle / 180.0;
+        public static double ToRadian(double degAngle) => Math.PI * DegreesToRadiansConstant;
 
         /// <summary>
         /// Restricts a value to a specified range.

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -537,15 +537,12 @@ namespace SadRogue.Primitives
 
         #endregion
 
-        #region circules
+        #region circles
         /// <summary>
         /// Returns a Polar Coordinate that is equivalent to this (Cartesian) Coordinate
         /// </summary>
         /// <returns>The Equivalent Polar Coordinate</returns>
-        public PolarCoordinate ToPolarCoordinate()
-        {
-            return PolarCoordinate.FromCartesian(this);
-        }
+        public PolarCoordinate ToPolarCoordinate() => PolarCoordinate.FromCartesian(this);
 
         /// <summary>
         /// Rotates a single point around the origin (0, 0).
@@ -554,7 +551,7 @@ namespace SadRogue.Primitives
         /// <returns>The equivalent point after a rotation</returns>
         public  Point Rotate(in double degrees)
         {
-            double radians = MathHelpers.DegreesToRadiansConstant * degrees;
+            double radians = MathHelpers.ToRadian(degrees);
             int x = (int)Math.Round(X * Math.Cos(radians) - Y * Math.Sin(radians));
             int y = (int)Math.Round(X * Math.Sin(radians) + Y * Math.Cos(radians));
             return new Point(x, y);
@@ -563,13 +560,13 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Rotates a single point around the origin point.
         /// </summary>
-        /// <param name="origin">The Point around which to rotate</param>
         /// <param name="degrees">The amount of Degrees to rotate this point</param>
+        /// <param name="origin">The Point around which to rotate</param>
         /// <returns>The equivalent point after a rotation</returns>
-        public Point Rotate(Point origin, in double degrees)
+        public Point Rotate(in double degrees, Point origin)
         {
             Point rotatingPoint = (X,Y) - origin;
-            double radians = MathHelpers.DegreesToRadiansConstant * degrees;
+            double radians = MathHelpers.ToRadian(degrees);
             int x = (int)Math.Round(rotatingPoint.X * Math.Cos(radians) - rotatingPoint.Y * Math.Sin(radians));
             int y = (int)Math.Round(rotatingPoint.X * Math.Sin(radians) + rotatingPoint.Y * Math.Cos(radians));
             return origin + (x, y);

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -537,7 +537,7 @@ namespace SadRogue.Primitives
 
         #endregion
 
-        #region polar coordinates
+        #region circules
         /// <summary>
         /// Returns a Polar Coordinate that is equivalent to this (Cartesian) Coordinate
         /// </summary>
@@ -545,6 +545,34 @@ namespace SadRogue.Primitives
         public PolarCoordinate ToPolarCoordinate()
         {
             return PolarCoordinate.FromCartesian(this);
+        }
+
+        /// <summary>
+        /// Rotates a single point around the origin (0, 0).
+        /// </summary>
+        /// <param name="degrees">The amount of Degrees to rotate this point clockwise</param>
+        /// <returns>The equivalent point after a rotation</returns>
+        public  Point Rotate(in double degrees)
+        {
+            double radians = MathHelpers.DegreesToRadiansConstant * degrees;
+            int x = (int)Math.Round(X * Math.Cos(radians) - Y * Math.Sin(radians));
+            int y = (int)Math.Round(X * Math.Sin(radians) + Y * Math.Cos(radians));
+            return new Point(x, y);
+        }
+
+        /// <summary>
+        /// Rotates a single point around the origin point.
+        /// </summary>
+        /// <param name="origin">The Point around which to rotate</param>
+        /// <param name="degrees">The amount of Degrees to rotate this point</param>
+        /// <returns>The equivalent point after a rotation</returns>
+        public Point Rotate(Point origin, in double degrees)
+        {
+            Point rotatingPoint = (X,Y) - origin;
+            double radians = MathHelpers.DegreesToRadiansConstant * degrees;
+            int x = (int)Math.Round(rotatingPoint.X * Math.Cos(radians) - rotatingPoint.Y * Math.Sin(radians));
+            int y = (int)Math.Round(rotatingPoint.X * Math.Sin(radians) + rotatingPoint.Y * Math.Cos(radians));
+            return origin + (x, y);
         }
         #endregion
     }


### PR DESCRIPTION
When creating the rotate method for use in GoRogue 3's `Region` class, I needed a method for a single point to rotate. In my haste, I made the method `private` in `Region`. It really belongs in this repository