### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/PointHashes.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashes.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    public class CustomHashComparer : IEqualityComparer<Point>
+    {
+        private Func<Point, int> _hashFunc;
+
+        public CustomHashComparer(Func<Point, int> hashFunc)
+        {
+            _hashFunc = hashFunc;
+        }
+
+        public bool Equals(Point x, Point y) => x.Equals(y);
+
+        public int GetHashCode(Point obj) => _hashFunc(obj);
+    }
+
+    public class PointHashes
+    {
+        [Params(10, 50, 100, 175, 256)]
+        public int Size;
+
+        // Initialized by global setup so nullability is suppressed
+        private Point[] _points = null!;
+        private Dictionary<Point, int> _getDictCurrentPrimitives = null!;
+        private Dictionary<Point, int> _getDictOldGoRogue = null!;
+        private Dictionary<Point, int> _getDictRosenbergStrong = null!;
+        private Dictionary<Point, int> _getDictRosenbergStrongOneLess = null!;
+
+        // Executed once per value of parameters
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            // Create array of appropriate size and populate
+            _points = new Point[Size * Size];
+            for (int i = 0; i < _points.Length; i++)
+                _points[i] = Point.FromIndex(i, Size);
+
+            // Create dictionaries with appropriate values for use with the get tests
+            _getDictCurrentPrimitives = new Dictionary<Point, int>(new CustomHashComparer(CurrentPrimitivesHash));
+            _getDictOldGoRogue = new Dictionary<Point, int>(new CustomHashComparer(OldGoRogueHash));
+            _getDictRosenbergStrong = new Dictionary<Point, int>(new CustomHashComparer(RosenbergStrongBasedHash));
+            _getDictRosenbergStrongOneLess = new Dictionary<Point, int>(new CustomHashComparer(RosenbergStrongBasedOneLessMultHash));
+            foreach (var p in _points)
+            {
+                int value = p.ToIndex(Size);
+                _getDictCurrentPrimitives[p] = value;
+                _getDictOldGoRogue[p] = value;
+                _getDictRosenbergStrong[p] = value;
+                _getDictRosenbergStrongOneLess[p] = value;
+            }
+        }
+
+        #region TimeToHash
+
+        [Benchmark]
+        public int SumPrimitivesHashing() => SumHashesAlgorithm(CurrentPrimitivesHash);
+
+        [Benchmark]
+        public int SumOldGoRogueAlgorithm() => SumHashesAlgorithm(OldGoRogueHash);
+
+        [Benchmark]
+        public int SumRosenbergStrongBasedAlgorithm() => SumHashesAlgorithm(RosenbergStrongBasedHash);
+
+        [Benchmark]
+        public int SumRosenbergStrongBasedOneLessMultAlgorithm() => SumHashesAlgorithm(RosenbergStrongBasedOneLessMultHash);
+
+        private int SumHashesAlgorithm(Func<Point, int> hashingAlgo)
+        {
+            int sum = 0;
+            for (int i = 0; i < _points.Length; i++)
+                sum += hashingAlgo(_points[i]);
+
+            return sum;
+        }
+        #endregion
+
+        #region AddToDictionary
+
+        [Benchmark]
+        public Dictionary<Point, int> PrimitivesHashingAdd() => AddToDict(CurrentPrimitivesHash);
+
+        [Benchmark]
+        public Dictionary<Point, int> OldGoRogueHashingAdd() => AddToDict(OldGoRogueHash);
+
+        [Benchmark]
+        public Dictionary<Point, int> RosenbergStrongBasedAdd() => AddToDict(RosenbergStrongBasedHash);
+
+        [Benchmark]
+        public Dictionary<Point, int> RosenbergStrongBasedOneLessAdd() => AddToDict(RosenbergStrongBasedOneLessMultHash);
+
+        private Dictionary<Point, int> AddToDict(Func<Point, int> hashFunc)
+        {
+            var dict = new Dictionary<Point, int>(new CustomHashComparer(hashFunc));
+            for (int i = 0; i < _points.Length; i++)
+                dict[_points[i]] = i;
+
+            return dict;
+        }
+        #endregion
+
+        #region GetFromDictionary
+        [Benchmark]
+        public int PrimitivesHashingGet() => GetFromDict(_getDictCurrentPrimitives);
+
+        [Benchmark]
+        public int OldGoRogueHashingGet() => GetFromDict(_getDictOldGoRogue);
+
+        [Benchmark]
+        public int RosenbergStrongBasedGet() => GetFromDict(_getDictRosenbergStrong);
+
+        [Benchmark]
+        public int RosenbergStrongBasedOneLessMultGet() => GetFromDict(_getDictRosenbergStrongOneLess);
+
+        private int GetFromDict(Dictionary<Point, int> dict)
+        {
+            int sum = 0;
+            for (int i = 0; i < _points.Length; i++)
+                sum += dict[_points[i]];
+
+            return sum;
+        }
+        #endregion
+
+        #region Hashing Algorithms
+        private int CurrentPrimitivesHash(Point p) => p.GetHashCode();
+        private int OldGoRogueHash(Point p)
+        {
+            // Intentional overflow on both of these, part of hash-code generation
+            int x2 = (int)(0x9E3779B9 * p.X), y2 = 0x632BE5AB * p.Y;
+            return (int)(((uint)(x2 ^ y2) >> ((x2 & 7) + (y2 & 7))) * 0x85157AF5);
+        }
+
+        private int RosenbergStrongBasedHash(Point p)
+        {
+            int x = p.X + 3, y = p.Y + 3, n = (x >= y ? x * (x + 2) - y : y * y + x);
+            return (int)(((n ^ (uint)n >> 1 ^ 0xD1B54A35) * 0xC13FA9AB ^ 0x7F4A7C15) * 0x91E10DA3);
+        }
+
+        private int RosenbergStrongBasedOneLessMultHash(Point p)
+        {
+            int x = p.X + 3, y = p.Y + 3, n = (x >= y ? x * (x + 2) - y : y * y + x);
+            return (int)((n ^ (uint)n >> 1 ^ 0xD1B54A35) * 0xC13FA9AB ^ 0x7F4A7C15);
+        }
+        #endregion
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/Program.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Program.cs
@@ -1,0 +1,10 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    class Program
+    {
+        private static void Main(string[] args)
+            => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
+++ b/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/TheSadRogue.Primitives.UnitTests/GridViews/DiffAwareGridViewTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/DiffAwareGridViewTests.cs
@@ -328,6 +328,36 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             Assert.Equal(2, view.CurrentDiffIndex);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FinalizeWithNoDiffs(bool autoCompress)
+        {
+            // Create a new grid view
+            var view = new DiffAwareGridView<int>(80, 25, autoCompress);
+
+            // Attempt to finalize with 0 diffs.  This should do nothing, since it leaves a valid operational
+            // state and is a valid operation, but there is no diff to mark.
+            view.FinalizeCurrentDiff();
+
+            // Should still be no diffs
+            Assert.Equal(-1, view.CurrentDiffIndex);
+            Assert.Empty(view.Diffs);
+
+            // Should also work with next-or-finalize
+            Assert.False(view.ApplyNextDiffOrFinalize());
+
+            // Should still be no diffs
+            Assert.Equal(-1, view.CurrentDiffIndex);
+            Assert.Empty(view.Diffs);
+
+            // Creating changes should still create a new diff as normal
+            view[1, 2] = 10;
+            view[2, 3] = 11;
+            Assert.Equal(0, view.CurrentDiffIndex);
+            Assert.Single(view.Diffs);
+        }
+
         [Fact]
         public void SetHistory()
         {

--- a/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
@@ -117,6 +117,7 @@ namespace SadRogue.Primitives.UnitTests
             Point center = (25, 20);
             int radius = 10;
 
+            // ReSharper disable once RedundantCast
             Distance dist = (Distance)shape;
 
             var positions = shape.PositionsInRadius(center, radius).ToList();
@@ -144,6 +145,7 @@ namespace SadRogue.Primitives.UnitTests
             Point center = (5, 7);
             int radius = 10;
 
+            // ReSharper disable once RedundantCast
             Distance dist = (Distance)shape;
 
             var positions = shape.PositionsInRadius(center, radius, bounds).ToList();

--- a/TheSadRogue.Primitives.sln
+++ b/TheSadRogue.Primitives.sln
@@ -20,6 +20,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "TheSadRogue.Primitives.Unit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TheSadRogue.Primitives.SFML", "TheSadRogue.Primitives.SFML\TheSadRogue.Primitives.SFML.csproj", "{F44C9E24-0CFD-49F1-A704-25E5AEDA9D55}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheSadRogue.Primitives.PerformanceTests", "TheSadRogue.Primitives.PerformanceTests\TheSadRogue.Primitives.PerformanceTests.csproj", "{BF099A36-E225-442A-94E4-15AA97BB0E48}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems*{1921edde-6ff1-42c9-ac69-a09074b1cfaa}*SharedItemsImports = 5
@@ -51,6 +53,10 @@ Global
 		{F44C9E24-0CFD-49F1-A704-25E5AEDA9D55}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F44C9E24-0CFD-49F1-A704-25E5AEDA9D55}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F44C9E24-0CFD-49F1-A704-25E5AEDA9D55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF099A36-E225-442A-94E4-15AA97BB0E48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF099A36-E225-442A-94E4-15AA97BB0E48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF099A36-E225-442A-94E4-15AA97BB0E48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF099A36-E225-442A-94E4-15AA97BB0E48}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TheSadRogue.Primitives/AdjacencyRule.cs
+++ b/TheSadRogue.Primitives/AdjacencyRule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace SadRogue.Primitives
@@ -242,6 +243,18 @@ namespace SadRogue.Primitives
 
         /// <summary>
         /// Gets all neighbors of the specified location, based on the current adjacency method.
+        /// Cardinals are returned before any diagonals.
+        /// </summary>
+        /// <param name="startingLocationX">X-value of the location to return neighbors for.</param>
+        /// <param name="startingLocationY">Y-value of the location to return neighbors for.</param>
+        /// <returns>All neighbors of the given location.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Pure]
+        public IEnumerable<Point> Neighbors(int startingLocationX, int startingLocationY)
+            => Neighbors(new Point(startingLocationX, startingLocationY));
+
+        /// <summary>
+        /// Gets all neighbors of the specified location, based on the current adjacency method.
         /// Neighbors are returned in clockwise order, starting with the neighbor in the given
         /// starting direction.
         /// </summary>
@@ -259,6 +272,26 @@ namespace SadRogue.Primitives
             foreach (Direction dir in DirectionsOfNeighborsClockwise(startingDirection))
                 yield return startingLocation + dir;
         }
+
+        /// <summary>
+        /// Gets all neighbors of the specified location, based on the current adjacency method.
+        /// Neighbors are returned in clockwise order, starting with the neighbor in the given
+        /// starting direction.
+        /// </summary>
+        /// <param name="startingLocationX">X-value of the location to return neighbors for.</param>
+        /// <param name="startingLocationY">Y-value of the location to return neighbors for.</param>
+        /// <param name="startingDirection">
+        /// The neighbor in this direction will be returned first, proceeding clockwise.
+        /// If <see cref="Direction.None"/> is specified, the default starting direction
+        /// is used, which is <see cref="Direction.Up"/> for CARDINALS/EIGHT_WAY, and <see cref="Direction.UpRight"/>
+        /// for DIAGONALS.
+        /// </param>
+        /// <returns>All neighbors of the given location.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IEnumerable<Point> NeighborsClockwise(int startingLocationX, int startingLocationY,
+                                                     Direction startingDirection = default)
+            => NeighborsClockwise(new Point(startingLocationX, startingLocationY), startingDirection);
 
         /// <summary>
         /// Gets all neighbors of the specified location, based on the current adjacency method.
@@ -280,6 +313,26 @@ namespace SadRogue.Primitives
             foreach (Direction dir in DirectionsOfNeighborsCounterClockwise(startingDirection))
                 yield return startingLocation + dir;
         }
+
+        /// <summary>
+        /// Gets all neighbors of the specified location, based on the current adjacency method.
+        /// Neighbors are returned in counter-clockwise order, starting with the neighbor in the given
+        /// starting direction.
+        /// </summary>
+        /// <param name="startingLocationX">X-value of the location to return neighbors for.</param>
+        /// <param name="startingLocationY">Y-value of the location to return neighbors for.</param>
+        /// <param name="startingDirection">
+        /// The neighbor in this direction will be returned first, proceeding counter-clockwise.
+        /// If <see cref="Direction.None"/> is specified, the default starting direction
+        /// is used, which is <see cref="Direction.Up"/> for CARDINALS/EIGHT_WAY, and
+        /// <see cref="Direction.UpLeft"/> for DIAGONALS.
+        /// </param>
+        /// <returns>All neighbors of the given location.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IEnumerable<Point> NeighborsCounterClockwise(int startingLocationX, int startingLocationY,
+                                                            Direction startingDirection = default)
+            => NeighborsCounterClockwise(new Point(startingLocationX, startingLocationY), startingDirection);
 
         /// <summary>
         /// True if the given AdjacencyRule has the same Type the current one.

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -214,6 +214,19 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
+        /// Adds the given position to the list of points within the area if it is not already in the
+        /// list, or does nothing otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Because the class uses a hash set internally to determine what points have already been added,
+        /// this is an average case O(1) operation.
+        /// </remarks>
+        /// <param name="positionX">X-value of the position to add.</param>
+        /// <param name="positionY">Y-value of the position to add.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(int positionX, int positionY) => Add(new Point(positionX, positionY));
+
+        /// <summary>
         /// Adds the given positions to the list of points within the area if they are not already in
         /// the list.
         /// </summary>
@@ -251,6 +264,15 @@ namespace SadRogue.Primitives
         /// <returns>True if the specified position is within the area, false otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(Point position) => _positionsSet.Contains(position);
+
+        /// <summary>
+        /// Determines whether or not the given position is within the area or not.
+        /// </summary>
+        /// <param name="positionX">X-value of the position to check.</param>
+        /// <param name="positionY">Y-value of the position to check.</param>
+        /// <returns>True if the specified position is within the area, false otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Contains(int positionX, int positionY) => Contains(new Point(positionX, positionY));
 
         /// <summary>
         /// Returns whether or not the given area is completely contained within the current one.
@@ -308,6 +330,16 @@ namespace SadRogue.Primitives
         /// <param name="position">The position to remove.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Remove(Point position) => Remove(YieldPoint(position));
+
+        /// <summary>
+        /// Removes the given position specified from the area. Particularly when the remove operation
+        /// operation changes the bounds, this operation can be expensive, so if you must do multiple
+        /// remove operations, it would be best to group them into 1 using <see cref="Remove(IEnumerable{Point})"/>.
+        /// </summary>
+        /// <param name="positionX">X-value of the position to remove.</param>
+        /// <param name="positionY">Y-value of the position to remove.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Remove(int positionX, int positionY) => Remove(YieldPoint(new Point(positionX, positionY)));
 
         /// <summary>
         /// Removes positions for which the given predicate returns true from the area.

--- a/TheSadRogue.Primitives/Direction.cs
+++ b/TheSadRogue.Primitives/Direction.cs
@@ -310,6 +310,24 @@ namespace SadRogue.Primitives
             => GetCardinalDirection(new Point(end.X - start.X, end.Y - start.Y));
 
         /// <summary>
+        /// Returns the cardinal direction that most closely matches the degree heading of the given
+        /// line. Rounds clockwise if the heading is exactly on a diagonal direction. Similar to
+        /// <see cref="GetDirection(Point, Point)"/>, except this function returns only cardinal directions.
+        /// </summary>
+        /// <param name="startX">X-value of the starting coordinate of the line.</param>
+        /// <param name="startY">Y-value of the starting coordinate of the line.</param>
+        /// <param name="endX">X-value of the ending coordinate of the line.</param>
+        /// <param name="endY">Y-value of the ending coordinate of the line.</param>
+        /// <returns>
+        /// The cardinal direction that most closely matches the heading indicated by the given line.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Direction GetCardinalDirection(int startX, int startY, int endX, int endY)
+            => GetCardinalDirection(new Point(startX, startY), new Point(endX, endY));
+
+
+        /// <summary>
         /// Returns the cardinal direction that most closely matches the degree heading of a line
         /// with the given delta-change values. Rounds clockwise if exactly on a diagonal. Similar to
         /// <see cref="GetDirection(Point)"/>, except this function returns only cardinal directions.
@@ -353,6 +371,20 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
+        /// Returns the cardinal direction that most closely matches the degree heading of a line
+        /// with the given delta-change values. Rounds clockwise if exactly on a diagonal. Similar to
+        /// <see cref="GetDirection(Point)"/>, except this function returns only cardinal directions.
+        /// </summary>
+        /// <param name="dx">Change in x along the line.</param>
+        /// <param name="dy">Change in y along the line.</param>
+        /// <returns>
+        /// The cardinal direction that most closely matches the degree heading of the given line.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Direction GetCardinalDirection(int dx, int dy) => GetCardinalDirection(new Point(dx, dy));
+
+        /// <summary>
         /// Returns the direction that most closely matches the degree heading of the given line.
         /// Rounds clockwise if the heading is exactly between two directions.
         /// </summary>
@@ -365,6 +397,22 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Direction GetDirection(Point start, Point end)
             => GetDirection(new Point(end.X - start.X, end.Y - start.Y));
+
+        /// <summary>
+        /// Returns the direction that most closely matches the degree heading of the given line.
+        /// Rounds clockwise if the heading is exactly between two directions.
+        /// </summary>
+        /// <param name="startX">X-value of the starting coordinate of the line.</param>
+        /// <param name="startY">Y-value of the starting coordinate of the line.</param>
+        /// <param name="endX">X-value of the ending coordinate of the line.</param>
+        /// <param name="endY">Y-value of the ending coordinate of the line.</param>
+        /// <returns>
+        /// The direction that most closely matches the heading indicated by the given line.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Direction GetDirection(int startX, int startY, int endX, int endY)
+            => GetDirection(new Point(startX, startY), new Point(endX, endY));
 
 
         /// <summary>
@@ -420,6 +468,19 @@ namespace SadRogue.Primitives
 
             return Up;
         }
+
+        /// <summary>
+        /// Returns the direction that most closely matches the degree heading of a line with the
+        /// given delta-change values. Rounds clockwise if the heading is exactly between two directions.
+        /// </summary>
+        /// <param name="dx">Change in x-value across the line.</param>
+        /// <param name="dy">Change in y-value across the line.</param>
+        /// <returns>
+        /// The direction that most closely matches the heading indicated by the given input.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Direction GetDirection(int dx, int dy) => GetDirection(new Point(dx, dy));
 
         /// <summary>
         /// Moves the direction counter-clockwise <paramref name="i"/> times.

--- a/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs
+++ b/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs
@@ -413,6 +413,10 @@ namespace SadRogue.Primitives.GridViews
                 throw new InvalidOperationException(
                     $"Cannot {nameof(FinalizeCurrentDiff)} if there are existing diffs that are not applied.");
 
+            // Nothing to do here; we're already in the appropriate state
+            if (Diffs.Count == 0)
+                return;
+
             // Compress diff if needed
             if (AutoCompress)
                 _diffs[^1].Compress();

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -39,6 +39,14 @@ namespace SadRogue.Primitives
         bool Contains(Point position);
 
         /// <summary>
+        /// Determines whether or not the given position is considered within the area or not.
+        /// </summary>
+        /// <param name="positionX">X-value of the position to check.</param>
+        /// <param name="positionY">X-value of the position to check.</param>
+        /// <returns>True if the specified position is within the area, false otherwise.</returns>
+        bool Contains(int positionX, int positionY);
+
+        /// <summary>
         /// Returns whether or not the given map area intersects the current one. If you intend to
         /// determine/use the exact intersection based on this return value, it is best to instead
         /// call <see cref="Area.GetIntersection(IReadOnlyArea, IReadOnlyArea)"/>, and check the number

--- a/TheSadRogue.Primitives/Point.cs
+++ b/TheSadRogue.Primitives/Point.cs
@@ -62,6 +62,19 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double BearingOfLine(Point start, Point end) => BearingOfLine(start - end);
 
+        /// <summary>
+        /// Calculates degree bearing of the line (start =&gt; end), where 0 points in the direction <see cref="Direction.Up"/>.
+        /// </summary>
+        /// <param name="startX">X-value of the position of line starting point.</param>
+        /// <param name="startY">Y-value of the position of line starting point.</param>
+        /// <param name="endX">X-value of the position of line ending point.</param>
+        /// <param name="endY">X-value of the position of line ending point.</param>
+        /// <returns>The degree bearing of the line specified by the two given points.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double BearingOfLine(int startX, int startY, int endX, int endY)
+            => BearingOfLine(new Point(startX, startY), new Point(endX, endY));
+
 
         /// <summary>
         /// Calculates the degree bearing of a line with the given delta-x and delta-y values, where
@@ -87,6 +100,18 @@ namespace SadRogue.Primitives
         }
 
         /// <summary>
+        /// Calculates the degree bearing of a line with the given delta-x and delta-y values, where
+        /// 0 degrees points in the direction <see cref="Direction.Up"/>.
+        /// </summary>
+        /// <param name="dx">Change in x-value across the line.</param>
+        /// <param name="dy">Change in y-value across the line.</param>
+        /// <returns>The degree bearing of the line with the given dx and dy values.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double BearingOfLine(int dx, int dy)
+            => BearingOfLine(new Point(dx, dy));
+
+        /// <summary>
         /// Returns the result of the euclidean distance formula, without the square root -- eg.,
         /// (c2.X - c1.X) * (c2.X - c1.X) + (c2.Y - c1.Y) * (c2.Y - c1.Y). Use this if you only care
         /// about the magnitude of the distance -- eg., if you're trying to compare two distances.
@@ -103,6 +128,25 @@ namespace SadRogue.Primitives
         public static double EuclideanDistanceMagnitude(Point c1, Point c2) => EuclideanDistanceMagnitude(c2 - c1);
 
         /// <summary>
+        /// Returns the result of the euclidean distance formula, without the square root -- eg.,
+        /// (c2.X - c1.X) * (c2.X - c1.X) + (c2.Y - c1.Y) * (c2.Y - c1.Y). Use this if you only care
+        /// about the magnitude of the distance -- eg., if you're trying to compare two distances.
+        /// Omitting the square root provides a speed increase.
+        /// </summary>
+        /// <param name="firstX">X-value for the first point.</param>
+        /// <param name="firstY">Y-value for the first point.</param>
+        /// <param name="secondX">X-value for the second point.</param>
+        /// <param name="secondY">Y-value for the second point.</param>
+        /// <returns>
+        /// The "magnitude" of the euclidean distance between the two points -- basically the
+        /// distance formula without the square root.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double EuclideanDistanceMagnitude(int firstX, int firstY, int secondX, int secondY)
+            => EuclideanDistanceMagnitude(new Point(firstX, firstY), new Point(secondX, secondY));
+
+        /// <summary>
         /// Returns the result of the euclidean distance formula, without the square root, given the
         /// dx and dy values between two points -- eg., (deltaChange.X * deltaChange.X) + (deltaChange.Y
         /// * deltaChange.Y). Use this if you only care about the magnitude of the distance -- eg., if
@@ -117,8 +161,26 @@ namespace SadRogue.Primitives
         /// values -- basically the distance formula without the square root.
         /// </returns>
         [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double EuclideanDistanceMagnitude(Point deltaChange)
             => deltaChange.X * deltaChange.X + deltaChange.Y * deltaChange.Y;
+
+        /// <summary>
+        /// Returns the result of the euclidean distance formula, without the square root, given the
+        /// dx and dy values between two points -- eg., (deltaChange.X * deltaChange.X) + (deltaChange.Y
+        /// * deltaChange.Y). Use this if you only care about the magnitude of the distance -- eg., if
+        /// you're trying to compare two distances. Omitting the square root provides a speed increase.
+        /// </summary>
+        /// <param name="dx">Change in x-values between the two points.</param>
+        /// <param name="dy">Change in y-values between the two points.</param>
+        /// <returns>
+        /// The "magnitude" of the euclidean distance of two locations with the given dx and dy
+        /// values -- basically the distance formula without the square root.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double EuclideanDistanceMagnitude(int dx, int dy)
+            => EuclideanDistanceMagnitude(new Point(dx, dy));
 
         /// <summary>
         /// True if the given coordinate has equal x and y values to the current one.
@@ -139,6 +201,19 @@ namespace SadRogue.Primitives
         public static Point Midpoint(Point c1, Point c2)
             => new Point((int)Math.Round((c1.X + c2.X) / 2.0f, MidpointRounding.AwayFromZero),
                 (int)Math.Round((c1.Y + c2.Y) / 2.0f, MidpointRounding.AwayFromZero));
+
+        /// <summary>
+        /// Returns the midpoint between the two points.
+        /// </summary>
+        /// <param name="firstX">X-value for the first point.</param>
+        /// <param name="firstY">Y-value for the first point.</param>
+        /// <param name="secondX">X-value for the second point.</param>
+        /// <param name="secondY">Y-value for the second point.</param>
+        /// <returns>The midpoint between the two points.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Point Midpoint(int firstX, int firstY, int secondX, int secondY)
+            => Midpoint(new Point(firstX, firstY), new Point(secondX, secondY));
 
         /// <summary>
         /// Returns the coordinate (c1.X - c2.X, c1.Y - c2.Y).
@@ -376,6 +451,17 @@ namespace SadRogue.Primitives
         public Point Translate(Point deltaChange) => new Point(X + deltaChange.X, Y + deltaChange.Y);
 
         /// <summary>
+        /// Returns the position resulting from adding dx to the X-value of the position, and dy
+        /// to the Y-value of the position.
+        /// </summary>
+        /// <param name="dx">Change in x-value to apply.</param>
+        /// <param name="dy">Change in y-value to apply.</param>
+        /// <returns>The position (<see cref="X"/> + dx, <see cref="Y"/> + dy)</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Point Translate(int dx, int dy) => Translate(new Point(dx, dy));
+
+        /// <summary>
         /// Creates a new Point with its X value moved to the given one.
         /// </summary>
         /// <param name="x">X-value for the new Point.</param>
@@ -586,6 +672,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="degrees">The amount of Degrees to rotate this point clockwise</param>
         /// <returns>The equivalent point after a rotation</returns>
+        [Pure]
         public  Point Rotate(double degrees)
         {
             double radians = MathHelpers.ToRadian(degrees);
@@ -600,14 +687,28 @@ namespace SadRogue.Primitives
         /// <param name="degrees">The amount of Degrees to rotate this point</param>
         /// <param name="origin">The Point around which to rotate</param>
         /// <returns>The equivalent point after a rotation</returns>
+        [Pure]
         public Point Rotate(double degrees, Point origin)
         {
             Point rotatingPoint = this - origin;
             double radians = MathHelpers.ToRadian(degrees);
             int x = (int)Math.Round(rotatingPoint.X * Math.Cos(radians) - rotatingPoint.Y * Math.Sin(radians));
             int y = (int)Math.Round(rotatingPoint.X * Math.Sin(radians) + rotatingPoint.Y * Math.Cos(radians));
-            return origin + (x, y);
+            return origin + new Point(x, y);
         }
+
+        /// <summary>
+        /// Rotates a single point around the origin point.
+        /// </summary>
+        /// <param name="degrees">The amount of Degrees to rotate this point</param>
+        /// <param name="originX">X-value of the location around which to rotate</param>
+        /// <param name="originY">Y-value of the location around which to rotate</param>
+        /// <returns>The equivalent point after a rotation</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Point Rotate(double degrees, int originX, int originY)
+            => Rotate(degrees, new Point(originX, originY));
+
         #endregion
     }
 }

--- a/TheSadRogue.Primitives/PolarCoordinate.cs
+++ b/TheSadRogue.Primitives/PolarCoordinate.cs
@@ -122,12 +122,24 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="cartesian">The cartesian point to analyze</param>
         /// <returns>An Equivalent Polar Coordinate</returns>
+        [Pure]
         public static PolarCoordinate FromCartesian(Point cartesian)
         {
             double radius = Math.Sqrt(cartesian.X * cartesian.X + cartesian.Y * cartesian.Y);
             double theta = Math.Atan2(cartesian.Y, cartesian.X);
             return new PolarCoordinate(radius, theta);
         }
+
+        /// <summary>
+        /// Returns a new PolarCoordinate that is equivalent to the Cartesian point provided.
+        /// </summary>
+        /// <param name="cartesianX">X-value of the cartesian point to analyze.</param>
+        /// <param name="cartesianY">Y-value of the cartesian point to analyze.</param>
+        /// <returns>An Equivalent Polar Coordinate</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static PolarCoordinate FromCartesian(int cartesianX, int cartesianY)
+            => FromCartesian(new Point(cartesianX, cartesianY));
 
         #region Tuple Compatibility
 

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -76,7 +76,7 @@ namespace SadRogue.Primitives
         /// Returns an IEnumerable of all positions in a radius of the current shape defined by the given parameters.
         /// </summary>
         /// <remarks>
-        /// If you are getting postions for a radius of the same size frequently, it may be more performant to instead
+        /// If you are getting positions for a radius of the same size frequently, it may be more performant to instead
         /// construct a <see cref="RadiusLocationContext"/> to represent it, and pass that to
         /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
         ///
@@ -98,7 +98,30 @@ namespace SadRogue.Primitives
         /// Returns an IEnumerable of all positions in a radius of the current shape defined by the given parameters.
         /// </summary>
         /// <remarks>
-        /// If you are getting postions for a radius of the same size frequently, it may be more performant to instead
+        /// If you are getting positions for a radius of the same size frequently, it may be more performant to instead
+        /// construct a <see cref="RadiusLocationContext"/> to represent it, and pass that to
+        /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
+        ///
+        /// The positions returned are all guaranteed to be within the <paramref name="bounds"/> specified.  As well,
+        /// they are guaranteed to be in order from least distance from center to most distance if either
+        /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
+        /// </remarks>
+        /// <param name="centerX">X-value of the center-point of the radius.</param>
+        /// <param name="centerY">Y-value of the center-point of the radius.</param>
+        /// <param name="radius">Length of the radius.</param>
+        /// <param name="bounds">Bounds to restrict the returned values by.</param>
+        /// <returns>All points in the radius shape defined by the given parameters, in order from least distance to greatest
+        /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IEnumerable<Point> PositionsInRadius(int centerX, int centerY, int radius, Rectangle bounds)
+            => PositionsInRadius(new RadiusLocationContext(new Point(centerX, centerY), radius, bounds));
+
+        /// <summary>
+        /// Returns an IEnumerable of all positions in a radius of the current shape defined by the given parameters.
+        /// </summary>
+        /// <remarks>
+        /// If you are getting positions for a radius of the same size frequently, it may be more performant to instead
         /// construct a <see cref="RadiusLocationContext"/> to represent it, and pass that to
         /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
         ///
@@ -113,6 +136,27 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerable<Point> PositionsInRadius(Point center, int radius)
             => PositionsInRadius(new RadiusLocationContext(center, radius));
+
+        /// <summary>
+        /// Returns an IEnumerable of all positions in a radius of the current shape defined by the given parameters.
+        /// </summary>
+        /// <remarks>
+        /// If you are getting positions for a radius of the same size frequently, it may be more performant to instead
+        /// construct a <see cref="RadiusLocationContext"/> to represent it, and pass that to
+        /// <see cref="PositionsInRadius(RadiusLocationContext)"/>.
+        ///
+        /// The positions returned are guaranteed to be in order from least distance from center to most distance if either
+        /// <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.
+        /// </remarks>
+        /// <param name="centerX">X-value of the center-point of the radius.</param>
+        /// <param name="centerY">Y-value of the center-point of the radius.</param>
+        /// <param name="radius">Length of the radius.</param>
+        /// <returns>All points in the radius shape defined by the given parameters, in order from least distance to greatest
+        /// if <see cref="Radius.Diamond"/> or <see cref="Radius.Square"/> is being used.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IEnumerable<Point> PositionsInRadius(int centerX, int centerY, int radius)
+            => PositionsInRadius(new Point(centerX, centerY), radius);
 
         /// <summary>
         /// Returns an IEnumerable of all positions in a radius of the current shape defined by the given context.  Creating
@@ -347,10 +391,32 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Constructor.
         /// </summary>
+        /// <param name="centerX">X-value of the starting center-point of the radius.</param>
+        /// <param name="centerY">Y-value of the starting center-point of the radius.</param>
+        /// <param name="radius">The starting length of the radius.</param>
+        /// <param name="bounds">The bounds to restrict the radius to.  Any positions inside the radius but outside
+        /// the bounds will be ignored and considered outside the radius.</param>
+        public RadiusLocationContext(int centerX, int centerY, int radius, Rectangle bounds)
+            : this(new Point(centerX, centerY), radius, bounds)
+        { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
         /// <param name="center">The starting center-point of the radius.</param>
         /// <param name="radius">The starting length of the radius.</param>
         public RadiusLocationContext(Point center, int radius)
             : this(center, radius, Rectangle.Empty)
+        { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="centerX">X-value of the starting center-point of the radius.</param>
+        /// <param name="centerY">Y-value of the starting center-point of the radius.</param>
+        /// <param name="radius">The starting length of the radius.</param>
+        public RadiusLocationContext(int centerX, int centerY, int radius)
+            : this(new Point(centerX, centerY), radius)
         { }
     }
 }

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -370,6 +370,45 @@ namespace SadRogue.Primitives
             => new Rectangle(X, Y, Width + deltaWidth, Height);
 
         /// <summary>
+        /// Creates and returns a new rectangle that has its position moved in the given direction.
+        /// </summary>
+        /// <param name="direction">The direction to move the new rectangle in.</param>
+        /// <returns>A new rectangle that has its position moved in the given direction.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Rectangle ChangePosition(Direction direction) => Translate(direction);
+
+        /// <summary>
+        /// Creates and returns a new rectangle whose position has been moved by the given
+        /// delta-change values.
+        /// </summary>
+        /// <param name="deltaChange">Delta-x and delta-y values by which to move the new rectangle.</param>
+        /// <returns>
+        /// A new rectangle, whose position has been moved by the given delta-change values.
+        /// </returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Rectangle ChangePosition(Point deltaChange) => Translate(deltaChange);
+
+        /// <summary>
+        /// Creates and returns a new rectangle whose x-position has been moved by the given delta value.
+        /// </summary>
+        /// <param name="dx">Value by which to move the new rectangle's x-position.</param>
+        /// <returns>A new rectangle, whose x-position has been moved by the given delta-x value.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Rectangle ChangeX(int dx) => TranslateX(dx);
+
+        /// <summary>
+        /// Creates and returns a new rectangle whose y-position has been moved by the given delta value.
+        /// </summary>
+        /// <param name="dy">Value by which to move the new rectangle's y-position.</param>
+        /// <returns>A new rectangle, whose y-position has been moved by the given delta-y value.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Rectangle ChangeY(int dy) => TranslateY(dy);
+
+        /// <summary>
         /// Returns whether or not the specified point is considered within the rectangle.
         /// </summary>
         /// <param name="position">The position to check.</param>

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -454,13 +454,14 @@ namespace SadRogue.Primitives
         public override bool Equals(object? obj) => obj is Rectangle && this == (Rectangle)obj;
 
         /// <summary>
-        /// Returns a new rectangle, expanded to include the additional specified rows/columns.
+        /// Returns a new rectangle, expanded on each side by the given amounts.  Negative change values
+        /// can be used to shrink the rectangle on each side.
         /// </summary>
         /// <param name="horizontalChange">
-        /// Number of additional columns to include on the left/right of the rectangle.
+        /// Number of additional columns to include on the left and right of the rectangle.
         /// </param>
         /// <param name="verticalChange">
-        /// Number of additional rows to include on the top/bottom of the rectangle.
+        /// Number of additional rows to include on the top and bottom of the rectangle.
         /// </param>
         /// <returns>A new rectangle, expanded appropriately.</returns>
         [Pure]

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -46,10 +46,4 @@
     <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
     <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
   </Target>
-
-  <!-- Run InheritDoc on the final builds. -->
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT'">
-	<Exec Command="dotnet tool restore" />
-    <Exec Command="dotnet inheritdoc -o -b $(OutDir)" />
-  </Target>
 </Project>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha7</Version>
+	<Version>1.0.0-alpha8</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -15,7 +15,13 @@
 
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
-	<PackageReleaseNotes>Added grid views.</PackageReleaseNotes>
+	<PackageReleaseNotes>
+    - Fixed a bug in DiffAwareGridView regarding index tracking at end of diffs.
+    - Added x/y overloads to functions taking Point .
+    - Added ChangePosition functions to Rectangle to apply a consistent interface
+    - Corrected description of Rectangle.Expand
+    - Removes inheritdoc from build to ensure the project can be built on all platforms
+  </PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
- Prevents exceptions when a DiffAwareGridView finalizes its current diff with 0 diffs (fixes #59)
- Adds performance test project and some basic performance tests for Point hashing
- Adds `ChangePosition` functions to `Rectangle` that forward to `Translate`, to be consistent with pattern used elsewhere (fixes #55)
- Modifies description for `Rectangle.Expand` to be more accurate (fixes #54)
- Removes inheritdoc tool from build process (fixes #53)
- Adds x/y overloads to functions taking points (fixes #18)
    - Some `Rectangle` functions were excluded here; I felt like adding the overloads in these cases added to confusion/ambiguity since there were already functions like `WithX` and `WithY`)