### PR TITLE
Version Bumps/Prep for Integration Package Release

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha3</Version>
+	<Version>1.0.0-alpha4</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -15,7 +15,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-	<PackageReleaseNotes>Upgraded/multi-targeted to .NET Standard 2.1/.NET Core 3.1.  Updated SadRogue.Primitives version.</PackageReleaseNotes>
+	<PackageReleaseNotes>Updated SadRogue.Primitives version.  Updated MonoGame package version to non-prerelease. Modified extension methods for equality to be named Matches to avoid ambiguitiy in calls.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -38,9 +38,9 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1375-develop" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha5" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha6" />
   </ItemGroup>
   
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha3</Version>
+	<Version>1.0.0-alpha4</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -15,7 +15,7 @@
 	
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>Upgraded/multi-targeted to .NET Standard 2.1/.NET Core 3.1.  Updated SadRogue.Primitives version.</PackageReleaseNotes>
+	<PackageReleaseNotes>Updated SadRogue.Primitives version.  Modified extension methods for equality to be named Matches to avoid ambiguitiy in calls.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -40,7 +40,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="SFML.Graphics" Version="2.5.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha5" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0-alpha6" />
   </ItemGroup>
   
   <!-- When packing, copy the nuget files to the nuget output directory -->


### PR DESCRIPTION
- Bumped version of the primitives library used by the integration packages to most recent
- Bumped version numbers of integration packages (prep for release)
- Bumped version of MonoGame used by the MonoGame integration package to the non-develop version that supports .NET Standard