### PR TITLE
Minor Refactor to Area Interface

### DIFF
--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -13,7 +13,7 @@ namespace SadRogue.Primitives
     /// unique position in the area.
     /// </summary>
     [DataContract]
-    public class Area : IReadOnlyArea, IEnumerable<Point>
+    public class Area : IReadOnlyArea
     {
         private readonly HashSet<Point> _positionsSet;
 
@@ -52,6 +52,9 @@ namespace SadRogue.Primitives
             : this((IEnumerable<Point>)initialPoints)
         { }
 
+        /// <inheritdoc />
+        public Point this[int index] => _positions[index];
+
         /// <summary>
         /// Smallest possible rectangle that encompasses every position in the area.
         /// </summary>
@@ -72,11 +75,6 @@ namespace SadRogue.Primitives
         public int Count => _positions.Count;
 
         /// <summary>
-        /// List of all (unique) positions in the area.
-        /// </summary>
-        public IReadOnlyList<Point> Positions => _positions.AsReadOnly();
-
-        /// <summary>
         /// Gets an area containing all positions in <paramref name="area1"/>, minus those that are in
         /// <paramref name="area2"/>.
         /// </summary>
@@ -88,7 +86,7 @@ namespace SadRogue.Primitives
         {
             Area retVal = new Area();
 
-            foreach (Point pos in area1.Positions)
+            foreach (Point pos in area1)
             {
                 if (area2.Contains(pos))
                     continue;
@@ -115,7 +113,7 @@ namespace SadRogue.Primitives
             if (area1.Count > area2.Count)
                 Swap(ref area1, ref area2);
 
-            foreach (Point pos in area1.Positions)
+            foreach (Point pos in area1)
                 if (area2.Contains(pos))
                     retVal.Add(pos);
 
@@ -150,7 +148,7 @@ namespace SadRogue.Primitives
         {
             Area retVal = new Area();
 
-            foreach (Point pos in lhs.Positions)
+            foreach (Point pos in lhs)
                 retVal.Add(pos + rhs);
 
             return retVal;
@@ -176,7 +174,7 @@ namespace SadRogue.Primitives
             if (Bounds != other.Bounds)
                 return false;
 
-            foreach (Point pos in Positions)
+            foreach (Point pos in _positions)
                 if (!other.Contains(pos))
                     return false;
 
@@ -253,7 +251,7 @@ namespace SadRogue.Primitives
         /// <param name="area">Area containing positions to add.</param>
         public void Add(IReadOnlyArea area)
         {
-            foreach (Point pos in area.Positions)
+            foreach (Point pos in area)
                 Add(pos);
         }
 
@@ -286,7 +284,7 @@ namespace SadRogue.Primitives
             if (!Bounds.Contains(area.Bounds))
                 return false;
 
-            foreach (Point pos in area.Positions)
+            foreach (Point pos in area)
                 if (!Contains(pos))
                     return false;
 
@@ -308,14 +306,14 @@ namespace SadRogue.Primitives
 
             if (Count <= area.Count)
             {
-                foreach (Point pos in Positions)
+                foreach (Point pos in _positions)
                     if (area.Contains(pos))
                         return true;
 
                 return false;
             }
 
-            foreach (Point pos in area.Positions)
+            foreach (Point pos in area)
                 if (Contains(pos))
                     return true;
 
@@ -397,7 +395,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="area">Area containing positions to remove.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Remove(IReadOnlyArea area) => Remove(area.Positions);
+        public void Remove(IReadOnlyArea area) => Remove((IEnumerable<Point>)area);
 
         /// <summary>
         /// Removes all positions in the given rectangle from this area.

--- a/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs
+++ b/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs
@@ -27,7 +27,7 @@ namespace SadRogue.Primitives.GridViews
         /// <param name="defaultValue">
         /// The value to return if a position is accessed that is outside the actual underlying grid view.
         /// </param>
-        public UnboundedViewport(IGridView<T> gridView, Rectangle viewArea, T defaultValue = default)
+        public UnboundedViewport(IGridView<T> gridView, Rectangle viewArea, T defaultValue)
         {
             GridView = gridView;
             _viewArea = viewArea;
@@ -41,7 +41,7 @@ namespace SadRogue.Primitives.GridViews
         /// <param name="defaultValue">
         /// The value to return if a position is accessed that is outside the actual underlying grid view.
         /// </param>
-        public UnboundedViewport(IGridView<T> gridView, T defaultValue = default)
+        public UnboundedViewport(IGridView<T> gridView, T defaultValue)
             : this(gridView, gridView.Bounds(), defaultValue)
         { }
 

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -5,7 +5,7 @@ namespace SadRogue.Primitives
     /// <summary>
     /// Read-only interface for an arbitrary 2D area.
     /// </summary>
-    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>
+    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>, IEnumerable<Point>
     {
         /// <summary>
         /// Smallest possible rectangle that encompasses every position in the area.
@@ -18,9 +18,10 @@ namespace SadRogue.Primitives
         int Count { get; }
 
         /// <summary>
-        /// List of all (unique) positions in the current area.
+        /// Returns positions from the area in the same fashion you would via a list.
         /// </summary>
-        IReadOnlyList<Point> Positions { get; }
+        /// <param name="index">Index of list to retrieve.</param>
+        Point this[int index] { get; }
 
         /// <summary>
         /// Returns whether or not the given area is completely contained within the current one.

--- a/TheSadRogue.Primitives/SerializedTypes/Area.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Area.cs
@@ -29,6 +29,6 @@ namespace SadRogue.Primitives.SerializedTypes
         /// <param name="area"/>
         /// <returns/>
         public static implicit operator AreaSerialized(Area area)
-            => new AreaSerialized() { Positions = area.Positions.Select(p => (PointSerialized)p).ToList() };
+            => new AreaSerialized() { Positions = area.Select(p => (PointSerialized)p).ToList() };
     }
 }

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,21 +6,18 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha8</Version>
+	<Version>1.0.0-alpha9</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2020 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+	<Copyright>Copyright © 2021 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of primitive data structures for working with a 2-dimensional grid.</Description>
 
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>
-    - Fixed a bug in DiffAwareGridView regarding index tracking at end of diffs.
-    - Added x/y overloads to functions taking Point .
-    - Added ChangePosition functions to Rectangle to apply a consistent interface
-    - Corrected description of Rectangle.Expand
-    - Removes inheritdoc from build to ensure the project can be built on all platforms
+    - Modified Area interface to have an indexer instead of the Positions property
+	- Removed default value for the DefaultValue parameter in UnboundedViewport to conform to nullability constraints
   </PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR primarily does a small refactor of the API for `Area`.  Nothing on the scope of #46 , though; all it does is replace the `Positions` property with implementing `IEnumerable` and providing a `this` indexer.  This makes it a bit less verbose to use, and also makes it easier to implement `IReadOnlyArea` manually; for example, I ran into a case in GoRogue where I wanted to implement that interface to wrap a `List` of `Areas`, but couldn't be because the `Positions` property exposed the positions as `IReadOnlyList<Point>`.

It also fixes a minor nullable reference issue in `UnboundedViewport`.  The compiler cannot know whether `default` (which is `null` for reference types) is safe for type `T`, so the default value was simply removed and the user now has to specify it.  This allows the compiler to enforce the 100% proper nullability constraints (eg. `null` is valid if and ONLY if `T` is nullable).