### PR TITLE
Bugfixes and Equality Unification

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/ColorExtensions.cs
@@ -28,7 +28,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRogueColor self, MonoColor other)
+        public static bool Matches(this SadRogueColor self, MonoColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }
 }
@@ -59,7 +59,7 @@ namespace Microsoft.Xna.Framework
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this MonoColor self, SadRogueColor other)
+        public static bool Matches(this MonoColor self, SadRogueColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }
 }

--- a/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/PointExtensions.cs
@@ -76,7 +76,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRoguePoint self, MonoPoint other) => self.X == other.X && self.Y == other.Y;
+        public static bool Matches(this SadRoguePoint self, MonoPoint other) => self.X == other.X && self.Y == other.Y;
     }
 }
 
@@ -229,6 +229,6 @@ namespace Microsoft.Xna.Framework
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this MonoPoint self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
+        public static bool Matches(this MonoPoint self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 }

--- a/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.MonoGame/RectangleExtensions.cs
@@ -29,7 +29,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRogueRectangle self, MonoRectangle other)
+        public static bool Matches(this SadRogueRectangle self, MonoRectangle other)
             => self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height;
     }
 }
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Framework
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this MonoRectangle self, SadRogueRectangle other)
+        public static bool Matches(this MonoRectangle self, SadRogueRectangle other)
             => self.X == other.X && self.Y == other.Y && self.Width == other.Width && self.Height == other.Height;
     }
 }

--- a/TheSadRogue.Primitives.SFML/ColorExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/ColorExtensions.cs
@@ -28,7 +28,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRogueColor self, SFMLColor other)
+        public static bool Matches(this SadRogueColor self, SFMLColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }
 }
@@ -59,7 +59,7 @@ namespace SFML.Graphics
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SFMLColor self, SadRogueColor other)
+        public static bool Matches(this SFMLColor self, SadRogueColor other)
             => self.R == other.R && self.G == other.G && self.B == other.B && self.A == other.A;
     }
 }

--- a/TheSadRogue.Primitives.SFML/PointExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/PointExtensions.cs
@@ -192,7 +192,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRoguePoint self, Vector2i other) => self.X == other.X && self.Y == other.Y;
+        public static bool Matches(this SadRoguePoint self, Vector2i other) => self.X == other.X && self.Y == other.Y;
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2u"/>.
@@ -202,7 +202,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRoguePoint self, Vector2u other) => self.X == other.X && self.Y == other.Y;
+        public static bool Matches(this SadRoguePoint self, Vector2u other) => self.X == other.X && self.Y == other.Y;
 
         /// <summary>
         /// Compares a <see cref="SadRogue.Primitives.Point"/> to a <see cref="SFML.System.Vector2f"/>.
@@ -212,7 +212,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRoguePoint self, Vector2f other)
+        public static bool Matches(this SadRoguePoint self, Vector2f other)
             => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
     }
 }
@@ -366,7 +366,7 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this Vector2i self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
+        public static bool Matches(this Vector2i self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 
     /// <summary>
@@ -518,7 +518,7 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this Vector2u self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
+        public static bool Matches(this Vector2u self, SadRoguePoint other) => self.X == other.X && self.Y == other.Y;
     }
 
     /// <summary>
@@ -665,7 +665,7 @@ namespace SFML.System
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this Vector2f self, SadRoguePoint other)
+        public static bool Matches(this Vector2f self, SadRoguePoint other)
             => Math.Abs(self.X - other.X) < 0.0000000001 && Math.Abs(self.Y - other.Y) < 0.0000000001;
     }
 }

--- a/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives.SFML/RectangleExtensions.cs
@@ -29,7 +29,7 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this SadRogueRectangle self, IntRect other)
+        public static bool Matches(this SadRogueRectangle self, IntRect other)
             => self.X == other.Left && self.Y == other.Top && self.Width == other.Width && self.Height == other.Height;
     }
 }
@@ -60,7 +60,7 @@ namespace SFML.Graphics
         /// <returns/>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this IntRect self, SadRogueRectangle other)
+        public static bool Matches(this IntRect self, SadRogueRectangle other)
             => self.Left == other.X && self.Top == other.Y && self.Width == other.Width && self.Height == other.Height;
     }
 }

--- a/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
+++ b/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Xunit;
 
@@ -48,5 +50,13 @@ namespace SadRogue.Primitives.UnitTests
         }
 
         public static IEnumerable<T> Enumerable<T>(params T[] objs) => objs;
+
+        public static void NotNull([NotNull]object? obj)
+        {
+            Assert.NotNull(obj);
+            if (obj == null)
+                throw new Exception("Can't happen, prevents compiler from complaining.");
+
+        }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/Serialization/BinaryTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/BinaryTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-using SadRogue.Primitives.SerializedTypes;
 using Xunit;
 using XUnit.ValueTuples;
 
@@ -10,58 +9,11 @@ namespace SadRogue.Primitives.UnitTests.Serialization
 {
     public class BinaryTests
     {
-        public static IEnumerable<object> ExpressiveTypes = new object[]
-        {
-            new AreaSerialized()
-            {
-                Positions = new List<PointSerialized>()
-                {
-                    new PointSerialized() { X = 1, Y = 2 },
-                    new PointSerialized() { X = 6, Y = 7 },
-                    new PointSerialized() { X = 10, Y = 2 }
-                }
-            },
-            new BoundedRectangleSerialized()
-            {
-                Area = new RectangleSerialized() { X = 1, Y = 2, Width = 45, Height = 50 },
-                Bounds = new RectangleSerialized() { X = 0, Y = -1, Width = 100, Height = 101 }
-            },
-            new ColorSerialized() { R = 12, G = 16, B = 45, A = 255 },
-            new GradientStopSerialized()
-            {
-                Color = new ColorSerialized() { R = 10, G = 20, B = 30, A = 40 }, Stop = 0.5f
-            },
-            new GradientSerialized()
-            {
-                Stops = new List<GradientStopSerialized>()
-                {
-                    new GradientStopSerialized()
-                    {
-                        Stop = 0f, Color = new ColorSerialized() { R = 156, G = 24, B = 97, A = 250 }
-                    },
-                    new GradientStopSerialized()
-                    {
-                        Stop = 1f, Color = new ColorSerialized() { R = 100, G = 200, B = 50, A = 25 }
-                    }
-                }
-            },
-            new PaletteSerialized()
-            {
-                Colors = new List<ColorSerialized>()
-                {
-                    new ColorSerialized() { R = 10, G = 34, B = 255, A = 100 },
-                    new ColorSerialized() { R = 67, G = 87, B = 98, A = 156 }
-                }
-            },
-            new PointSerialized() { X = 42, Y = 24 },
-            new RectangleSerialized() { X = 42, Y = 24, Width = 50, Height = 100 }, AdjacencyRule.Types.Cardinals,
-            AdjacencyRule.Types.Diagonals, AdjacencyRule.Types.EightWay, Direction.Types.Up, Direction.Types.Left,
-            Direction.Types.DownRight, Distance.Types.Euclidean, Distance.Types.Chebyshev, Distance.Types.Manhattan,
-            Radius.Types.Square, Radius.Types.Circle, Radius.Types.Diamond
-        };
+        // Tests require the properties used for theories to be in the same class, so we refer to TestData
+        public static IEnumerable<object> BinarySerializableTypes => TestData.BinarySerializableTypes;
 
         [Theory]
-        [MemberDataEnumerable(nameof(ExpressiveTypes))]
+        [MemberDataEnumerable(nameof(BinarySerializableTypes))]
         public void SerializeToDeserializeEquivalence(object objToSerialize)
         {
             Func<object, object, bool> equalityFunc = Comparisons.GetComparisonFunc(objToSerialize);

--- a/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
@@ -11,8 +11,12 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         private static readonly Dictionary<Type, Func<object, object, bool>> _equalityMethods =
             new Dictionary<Type, Func<object, object, bool>>()
             {
+                { typeof(Area), MatchableCompare<IReadOnlyArea> },
                 { typeof(AreaSerialized), AreaSerializedCompare },
+                { typeof(BoundedRectangle), MatchableCompare<BoundedRectangle> },
+                { typeof(Gradient), MatchableCompare<Gradient> },
                 { typeof(GradientSerialized), GradientSerializedCompare },
+                { typeof(Palette), MatchableCompare<Palette> },
                 { typeof(PaletteSerialized), PaletteSerializedCompare }
             };
 
@@ -29,6 +33,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         private static bool GradientSerializedCompare(object o1, object o2)
             => ElementWiseEquality(((GradientSerialized)o1).Stops, ((GradientSerialized)o2).Stops);
 
+        private static bool MatchableCompare<T>(object o1, object o2)
+            where T : class, IMatchable<T>
+            => ((T)o1).Matches((T?)o2);
         private static bool ElementWiseEquality<T>(IEnumerable<T> e1, IEnumerable<T> e2,
                                                    Func<T, T, bool>? compareFunc = null)
         {

--- a/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/DataContractTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using SadRogue.Primitives.SerializedTypes;
 using Xunit;
 using Xunit.Abstractions;
 using XUnit.ValueTuples;
@@ -12,101 +11,22 @@ namespace SadRogue.Primitives.UnitTests.Serialization
 {
     public class DataContractTests
     {
+        // Settings used for serialization/deserialization.  Ensures that things stored as polymorphic types
+        // deserialize properly
+        private static readonly JsonSerializerSettings _settings =
+            new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
+
         #region Test Data
-
-        // Types that serialize to JSON objects via JSON .NET, so we can check which fields are serialized.
-        public static IEnumerable<object> SerializableValuesJsonObjects = new object[]
-        {
-            // AdjacencyRules
-            AdjacencyRule.Cardinals, AdjacencyRule.EightWay,
-            // AreaSerialized
-            (AreaSerialized)new Area((1, 2), (3, 4), (5, 6)),
-            // BoundedRectangle
-            new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
-            // BoundedRectangleSerialized
-            (BoundedRectangleSerialized)new BoundedRectangle(new Rectangle(1, 4, 10, 14),
-                new Rectangle(-10, -9, 100, 101)),
-            // Colors
-            new Color(.5f, .6f, .7f), new Color(120, 121, 122, 100), Color.AliceBlue,
-            // ColorSerialized
-            (ColorSerialized)new Color(.5f, .6f, .7f), (ColorSerialized)new Color(120, 121, 122, 100),
-            (ColorSerialized)Color.AliceBlue,
-            // Directions
-            Direction.Down, Direction.UpRight,
-            // Distances
-            Distance.Chebyshev, Distance.Manhattan,
-            // GradientStop
-            new GradientStop(new Color(100, 101, 102, 103), .5f),
-            // GradientStopSerialized
-            (GradientStopSerialized)new GradientStop(new Color(100, 101, 102, 103), .5f),
-            // GradientSerialized
-            (GradientSerialized)new Gradient(new Color(100, 101, 102, 103), new Color(200, 201, 202, 203)),
-            // PaletteSerialized
-            (PaletteSerialized)new Palette(new[] { new Color(100, 101, 102, 103), new Color(150, 151, 152, 149) }),
-            // Point
-            new Point(-1, -5), new Point(4, 9),
-            // PointSerialized
-            (PointSerialized)new Point(-1, -5), (PointSerialized)new Point(4, 9),
-            // Radiuses
-            Radius.Circle, Radius.Diamond,
-            // Rectangles
-            new Rectangle(1, 2, 3, 4), new Rectangle(-10, -4, 56, 68),
-            // RectangleSerialized
-            (RectangleSerialized)new Rectangle(1, 2, 3, 4), (RectangleSerialized)new Rectangle(-10, -4, 56, 68)
-        };
-
-        // Types that serialize to non-JSON objects (for example, JSON arrays), so we do NOT check for specific fields.
-        public static IEnumerable<object> SerializableValuesNonJsonObjects = new object[]
-        {
-            // AdjacencyRule.Types
-            AdjacencyRule.Types.Cardinals, AdjacencyRule.Types.Diagonals,
-            // Area
-            new Area((1, 2), (3, 4), (5, 6)),
-            // Direction.Types
-            Direction.Types.Down, Direction.Types.Right,
-            // Distance.Types
-            Distance.Types.Chebyshev, Distance.Types.Euclidean,
-            // Gradient
-            new Gradient(new Color(100, 101, 102, 103), new Color(200, 201, 202, 203)),
-            // Palette
-            new Palette(new[] { new Color(100, 101, 102, 103), new Color(150, 151, 152, 149) }),
-            // Radius.Types
-            Radius.Types.Square, Radius.Types.Circle
-        };
-
-        // All JSON objects for which we can test serialization equality
-        public static IEnumerable<object> AllSerializableObjects =
-            SerializableValuesJsonObjects.Concat(SerializableValuesNonJsonObjects);
-
-        // Dictionary of object types to an unordered but complete list of fields that each object type should have serialized
-        // in its JSON object form.
-        private static Dictionary<Type, string[]> typeSerializedFields = new Dictionary<Type, string[]>
-        {
-            { typeof(AdjacencyRule), new[] { "Type" } },
-            { typeof(AreaSerialized), new[] { "Positions" } },
-            { typeof(BoundedRectangle), new[] { "_area", "_boundingBox" } },
-            { typeof(BoundedRectangleSerialized), new[] { "Area", "Bounds" } },
-            { typeof(Color), new[] { "_packedValue" } },
-            { typeof(ColorSerialized), new[] { "R", "G", "B", "A" } },
-            { typeof(Direction), new[] { "Type" } },
-            { typeof(Distance), new[] { "Type" } },
-            { typeof(GradientStop), new[] { "Color", "Stop" } },
-            { typeof(GradientStopSerialized), new[] { "Color", "Stop" } },
-            { typeof(GradientSerialized), new[] { "Stops" } },
-            { typeof(PaletteSerialized), new[] { "Colors" } },
-            { typeof(Point), new[] { "X", "Y" } },
-            { typeof(PointSerialized), new[] { "X", "Y" } },
-            { typeof(Radius), new[] { "Type" } },
-            { typeof(Rectangle), new[] { "X", "Y", "Width", "Height" } },
-            { typeof(RectangleSerialized), new[] { "X", "Y", "Width", "Height" } }
-        };
-
+        // Tests require the properties used for theories to be in the same class, so we refer to TestData
+        public static IEnumerable<object> AllSerializableObjects => TestData.AllSerializableObjects;
+        public static IEnumerable<object> SerializableValuesJsonObjects => TestData.SerializableValuesJsonObjects;
+        public static IEnumerable<object> SerializableValuesNonJsonObjects => TestData.SerializableValuesNonJsonObjects;
         #endregion
 
         // Useful for viewing output
-        private readonly ITestOutputHelper output;
+        private readonly ITestOutputHelper _output;
 
-        public DataContractTests(ITestOutputHelper output) => this.output = output;
+        public DataContractTests(ITestOutputHelper output) => _output = output;
 
         /// <summary>
         /// Tests that if we serialize an object to JSON, then deserialize it back to an object,
@@ -119,22 +39,23 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         public void SerializeToDeserializeEquivalence(object objToSerialize)
         {
             var objType = objToSerialize.GetType();
-            output.WriteLine($"Type is: {objType.Name}");
+            _output.WriteLine($"Type is: {objType.Name}");
 
             // Set equality to custom comparer if we have one, otherwise default to .Equals
             Func<object, object, bool> equality = Comparisons.GetComparisonFunc(objToSerialize);
 
             // Serialize to JSON string
-            string json = JsonConvert.SerializeObject(objToSerialize);
+            string json = JsonConvert.SerializeObject(objToSerialize, _settings);
 
-            output.WriteLine($"Json: {json}");
+            _output.WriteLine("Json:");
+            _output.WriteLine(JToken.Parse(json).ToString(Formatting.Indented));
 
             // Deserialize to object
-            object? deSerialized = JsonConvert.DeserializeObject(json, objType);
-            Assert.NotNull(deSerialized);
+            object? deSerialized = JsonConvert.DeserializeObject(json, objType, _settings);
+            TestUtils.NotNull(deSerialized);
 
             // Make sure the deserialized object is equivalent to the one we serialized
-            Assert.True(equality(objToSerialize, deSerialized!));
+            Assert.True(equality(objToSerialize, deSerialized));
         }
 
         /// <summary>
@@ -147,16 +68,31 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         public void ExpectedFieldsSerialized(object objToSerialize)
         {
             // Serialize to JSON string
-            string json = JsonConvert.SerializeObject(objToSerialize);
+            string json = JsonConvert.SerializeObject(objToSerialize, _settings);
 
             // Get fields in hash set
             var fields = JObject.Parse(json).Properties().Select(i => i.Name).ToHashSet();
 
             // Make hash set from specified fields that _should_ be there
-            var expectedFields = typeSerializedFields[objToSerialize.GetType()].ToHashSet();
+            var expectedFields = TestData.TypeSerializedFields[objToSerialize.GetType()].ToHashSet();
 
             // Ensure expected fields are what we got (in arbitrary order)
             Assert.Equal(expectedFields, fields);
+        }
+
+        // We assume that there are no fields to validate on the objects in the non-objects list,
+        // so we check to make sure they're arrays and thus have no fields.  There may be other types we want to
+        // check for here later
+        [Theory]
+        [MemberDataEnumerable(nameof(SerializableValuesNonJsonObjects))]
+        public void NonJsonObjectsSerializeToJsonArray(object objToSerialize)
+        {
+            // Serialize to JSON string
+            string json = JsonConvert.SerializeObject(objToSerialize, _settings);
+
+            var array = JArray.Parse(json);
+            Assert.NotNull(array);
+            Assert.NotEmpty(array);
         }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/Serialization/ImplicitConversionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/ImplicitConversionTests.cs
@@ -1,119 +1,80 @@
-﻿using SadRogue.Primitives.SerializedTypes;
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
+using Xunit.Abstractions;
+using XUnit.ValueTuples;
 
 namespace SadRogue.Primitives.UnitTests.Serialization
 {
     public class ImplicitConversionTests
     {
-        [Fact]
-        public void AreaToAreaSerialized()
-        {
-            var original = new Area(TestUtils.Enumerable<Point>((1, 2), (3, 4), (5, 6)));
-            AreaSerialized expressive = (AreaSerialized)original;
-            var converted = (Area)expressive;
+        // Required to be in-class so we just forward
+        public static IEnumerable<object> AllNonExpressiveTypes = TestData.AllNonExpressiveTypes;
 
-            Assert.Equal(original, converted);
+        private readonly ITestOutputHelper _output;
+
+        public ImplicitConversionTests(ITestOutputHelper output) => _output = output;
+
+        private static MethodInfo? FindImplicitConversionOnType(Type typeToScan, Type from, Type to)
+        {
+            var methods = typeToScan.GetMethods();
+            foreach (var method in methods)
+            {
+                if (method.IsStatic && method.Name == "op_Implicit" && method.ReturnType == to)
+                {
+                    // Check return type
+                    var methodParams = method.GetParameters();
+                    if (methodParams.Length != 1)
+                        continue;
+
+                    if (methodParams[0].ParameterType == from)
+                        return method;
+                }
+            }
+
+            return null;
+        }
+        private static MethodInfo? FindImplicitConversion(Type from, Type to)
+        {
+            var conversion = FindImplicitConversionOnType(from, from, to);
+            return conversion ?? FindImplicitConversionOnType(to, from, to);
         }
 
-        [Fact]
-        public void BoundedRectangleToBoundedRectangleSerialized()
+        [Theory]
+        [MemberDataEnumerable(nameof(AllNonExpressiveTypes))]
+        public void RegularToSerializedConversion(object original)
         {
-            var original = new BoundedRectangle((1, 2, 9, 11), (-1, -2, 100, 101));
-            BoundedRectangleSerialized expressive = (BoundedRectangleSerialized)original;
-            var converted = (BoundedRectangle)expressive;
+            var originalType = original.GetType();
+            var expressiveType = TestData.RegularToExpressiveTypes[originalType];
+            var equalityFunc = Comparisons.GetComparisonFunc(original);
 
-            Assert.Equal(original, converted);
-        }
+            _output.WriteLine($"Testing expressive conversion from {originalType} to {expressiveType}.");
 
-        [Fact]
-        public void ColorToColorSerialized()
-        {
-            Color original = new Color(23, 25, 27, 67);
-            ColorSerialized expressive = (ColorSerialized)original;
-            Color converted = (Color)expressive;
+            // Retrieve each implicit conversion operator.  We must use reflection because there is no way to add type
+            // constraints that tell the compiler that the object must have these implicit conversions without adding
+            // unnecessary things to the source code.  The conversion operators must be there or it's an error
+            // in the test case, so we check both types.
+            var toExpressive = FindImplicitConversion(originalType, expressiveType);
+            var toOriginal = FindImplicitConversion(expressiveType, originalType);
 
-            Assert.Equal(original, converted);
-        }
+            // Make sure the conversion functions exist
+            TestUtils.NotNull(toExpressive);
+            TestUtils.NotNull(toOriginal);
 
-        [Fact]
-        public void GradientToGradientSerialized()
-        {
-            var original = new Gradient(TestUtils.Enumerable(Color.AliceBlue, Color.Black, Color.Red),
-                TestUtils.Enumerable(0.0f, 0.5f, 1.0f));
-            GradientSerialized expressive = (GradientSerialized)original;
-            var converted = (Gradient)expressive;
+            // Convert to expressive type and assert it returns a valid object of the correct type
+            var expressive = toExpressive.Invoke(null, new[] { original });
+            TestUtils.NotNull(expressive);
+            Assert.Equal(expressiveType, expressive.GetType());
 
-            Assert.Equal(original, converted);
-        }
+            // Convert from the expressive type back to the original and assert it returns a valid object
+            // of the correct type
+            var converted = toOriginal.Invoke(null, new[] { expressive });
+            TestUtils.NotNull(converted);
+            Assert.Equal(originalType, converted.GetType());
 
-        [Fact]
-        public void PaletteToPaletteSerialized()
-        {
-            var original = new Palette(TestUtils.Enumerable(Color.AliceBlue, Color.Red, Color.Black, Color.Yellow));
-            PaletteSerialized expressive = (PaletteSerialized)original;
-            var converted = (Palette)expressive;
-
-            Assert.Equal(original, converted);
-        }
-
-        [Fact]
-        public void PointToPointSerialized()
-        {
-            Point original = new Point(1, 2);
-            PointSerialized expressive = (PointSerialized)original;
-            Point converted = (Point)expressive;
-
-            Assert.Equal(original, converted);
-        }
-
-        [Fact]
-        public void RectangleToRectangleSerialized()
-        {
-            Rectangle original = new Rectangle(1, 2, 34, 20);
-            RectangleSerialized expressive = (RectangleSerialized)original;
-            Rectangle converted = (Rectangle)expressive;
-
-            Assert.Equal(original, converted);
-        }
-
-        [Fact]
-        public void AdjacencyRuleToType()
-        {
-            AdjacencyRule original = AdjacencyRule.Diagonals;
-            AdjacencyRule.Types expressive = (AdjacencyRule.Types)original;
-            AdjacencyRule converted = (AdjacencyRule)expressive;
-
-            Assert.Equal(original, converted);
-        }
-
-        [Fact]
-        public void DirectionToType()
-        {
-            Direction original = Direction.None;
-            Direction.Types expressive = (Direction.Types)original;
-            Direction converted = (Direction)expressive;
-
-            Assert.Equal(original, converted);
-        }
-
-        [Fact]
-        public void DistanceToType()
-        {
-            Distance original = Distance.Euclidean;
-            Distance.Types expressive = (Distance.Types)original;
-            Distance converted = (Distance)expressive;
-
-            Assert.Equal(original, converted);
-        }
-
-        [Fact]
-        public void RadiusToType()
-        {
-            Radius original = Radius.Circle;
-            Radius.Types expressive = (Radius.Types)original;
-            Radius converted = (Radius)expressive;
-
-            Assert.Equal(original, converted);
+            // Assert the type is equivalent after conversion as compared to before
+            Assert.True(equalityFunc(original, converted));
         }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SadRogue.Primitives.SerializedTypes;
+
+namespace SadRogue.Primitives.UnitTests.Serialization
+{
+    public static class TestData
+    {
+        #region Original Data
+        /// <summary>
+        /// List of expressive versions of types.  The assumptions here are:
+        ///     1. All types in this list are serializable via generic data contract serialization
+        ///     2. All types in this list serialize to JSON objects (JObject) when using Newtonsoft.Json
+        /// </summary>
+        private static readonly IEnumerable<object> _expressiveTypes = new object[]
+        {
+            // AreaSerialized
+            new AreaSerialized
+            {
+                Positions = new List<PointSerialized>
+                {
+                    new PointSerialized { X = 1, Y = 2 },
+                    new PointSerialized { X = 3, Y = 4 },
+                    new PointSerialized { X = 5, Y = 6 }
+                }
+            },
+            // BoundedRectangleSerialized
+            new BoundedRectangleSerialized
+            {
+                Area = new RectangleSerialized {X = 1, Y = 4, Width = 10, Height = 14},
+                Bounds = new RectangleSerialized {X = -10, Y = -1, Width = 100, Height = 101 }
+            },
+            // ColorSerialized
+            new ColorSerialized  { R = 120, G = 121, B = 122, A = 150 },
+            // GradientStopSerialized
+            new GradientStopSerialized
+            {
+                Color = new ColorSerialized { R = 100, G = 101, B = 102, A = 103 },
+                Stop = 0.5f
+            },
+            // GradientSerialized
+            new GradientSerialized
+            {
+                Stops = new List<GradientStopSerialized>
+                {
+                    new GradientStopSerialized
+                    {
+                        Color = new ColorSerialized { R = 100, G = 101, B = 102, A = 103 },
+                        Stop = 0.5f
+                    },
+                    new GradientStopSerialized
+                    {
+                        Color = new ColorSerialized {R = 200, G = 201, B = 202, A = 203 },
+                        Stop = 1.0f
+                    }
+                }
+            },
+            // PaletteSerialized
+            new PaletteSerialized
+            {
+                Colors = new List<ColorSerialized>
+                {
+                    new ColorSerialized { R = 100, G = 101, B = 102, A = 103 },
+                    new ColorSerialized {R = 200, G = 201, B = 202, A = 203 }
+                }
+            },
+            // PointSerialized
+            new PointSerialized { X = 10, Y = 20 },
+            // RectangleSerialized
+            new RectangleSerialized { X = 10, Y = 20, Width = 100, Height = 200 }
+        };
+
+        /// <summary>
+        /// Any expressive types (ones that implicitly convert for the sake of serialization), that don't serialize
+        /// to JSON Object (generally instead serialize to primitive types like integers).
+        /// </summary>
+        private static readonly IEnumerable<object> _expressivePrimitiveTypes = new object[]
+        {
+            // AdjacencyRule.Types
+            AdjacencyRule.Types.Cardinals, AdjacencyRule.Types.Diagonals,
+            // Direction.Types
+            Direction.Types.Down, Direction.Types.Right,
+            // Distance.Types
+            Distance.Types.Chebyshev, Distance.Types.Euclidean,
+            // Radius.Types
+            Radius.Types.Square, Radius.Types.Circle,
+        };
+
+        /// <summary>
+        /// List of all non-expressive types that serialize to JSON objects (JObject)
+        /// </summary>
+        private static readonly object[] _nonExpressiveJsonObjects =
+        {
+            // AdjacencyRules
+            AdjacencyRule.Cardinals, AdjacencyRule.EightWay,
+            // BoundedRectangle
+            new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
+            // Colors
+            new Color(.5f, .6f, .7f), new Color(120, 121, 122, 100), Color.AliceBlue,
+            // Directions
+            Direction.Down, Direction.UpRight,
+            // Distances
+            Distance.Chebyshev, Distance.Manhattan,
+            // GradientStop
+            new GradientStop(new Color(100, 101, 102, 103), .5f),
+            // Points
+            new Point(-1, -5), new Point(4, 9),
+            // Polar Coordinates
+            new PolarCoordinate(10.0, 0.25), new PolarCoordinate(5.0, 3 * Math.PI / 2.0),
+            // Radii
+            Radius.Circle, Radius.Diamond,
+            // Rectangles
+            new Rectangle(1, 2, 3, 4), new Rectangle(-10, -4, 56, 68),
+        };
+
+        /// <summary>
+        /// Dictionary of object types to an unordered but complete list of fields that each object type should have
+        /// serialized in its JSON object form.  All objects in SerializableValuesJsonObjects should have an entry here.
+        /// </summary>
+        public static readonly Dictionary<Type, string[]> TypeSerializedFields = new Dictionary<Type, string[]>
+        {
+            { typeof(AdjacencyRule), new[] { "Type" } },
+            { typeof(AreaSerialized), new[] { "Positions" } },
+            { typeof(BoundedRectangle), new[] { "_area", "_boundingBox" } },
+            { typeof(BoundedRectangleSerialized), new[] { "Area", "Bounds" } },
+            { typeof(Color), new[] { "_packedValue" } },
+            { typeof(ColorSerialized), new[] { "R", "G", "B", "A" } },
+            { typeof(Direction), new[] { "Type" } },
+            { typeof(Distance), new[] { "Type" } },
+            { typeof(GradientStop), new[] { "Color", "Stop" } },
+            { typeof(GradientStopSerialized), new[] { "Color", "Stop" } },
+            { typeof(GradientSerialized), new[] { "Stops" } },
+            { typeof(PaletteSerialized), new[] { "Colors" } },
+            { typeof(Point), new[] { "X", "Y" } },
+            { typeof(PointSerialized), new[] { "X", "Y" } },
+            { typeof(PolarCoordinate), new[] { "Radius", "Theta" } },
+            { typeof(PolarCoordinateSerialized), new[] { "Radius", "Theta" } },
+            { typeof(Radius), new[] { "Type" } },
+            { typeof(Rectangle), new[] { "X", "Y", "Width", "Height" } },
+            { typeof(RectangleSerialized), new[] { "X", "Y", "Width", "Height" } }
+        };
+
+        /// <summary>
+        /// Objects that are JSON serializable but should NOT serialize to JSON objects (instead, for example,
+        /// JSON array)
+        /// </summary>
+        public static readonly IEnumerable<object> SerializableValuesNonJsonObjects = new object[]
+        {
+            // Area
+            new Area((1, 2), (3, 4), (5, 6)),
+            // Gradient
+            new Gradient(new Color(100, 101, 102, 103), new Color(200, 201, 202, 203)),
+            // Palette
+            new Palette(new[] { new Color(100, 101, 102, 103), new Color(150, 151, 152, 149) }),
+        };
+
+
+        /// <summary>
+        /// Dictionary of non-expressive types to their expressive type
+        /// </summary>
+        public static readonly Dictionary<Type, Type> RegularToExpressiveTypes = new Dictionary<Type, Type>
+        {
+            [typeof(AdjacencyRule)] = typeof(AdjacencyRule.Types),
+            [typeof(Area)] = typeof(AreaSerialized),
+            [typeof(BoundedRectangle)] = typeof(BoundedRectangleSerialized),
+            [typeof(Color)] = typeof(ColorSerialized),
+            [typeof(Direction)] = typeof(Direction.Types),
+            [typeof(Distance)] = typeof(Distance.Types),
+            [typeof(GradientStop)] = typeof(GradientStopSerialized),
+            [typeof(Gradient)] = typeof(GradientSerialized),
+            [typeof(Palette)] = typeof(PaletteSerialized),
+            [typeof(Point)] = typeof(PointSerialized),
+            [typeof(PolarCoordinate)] = typeof(PolarCoordinateSerialized),
+            [typeof(Radius)] = typeof(Radius.Types),
+            [typeof(Rectangle)] = typeof(RectangleSerialized)
+        };
+
+
+        /// <summary>
+        /// List of non-serializable objects that do have serializable equivalents (expressive types).
+        /// </summary>
+        private static readonly object[] _nonSerializableValuesWithExpressiveTypes = { };
+        #endregion
+
+        #region Combinatory Data
+
+        /// <summary>
+        /// All types that should serialize with binary serializers.
+        /// </summary>
+        public static IEnumerable<object> BinarySerializableTypes => _expressiveTypes.Concat(_expressivePrimitiveTypes);
+
+        /// <summary>
+        /// All objects that should serialize to JSON objects.  All should have entries in TypeSerializedFields
+        /// </summary>
+        public static IEnumerable<object> SerializableValuesJsonObjects
+            => _expressiveTypes.Concat(_nonExpressiveJsonObjects);
+
+        /// <summary>
+        /// Objects that should have expressive versions of types.  Each item must have an entry in
+        /// RegularToExpressiveTypes
+        /// </summary>
+        public static IEnumerable<object> AllNonExpressiveTypes
+            => _nonExpressiveJsonObjects.Concat(SerializableValuesNonJsonObjects).Concat(_nonSerializableValuesWithExpressiveTypes);
+
+        /// <summary>
+        /// All JSON objects for which we can test serialization equality
+        /// </summary>
+        public static IEnumerable<object> AllSerializableObjects =>
+            SerializableValuesJsonObjects.Concat(SerializableValuesNonJsonObjects);
+        #endregion
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
@@ -67,6 +67,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             },
             // PointSerialized
             new PointSerialized { X = 10, Y = 20 },
+            // PolarCoordinateSerialized
+            new PolarCoordinateSerialized { Radius = 5.0, Theta = 3 * Math.PI / 2.0 },
             // RectangleSerialized
             new RectangleSerialized { X = 10, Y = 20, Width = 100, Height = 200 }
         };

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -11,7 +11,7 @@ namespace SadRogue.Primitives
     /// static instances are provided.
     /// </summary>
     [DataContract]
-    public readonly struct AdjacencyRule : IEquatable<AdjacencyRule>
+    public readonly struct AdjacencyRule : IEquatable<AdjacencyRule>, IMatchable<AdjacencyRule>
     {
         /// <summary>
         /// Represents method of determining adjacency where neighbors are considered adjacent if
@@ -218,6 +218,14 @@ namespace SadRogue.Primitives
                         $"{nameof(DirectionsOfNeighborsCounterClockwise)} does not support AdjacencyRule type {Type} -- this is a bug!");
             }
         }
+
+        /// <summary>
+        /// True if the given AdjacencyRule has the same Type the current one.
+        /// </summary>
+        /// <param name="other">AdjacencyRule to compare.</param>
+        /// <returns>True if the two directions are the same, false if not.</returns>
+        [Pure]
+        public bool Matches(AdjacencyRule other) => Equals(other);
 
         /// <summary>
         /// Gets all neighbors of the specified location, based on the current adjacency method.

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -139,14 +139,6 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
-        /// Inequality comparison -- true if the two areas do NOT contain exactly the same points.
-        /// </summary>
-        /// <param name="lhs"/>
-        /// <param name="rhs"/>
-        /// <returns>True if the areas do NOT contain exactly the same points, false otherwise.</returns>
-        public static bool operator !=(Area lhs, Area rhs) => !(lhs == rhs);
-
-        /// <summary>
         /// Creates an area with the positions all shifted by the given vector.
         /// </summary>
         /// <param name="lhs"/>
@@ -167,27 +159,25 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Compares for equality. Returns true if the two areas contain exactly the same points.
         /// </summary>
-        /// <param name="lhs"/>
-        /// <param name="rhs"/>
+        /// <param name="other"/>
         /// <returns>True if the areas contain exactly the same points, false otherwise.</returns>
-        public static bool operator ==(Area? lhs, Area? rhs)
+        public bool Matches(IReadOnlyArea? other)
         {
-            if (ReferenceEquals(lhs, rhs))
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
                 return true;
 
-            // If one side is null (can't both be null or above would have returned)
-            if (lhs is null || rhs is null)
-                return false;
-
             // Quick checks that can short-circuit a function that would otherwise require looping over all points
-            if (lhs.Count != rhs.Count)
+            if (Count != other.Count)
                 return false;
 
-            if (lhs.Bounds != rhs.Bounds)
+            if (Bounds != other.Bounds)
                 return false;
 
-            foreach (Point pos in lhs.Positions)
-                if (!rhs.Contains(pos))
+            foreach (Point pos in Positions)
+                if (!other.Contains(pos))
                     return false;
 
             return true;
@@ -280,22 +270,6 @@ namespace SadRogue.Primitives
 
             return true;
         }
-
-        /// <summary>
-        /// Returns true if the given object is an Area and the two areas contain exactly the same points,
-        /// false otherwise.
-        /// </summary>
-        /// <param name="obj">Object to compare</param>
-        /// <returns>
-        /// True if the object given is a area and contains exactly the same points, false otherwise.
-        /// </returns>
-        public override bool Equals(object? obj) => obj is Area area && this == area;
-
-        /// <summary>
-        /// Returns hash of the underlying set
-        /// </summary>
-        /// <returns>Hash code for the underlying set.</returns>
-        public override int GetHashCode() => _positionsSet.GetHashCode();
 
         /// <summary>
         /// Returns whether or not the given map area intersects the current one. If you intend to

--- a/TheSadRogue.Primitives/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/BoundedRectangle.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace SadRogue.Primitives
 {
@@ -9,7 +8,7 @@ namespace SadRogue.Primitives
     /// keeping track of a camera's view area.
     /// </summary>
     [DataContract]
-    public class BoundedRectangle : IEquatable<BoundedRectangle>
+    public class BoundedRectangle : IMatchable<BoundedRectangle>
     {
         [DataMember] private Rectangle _area;
         // A bug in code cleanup will add the readonly modifier to this field even though it would break the BoundingBox property at compile-time,
@@ -48,47 +47,8 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">BoundedRectangle to compare.</param>
         /// <returns>True if the two BoundedRectangles are the same, false if not.</returns>
-        public bool Equals(BoundedRectangle? other)
+        public bool Matches(BoundedRectangle? other)
             => !ReferenceEquals(other, null) && _area == other._area && _boundingBox == other._boundingBox;
-
-        /// <summary>
-        /// Same as operator == in this case; returns false if <paramref name="obj" /> is not a BoundedRectangle.
-        /// </summary>
-        /// <param name="obj">The object to compare the current BoundedRectangle to.</param>
-        /// <returns>
-        /// True if <paramref name="obj" /> is a BoundedRectangle, and the two BoundedRectangles are the same, false otherwise.
-        /// </returns>
-        public override bool Equals(object? obj) => obj is BoundedRectangle c && Equals(c);
-
-        /// <summary>
-        /// Returns a hash-map value for the current object based on <see cref="Area"/> and <see cref="BoundingBox"/>.
-        /// If instances are being used in a hash table or dictionary, you MUST NOT change either of those properties
-        /// once it has been added to the collection.
-        /// </summary>
-        /// <returns />
-        public override int GetHashCode()
-            // ReSharper disable once NonReadonlyMemberInGetHashCode
-            => _area.GetHashCode() ^
-               // ReSharper disable once NonReadonlyMemberInGetHashCode
-               _boundingBox.GetHashCode();
-
-        /// <summary>
-        /// True if the two BoundedRectangle objects are equivalent.
-        /// </summary>
-        /// <param name="lhs" />
-        /// <param name="rhs" />
-        /// <returns>True if the two BoundedRectangle objects are equivalent, false if not.</returns>
-        public static bool operator ==(BoundedRectangle? lhs, BoundedRectangle? rhs) => lhs?.Equals(rhs) ?? rhs is null;
-
-        /// <summary>
-        /// True if the types are not equal.
-        /// </summary>
-        /// <param name="lhs" />
-        /// <param name="rhs" />
-        /// <returns>
-        /// True if the types are not equal, false if they are both equal.
-        /// </returns>
-        public static bool operator !=(BoundedRectangle lhs, BoundedRectangle rhs) => !(lhs == rhs);
 
         /// <summary>
         /// Forces the area given to conform to the <see cref="BoundingBox" /> specified and sets it to <see cref="Area" />.

--- a/TheSadRogue.Primitives/BoundedRectangle.cs
+++ b/TheSadRogue.Primitives/BoundedRectangle.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace SadRogue.Primitives
 {
@@ -47,7 +48,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="other">BoundedRectangle to compare.</param>
         /// <returns>True if the two BoundedRectangles are the same, false if not.</returns>
-        public bool Matches(BoundedRectangle? other)
+        public bool Matches([AllowNull]BoundedRectangle other)
             => !ReferenceEquals(other, null) && _area == other._area && _boundingBox == other._boundingBox;
 
         /// <summary>

--- a/TheSadRogue.Primitives/Color.cs
+++ b/TheSadRogue.Primitives/Color.cs
@@ -16,7 +16,7 @@ namespace SadRogue.Primitives
     /// </summary>
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
-    public readonly struct Color : IEquatable<Color>
+    public readonly struct Color : IEquatable<Color>, IMatchable<Color>
     {
         static Color()
         {
@@ -1273,6 +1273,14 @@ namespace SadRogue.Primitives
                 (int)MathHelpers.Lerp(value1.B, value2.B, amount),
                 (int)MathHelpers.Lerp(value1.A, value2.A, amount));
         }
+
+        /// <summary>
+        /// Returns true if the colors represent the same color values.
+        /// </summary>
+        /// <param name="other"/>
+        /// <returns/>
+        [Pure]
+        public bool Matches(Color other) => Equals(other);
 
         /// <summary>
         /// Multiply <see cref="Color"/> by value.

--- a/TheSadRogue.Primitives/ColorExtensions.cs
+++ b/TheSadRogue.Primitives/ColorExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// Contains set of operators that match ones defined by other packages for interoperability,
+    /// so syntax may be uniform.  Functionality is similar to the corresponding actual operators for Color.
+    /// </summary>
+    public static class ColorExtensions
+    {
+        /// <summary>
+        /// Compares a two colors for equality.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
+        public static bool Matches(this Color self, Color other) => self.Equals(other);
+    }
+}

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -24,7 +24,7 @@ namespace SadRogue.Primitives
     /// coordinate plane defined by Unity and other game engines.
     /// </remarks>
     [DataContract]
-    public readonly struct Direction : IEquatable<Direction>
+    public readonly struct Direction : IEquatable<Direction>, IMatchable<Direction>
     {
         private static readonly string[] s_writeVals = Enum.GetNames(typeof(Types));
 
@@ -213,6 +213,14 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public override int GetHashCode() => Type.GetHashCode();
+
+        /// <summary>
+        /// True if the given direction has the same Type the current one.
+        /// </summary>
+        /// <param name="other">Direction to compare.</param>
+        /// <returns>True if the two directions are the same, false if not.</returns>
+        [Pure]
+        public bool Matches(Direction other) => Equals(other);
 
         /// <summary>
         /// True if the two directions have the same Type.

--- a/TheSadRogue.Primitives/Distance.cs
+++ b/TheSadRogue.Primitives/Distance.cs
@@ -17,7 +17,7 @@ namespace SadRogue.Primitives
     /// locations and a radius shape are implied by a distance calculation).
     /// </remarks>
     [DataContract]
-    public readonly struct Distance : IEquatable<Distance>
+    public readonly struct Distance : IEquatable<Distance>, IMatchable<Distance>
     {
         /// <summary>
         /// Represents chebyshev distance (equivalent to 8-way movement with no extra cost for diagonals).
@@ -205,6 +205,14 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public override int GetHashCode() => Type.GetHashCode();
+
+        /// <summary>
+        /// True if the given Distance has the same Type the current one.
+        /// </summary>
+        /// <param name="other">Distance to compare.</param>
+        /// <returns>True if the two distance calculation methods are the same, false if not.</returns>
+        [Pure]
+        public bool Matches(Distance other) => Equals(other);
 
         /// <summary>
         /// True if the two Distances have the same Type.

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -81,7 +81,7 @@ namespace SadRogue.Primitives
     /// Represents a gradient with multiple color stops.
     /// </summary>
     [DataContract]
-    public class Gradient : IEnumerable<GradientStop>
+    public class Gradient : IEnumerable<GradientStop>, IMatchable<Gradient>
     {
         /// <summary>
         /// The color stops that define the gradient.
@@ -247,48 +247,26 @@ namespace SadRogue.Primitives
         public static implicit operator Gradient(Color color) => new Gradient(color, color);
 
         /// <summary>
-        /// Returns true if the object is a gradient that contains precisely the same stops.
-        /// </summary>
-        /// <param name="obj"/>
-        /// <returns>True if the object is a gradient that contains precisely the same stops; false otherwise</returns>
-        public override bool Equals(object? obj) => obj is Gradient gradient && this == gradient;
-
-        /// <summary>
-        /// Returns a hash code based on the gradient's stops.
-        /// </summary>
-        /// <returns>A hash code based on the gradient's stops.</returns>
-        public override int GetHashCode() => Stops.GetHashCode();
-
-        /// <summary>
         /// Returns true if the given gradients contain precisely the same stops.
         /// </summary>
-        /// <param name="g1"/>
-        /// <param name="g2"/>
+        /// <param name="other"/>
         /// <returns>True if the given gradients contain precisely the same stops; false otherwise.</returns>
-        public static bool operator ==(Gradient? g1, Gradient? g2)
+        public bool Matches(Gradient? other)
         {
-            if (ReferenceEquals(g1, g2))
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
                 return true;
 
-            if (g1 is null || g2 is null)
+            if (Stops.Length != other.Stops.Length)
                 return false;
 
-            if (g1.Stops.Length != g2.Stops.Length)
-                return false;
-
-            for (int i = 0; i < g1.Stops.Length; i++)
-                if (g1.Stops[i] != g2.Stops[i])
+            for (int i = 0; i < Stops.Length; i++)
+                if (Stops[i] != other.Stops[i])
                     return false;
 
             return true;
         }
-
-        /// <summary>
-        /// Returns true if the gradients have a different sequence of stops.
-        /// </summary>
-        /// <param name="g1"/>
-        /// <param name="g2"/>
-        /// <returns>True if the gradients have a different sequence of stops; false otherwise.</returns>
-        public static bool operator !=(Gradient g1, Gradient g2) => !(g1 == g2);
     }
 }

--- a/TheSadRogue.Primitives/Gradient.cs
+++ b/TheSadRogue.Primitives/Gradient.cs
@@ -11,7 +11,7 @@ namespace SadRogue.Primitives
     /// A gradient stop. Defines a color and where it is located within the gradient.
     /// </summary>
     [DataContract]
-    public readonly struct GradientStop : IEquatable<GradientStop>
+    public readonly struct GradientStop : IEquatable<GradientStop>, IMatchable<GradientStop>
     {
         /// <summary>
         /// The color.
@@ -75,6 +75,14 @@ namespace SadRogue.Primitives
         /// <returns>True if this gradient stop and the specified one have the same color and stop values; false otherwise.</returns>
         [Pure]
         public bool Equals(GradientStop g) => Color == g.Color && Math.Abs(Stop - g.Stop) < 0.0000000001;
+
+        /// <summary>
+        /// Compares this gradient stop to the one given.
+        /// </summary>
+        /// <param name="other"/>
+        /// <returns>True if this gradient stop and the specified one have the same color and stop values; false otherwise.</returns>
+        [Pure]
+        public bool Matches(GradientStop other) => Equals(other);
     }
 
     /// <summary>

--- a/TheSadRogue.Primitives/IMatchable.cs
+++ b/TheSadRogue.Primitives/IMatchable.cs
@@ -1,12 +1,13 @@
-﻿namespace SadRogue.Primitives
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace SadRogue.Primitives
 {
     /// <summary>
-    /// Interface implemented by mutable reference types to implement an equality comparison that doesn't make
-    /// guarantees about GetHashCode.
+    /// Interface implemented to define a form of checking value equality, without guarantees that it corresponds
+    /// to GetHashCode.
     /// </summary>
     /// <typeparam name="T">Type of object being compared.</typeparam>
     public interface IMatchable<in T>
-        where T : class
     {
         /// <summary>
         /// Returns true if the given object is considered "equal" to the current one, based on the definition
@@ -14,6 +15,6 @@
         /// </summary>
         /// <param name="other">Object to compare to.</param>
         /// <returns>True if the objects are considered equal, false, otherwise.</returns>
-        bool Matches(T? other);
+        bool Matches([AllowNull]T other);
     }
 }

--- a/TheSadRogue.Primitives/IMatchable.cs
+++ b/TheSadRogue.Primitives/IMatchable.cs
@@ -1,0 +1,19 @@
+﻿namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// Interface implemented by mutable reference types to implement an equality comparison that doesn't make
+    /// guarantees about GetHashCode.
+    /// </summary>
+    /// <typeparam name="T">Type of object being compared.</typeparam>
+    public interface IMatchable<in T>
+        where T : class
+    {
+        /// <summary>
+        /// Returns true if the given object is considered "equal" to the current one, based on the definition
+        /// of equality for the object.
+        /// </summary>
+        /// <param name="other">Object to compare to.</param>
+        /// <returns>True if the objects are considered equal, false, otherwise.</returns>
+        bool Matches(T? other);
+    }
+}

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -5,7 +5,7 @@ namespace SadRogue.Primitives
     /// <summary>
     /// Read-only interface for an arbitrary 2D area.
     /// </summary>
-    public interface IReadOnlyArea
+    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>
     {
         /// <summary>
         /// Smallest possible rectangle that encompasses every position in the area.

--- a/TheSadRogue.Primitives/Palette.cs
+++ b/TheSadRogue.Primitives/Palette.cs
@@ -10,7 +10,7 @@ namespace SadRogue.Primitives
     /// A palette of colors.
     /// </summary>
     [DataContract]
-    public class Palette : IEnumerable<Color>
+    public class Palette : IEnumerable<Color>, IMatchable<Palette>
     {
         [DataMember] private readonly Color[] _colors;
 
@@ -138,48 +138,26 @@ namespace SadRogue.Primitives
         IEnumerator IEnumerable.GetEnumerator() => _colors.GetEnumerator();
 
         /// <summary>
-        /// True if the given object is a Palette and its colors are identical and in the same order.
-        /// </summary>
-        /// <param name="obj"/>
-        /// <returns>True if the given object is a Palette and its colors are identical and in the same order; false otherwise.</returns>
-        public override bool Equals(object? obj) => obj is Palette palette && this == palette;
-
-        /// <summary>
-        /// Returns hash code based on the colors.
-        /// </summary>
-        /// <returns>Hash code for the object based on the colors.</returns>
-        public override int GetHashCode() => _colors.GetHashCode();
-
-        /// <summary>
         /// Returns true if the two palettes hold identical colors in the same order.
         /// </summary>
-        /// <param name="p1"/>
-        /// <param name="p2"/>
+        /// <param name="other"/>
         /// <returns>True if the two palettes hold identical colors in the same order; false otherwise.</returns>
-        public static bool operator ==(Palette? p1, Palette? p2)
+        public bool Matches(Palette? other)
         {
-            if (ReferenceEquals(p1, p2))
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
                 return true;
 
-            if (p1 is null || p2 is null)
+            if (Length != other.Length)
                 return false;
 
-            if (p1.Length != p2.Length)
-                return false;
-
-            for (int i = 0; i < p1.Length; i++)
-                if (p1[i] != p2[i])
+            for (int i = 0; i < Length; i++)
+                if (this[i] != other[i])
                     return false;
 
             return true;
         }
-
-        /// <summary>
-        /// Returns true if the two palettes have different colors or the same colors in a different order.
-        /// </summary>
-        /// <param name="p1"/>
-        /// <param name="p2"/>
-        /// <returns>True if the two palettes have different colors or the same colors in a different order; false otherwise.</returns>
-        public static bool operator !=(Palette p1, Palette p2) => !(p1 == p2);
     }
 }

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -586,7 +586,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="degrees">The amount of Degrees to rotate this point clockwise</param>
         /// <returns>The equivalent point after a rotation</returns>
-        public  Point Rotate(in double degrees)
+        public  Point Rotate(double degrees)
         {
             double radians = MathHelpers.ToRadian(degrees);
             int x = (int)Math.Round(X * Math.Cos(radians) - Y * Math.Sin(radians));
@@ -600,9 +600,9 @@ namespace SadRogue.Primitives
         /// <param name="degrees">The amount of Degrees to rotate this point</param>
         /// <param name="origin">The Point around which to rotate</param>
         /// <returns>The equivalent point after a rotation</returns>
-        public Point Rotate(in double degrees, Point origin)
+        public Point Rotate(double degrees, Point origin)
         {
-            Point rotatingPoint = (X,Y) - origin;
+            Point rotatingPoint = this - origin;
             double radians = MathHelpers.ToRadian(degrees);
             int x = (int)Math.Round(rotatingPoint.X * Math.Cos(radians) - rotatingPoint.Y * Math.Sin(radians));
             int y = (int)Math.Round(rotatingPoint.X * Math.Sin(radians) + rotatingPoint.Y * Math.Cos(radians));

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -12,13 +12,14 @@ namespace SadRogue.Primitives
     /// <remarks>
     /// Point instances can be created using the standard Point c = new Point(x, y) syntax.  In addition,
     /// you may create a coord from a c# 7 tuple, like Point c = (x, y);.  As well, Point supports C#
-    /// Deconstrution syntax.
+    /// Deconstruction syntax.
     ///
     /// Point also provides operators and static helper functions that perform common grid math/operations,
     /// as well as interoperability with other grid-based classes like <see cref="Direction"/>.
     /// </remarks>
     [DataContract]
-    public readonly struct Point : IEquatable<Point>, IEquatable<(int x, int y)>
+    public readonly struct Point : IEquatable<Point>, IEquatable<(int x, int y)>, IMatchable<Point>,
+                                   IMatchable<(int x, int y)>
     {
         /// <summary>
         /// Point value that represents None or no position (since Point is not a nullable type).
@@ -119,6 +120,13 @@ namespace SadRogue.Primitives
         public static double EuclideanDistanceMagnitude(Point deltaChange)
             => deltaChange.X * deltaChange.X + deltaChange.Y * deltaChange.Y;
 
+        /// <summary>
+        /// True if the given coordinate has equal x and y values to the current one.
+        /// </summary>
+        /// <param name="other">Position to compare.</param>
+        /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
+        public bool Matches(Point other) => Equals(other);
 
         /// <summary>
         /// Returns the midpoint between the two points.
@@ -542,11 +550,18 @@ namespace SadRogue.Primitives
         /// <summary>
         /// True if the given position has equal x and y values to the current one.
         /// </summary>
-        /// <param name="other">Point to compare.</param>
+        /// <param name="other">Tuple to compare.</param>
         /// <returns>True if the two positions are equal, false if not.</returns>
         [Pure]
         public bool Equals((int x, int y) other) => X == other.x && Y == other.y;
 
+        /// <summary>
+        /// True if the given position has equal x and y values to the current one.
+        /// </summary>
+        /// <param name="other">Point to compare.</param>
+        /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
+        public bool Matches((int x, int y) other) => Equals(other);
         #endregion
 
         #region Circles

--- a/TheSadRogue.Primitives/PointExtensions.cs
+++ b/TheSadRogue.Primitives/PointExtensions.cs
@@ -128,5 +128,15 @@ namespace SadRogue.Primitives
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Point Divide(this Point self, double d) => self / d;
+
+        /// <summary>
+        /// Compares the two points for equality; equivalent to <see cref="Point.Equals(Point)"/>.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns>True if the two points are equal; false otherwise.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Matches(this Point self, Point other) => self.Equals(other);
     }
 }

--- a/TheSadRogue.Primitives/PolarCoordinate.cs
+++ b/TheSadRogue.Primitives/PolarCoordinate.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 
 namespace SadRogue.Primitives
 {
@@ -12,20 +13,21 @@ namespace SadRogue.Primitives
     /// See wikipedia: https://en.wikipedia.org/wiki/Polar_coordinate_system
     /// Polar Coordinates are very, very slow and should not be used often
     /// </remarks>
+    [DataContract]
     public readonly struct PolarCoordinate : IEquatable<PolarCoordinate>
     {
         /// <summary>
         /// The distance away from the Origin (0,0) of this Polar Coord
         /// </summary>
-        public readonly double Radius;
+        [DataMember] public readonly double Radius;
 
         /// <summary>
         /// The angle of rotation, clockwise, in radians
         /// </summary>
-        public readonly double Theta; //in degrees clockwise
+        [DataMember] public readonly double Theta; //in degrees clockwise
 
         /// <summary>
-        /// Creates a new Polaar Coordinate with the given Radius and Theta
+        /// Creates a new Polar Coordinate with the given Radius and Theta
         /// </summary>
         /// <param name="radius">Radius of the Polar Coord</param>
         /// <param name="theta">Degree of rotation (clockwise) of the Polar Coord</param>

--- a/TheSadRogue.Primitives/PolarCoordinate.cs
+++ b/TheSadRogue.Primitives/PolarCoordinate.cs
@@ -14,7 +14,8 @@ namespace SadRogue.Primitives
     /// Polar Coordinates are very, very slow and should not be used often
     /// </remarks>
     [DataContract]
-    public readonly struct PolarCoordinate : IEquatable<PolarCoordinate>
+    public readonly struct PolarCoordinate : IEquatable<PolarCoordinate>, IMatchable<PolarCoordinate>,
+                                             IEquatable<(double radius, double theta)>, IMatchable<(double radius, double theta)>
     {
         /// <summary>
         /// The distance away from the Origin (0,0) of this Polar Coord
@@ -71,7 +72,7 @@ namespace SadRogue.Primitives
         public override int GetHashCode() => Math.Round(Radius, 5).GetHashCode() ^ Math.Round(Theta, 5).GetHashCode();
 
         /// <summary>
-        /// Performs  comparison between this PolarCoordinate and an other
+        /// Performs comparison between this PolarCoordinate and an other
         /// </summary>
         /// <param name="other">The other Polar Coordinate to analyze</param>
         /// <returns>Whether these two PolarCoordinates are equal</returns>
@@ -90,6 +91,14 @@ namespace SadRogue.Primitives
                 return this == polar;
             return false;
         }
+
+        /// <summary>
+        /// Performs comparison between this PolarCoordinate and an other
+        /// </summary>
+        /// <param name="other">The other Polar Coordinate to analyze</param>
+        /// <returns>Whether these two PolarCoordinates are equal</returns>
+        [Pure]
+        public bool Matches(PolarCoordinate other) => Equals(other);
 
         /// <summary>
         /// Implicitly converts the polar coordinate to its cartesian plane equivalent.
@@ -120,8 +129,99 @@ namespace SadRogue.Primitives
             return new PolarCoordinate(radius, theta);
         }
 
+        #region Tuple Compatibility
+
         /// <summary>
-        /// A handly list of example polar functions for you.
+        /// Adds support for C# Deconstruction syntax.
+        /// </summary>
+        /// <param name="radius" />
+        /// <param name="theta" />
+        [Pure]
+        public void Deconstruct(out double radius, out double theta)
+        {
+            radius = Radius;
+            theta = Theta;
+        }
+
+        /// <summary>
+        /// Implicitly converts a PolarCoordinate to an equivalent tuple of two doubles.
+        /// </summary>
+        /// <param name="c" />
+        /// <returns />
+        [Pure]
+        public static implicit operator (double radius, double theta)(PolarCoordinate c) => (c.Radius, c.Theta);
+
+        /// <summary>
+        /// Implicitly converts a tuple of two doubles to an equivalent PolarCoordinate.
+        /// </summary>
+        /// <param name="tuple" />
+        /// <returns />
+        [Pure]
+        public static implicit operator PolarCoordinate((double radius, double theta) tuple)
+            => new PolarCoordinate(tuple.radius, tuple.theta);
+
+        /// <summary>
+        /// Compares the values in this polar coordinate to the specified values.
+        /// </summary>
+        /// <param name="other"/>
+        /// <returns/>
+        public bool Equals((double radius, double theta) other)
+            => Math.Round(Theta - other.theta, 5) == 0.0 && Math.Round(Radius - other.radius, 5) == 0.0;
+
+        /// <summary>
+        /// Compares the values in this polar coordinate to the specified values.
+        /// </summary>
+        /// <param name="other"/>
+        /// <returns/>
+        public bool Matches((double radius, double theta) other) => Equals(other);
+
+        /// <summary>
+        /// True if the two polar coordinates' radius and theta values are close enough to equal.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <param name="tuple"></param>
+        /// <returns>True if the two polar coordinates are equivalent, false if not.</returns>
+        [Pure]
+        public static bool operator ==(PolarCoordinate c, (double radius, double theta) tuple) => c.Equals(tuple);
+
+        /// <summary>
+        /// True if either the radius or theta values aren't equivalent.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <param name="tuple"></param>
+        /// <returns>
+        /// True if either the radius or theta values are not equal, false if they are both equal.
+        /// </returns>
+        [Pure]
+        public static bool operator !=(PolarCoordinate c, (double radius, double theta) tuple)
+            => !(c == tuple);
+
+        /// <summary>
+        /// True if the two polar coordinate's values are equivalent.
+        /// </summary>
+        /// <param name="tuple"></param>
+        /// <param name="c"></param>
+        /// <returns>True if the two polar coordinates are equal, false if not.</returns>
+        [Pure]
+        public static bool operator ==((double radius, double theta) tuple, PolarCoordinate c)
+            => c.Equals(tuple);
+
+        /// <summary>
+        /// True if either the radius or theta values are not equal.
+        /// </summary>
+        /// <param name="tuple"></param>
+        /// <param name="c"></param>
+        /// <returns>
+        /// True if either the radius or theta values are not equal, false if they are both equal.
+        /// </returns>
+        [Pure]
+        public static bool operator !=((double radius, double theta) tuple, PolarCoordinate c)
+            => !(tuple == c);
+
+        #endregion
+
+        /// <summary>
+        /// A handy list of example polar functions for you.
         /// </summary>
         /// <remarks>
         /// This list contains several examples of Polar Coordinates you can use.

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -18,7 +18,7 @@ namespace SadRogue.Primitives
     /// shape).
     /// </remarks>
     [DataContract]
-    public readonly struct Radius : IEquatable<Radius>
+    public readonly struct Radius : IEquatable<Radius>, IMatchable<Radius>
     {
         /// <summary>
         /// Radius is a circle around the center point. CIRCLE would represent movement radius in
@@ -194,6 +194,13 @@ namespace SadRogue.Primitives
         /// <returns/>
         [Pure]
         public override int GetHashCode() => Type.GetHashCode();
+
+        /// <summary>
+        /// True if the given Radius has the same Type the current one.
+        /// </summary>
+        /// <param name="other">Radius to compare.</param>
+        /// <returns>True if the two radius shapes are the same, false if not.</returns>
+        public bool Matches(Radius other) => Equals(other);
 
         /// <summary>
         /// True if the two radius shapes have the same Type.

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -11,7 +11,9 @@ namespace SadRogue.Primitives
     /// involving rectangles.
     /// </summary>
     [DataContract]
-    public readonly struct Rectangle : IEquatable<Rectangle>, IEquatable<(int x, int y, int width, int height)>
+    public readonly struct Rectangle : IEquatable<Rectangle>, IEquatable<(int x, int y, int width, int height)>,
+                                       IMatchable<Rectangle>, IMatchable<(int x, int y, int width, int height)>,
+                                       IEquatable<(Point minExtent, Point maxExtent)>, IMatchable<(Point minExtent, Point maxExtent)>
     {
         /// <summary>
         /// The empty rectangle. Has origin of (0, 0) with 0 width and height.
@@ -447,6 +449,17 @@ namespace SadRogue.Primitives
                                                    other.Y < Y + Height && Y < other.Y + other.Height;
 
         /// <summary>
+        /// Compares based upon whether or not the areas contained within the rectangle are identical
+        /// in both position and extents.
+        /// </summary>
+        /// <param name="other"/>
+        /// <returns>
+        /// true if the area of the two rectangles encompass the exact same area, false otherwise.
+        /// </returns>
+        [Pure]
+        public bool Matches(Rectangle other) => Equals(other);
+
+        /// <summary>
         /// Creates and returns a new rectangle that has its <see cref="Position"/> moved to the given position.
         /// </summary>
         /// <param name="position">The position for the new rectangle.</param>
@@ -741,6 +754,14 @@ namespace SadRogue.Primitives
         public bool Equals((int x, int y, int width, int height) other)
             => X == other.x && Y == other.y && Width == other.width && Height == other.height;
 
+        /// <summary>
+        /// True if the given position has equal x and y values to the current one.
+        /// </summary>
+        /// <param name="other">Point to compare.</param>
+        /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
+        public bool Matches((int x, int y, int width, int height) other) => Equals(other);
+
         #endregion
 
         #region (minExtent, maxExtent)
@@ -825,6 +846,14 @@ namespace SadRogue.Primitives
         [Pure]
         public bool Equals((Point minExtent, Point maxExtent) other)
             => MinExtent == other.minExtent && MaxExtent == other.maxExtent;
+
+        /// <summary>
+        /// True if the given position has equal x and y values to the current one.
+        /// </summary>
+        /// <param name="other">Point to compare.</param>
+        /// <returns>True if the two positions are equal, false if not.</returns>
+        [Pure]
+        public bool Matches((Point minExtent, Point maxExtent) other) => Equals(other);
 
         #endregion
 

--- a/TheSadRogue.Primitives/RectangleExtensions.cs
+++ b/TheSadRogue.Primitives/RectangleExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// Contains set of operators that match ones defined by other packages for interoperability,
+    /// so syntax may be uniform.  Functionality is similar to the corresponding actual operators for Color.
+    /// </summary>
+    public static class RectangleExtensions
+    {
+        /// <summary>
+        /// Compares a two rectangles for equality.
+        /// </summary>
+        /// <param name="self"/>
+        /// <param name="other"/>
+        /// <returns/>
+        public static bool Matches(this Rectangle self, Rectangle other) => self.Equals(other);
+    }
+}

--- a/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace SadRogue.Primitives.SerializedTypes
+{
+    /// <summary>
+    /// Serializable (pure-data) object representing a <see cref="PolarCoordinate"/>.
+    /// </summary>
+    [Serializable]
+    public struct PolarCoordinateSerialized
+    {
+        /// <summary>
+        /// The distance away from the Origin (0,0) of this Polar Coord
+        /// </summary>
+        public double Radius;
+
+        /// <summary>
+        /// The angle of rotation, clockwise, in radians
+        /// </summary>
+        public double Theta;
+
+        /// <summary>
+        /// Converts from <see cref="PolarCoordinate"/> to <see cref="PolarCoordinateSerialized"/>.
+        /// </summary>
+        /// <param name="point"/>
+        /// <returns/>
+        public static implicit operator PolarCoordinateSerialized(PolarCoordinate point)
+            => new PolarCoordinateSerialized { Radius = point.Radius, Theta = point.Theta };
+
+        /// <summary>
+        /// Converts from <see cref="PolarCoordinateSerialized"/> to <see cref="PolarCoordinate"/>.
+        /// </summary>
+        /// <param name="serialized"/>
+        /// <returns/>
+        public static implicit operator PolarCoordinate(PolarCoordinateSerialized serialized)
+            => new PolarCoordinate(serialized.Radius, serialized.Theta);
+    }
+}

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -12,7 +12,7 @@
 	<Company>TheSadRogue</Company>
 	<Copyright>Copyright © 2020 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of primitive data structures for working with a 2-dimensional grid.</Description>
-	
+
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>Added rotation method to points.  Added functions for bisection/division to Rectangle.  Changed ANSI colors to be readonly.  Small optimizations to PolarCoordinate.  Added AggressiveInline attribute to appropriate methods.  Corrected nullability of equality operations.  Removed equality operations from mutable types, and replaced with IMatchable implementations.</PackageReleaseNotes>
@@ -35,18 +35,18 @@
     <DefineConstants>TRACE</DefineConstants>
     <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.xml</DocumentationFile>
   </PropertyGroup>
-  
+
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
-  
+
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
     <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
     <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
   </Target>
-  
+
   <!-- Run InheritDoc on the final builds. -->
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT'">
 	<Exec Command="dotnet tool restore" />

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha5</Version>
+	<Version>1.0.0-alpha6</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -15,7 +15,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
-	<PackageReleaseNotes>Updated to C# 8 and .NET Standard 2.1.  Multi-targeted to .NET Core 3.1.  Added missing docstrings.  Removed duplicate XEdgePositions functions, and refactored IsOnXEdge functions to match API.  Added polar coordinates.</PackageReleaseNotes>
+	<PackageReleaseNotes>Added rotation method to points.  Added functions for bisection/division to Rectangle.  Changed ANSI colors to be readonly.  Small optimizations to PolarCoordinate.  Added AggressiveInline attribute to appropriate methods.  Corrected nullability of equality operations.  Removed equality operations from mutable types, and replaced with IMatchable implementations.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
- Added full serialization system support to `PolarCoordinate`
- Added tuple compatibility functions to `PolarCoordinate`
- Created and utilized new `IMatchable<T>` interface for defining mutable type equality comparisons (fixes #44)
    - Removed `IEquatable<T>` implementations from all mutable types
    - Removed `Equals`, `operator==`, `operator!=`, and `GetHashCode` implementations from all mutable types
    - Replaced all above function with `IMatchable<T>` implementation
    - Implemented `IMatchable<T>` on immutable types (mirroring `Equals`) to provide parity
- Renamed `Equals` extension methods to `Matches`, and added extension methods for built in types (fixes #50)
- Refactored unit tests to deal with `IMatchable<T>` and correctly test all serialization aspects
- Bumped version number and changelog to prepare for release
