### PR TITLE
Updated Docs and CSProj to v1.0

### DIFF
--- a/TheSadRogue.Primitives.Docs/articles/intro.md
+++ b/TheSadRogue.Primitives.Docs/articles/intro.md
@@ -1,1 +1,2 @@
-# Add your introductions here!
+# Articles/How-Tos
+Nothing here yet, check back often!  There will eventually be helpful articles detailing how to use various features.

--- a/TheSadRogue.Primitives.Docs/docfx.json
+++ b/TheSadRogue.Primitives.Docs/docfx.json
@@ -33,7 +33,7 @@
           "toc.yml",
           "*.md"
         ]
-      }
+      },
     ],
     "resource": [
       {
@@ -52,6 +52,9 @@
           "_site/**"
         ]
       }
+    ],
+	"xrefservice": [
+      "https://xref.docs.microsoft.com/query?uid={uid}"
     ],
     "dest": "../docs",
     "globalMetadataFiles": [],

--- a/TheSadRogue.Primitives.Docs/index.md
+++ b/TheSadRogue.Primitives.Docs/index.md
@@ -3,4 +3,4 @@ title: TheSadRogue.Primitives Documentation Home
 ---
 
 # TheSadRogue.Primitives Documentation
-Welcome to the documentation for TheSadRogue.Primitives library!  Currently, we have only the API documentation hosted under the API Documentation tab.  More coming soon!
+Welcome to the documentation for TheSadRogue.Primitives library!  Currently, we have only the API documentation hosted under the API Documentation tab.  This documents every class/function/property in the library, so should help you get started.  Additional helpful articles will be posted in the future as well.

--- a/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs
+++ b/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs
@@ -42,7 +42,11 @@ namespace SadRogue.Primitives.GridViews
             NewValue = newValue;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Compares the two changes according to their positions and values.
+        /// </summary>
+        /// <param name="other"/>
+        /// <returns>True if the two value changes represent the same change, false otherwise.</returns>
         public bool Equals(ValueChange<T> other)
             => Position.Equals(other.Position) && OldValue.Equals(other.OldValue) && NewValue.Equals(other.NewValue);
 
@@ -53,10 +57,17 @@ namespace SadRogue.Primitives.GridViews
         /// <returns>True if the two value changes represent the same change, false otherwise.</returns>
         public bool Matches(ValueChange<T> other) => Equals(other);
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Compares the two changes according to their types, positions and values.
+        /// </summary>
+        /// <param name="obj"/>
+        /// <returns>True if the two value changes represent the same object and change, false otherwise.</returns>
         public override bool Equals(object? obj) => obj is ValueChange<T> other && Equals(other);
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a hash value computed using the item's position, old value, and new value.
+        /// </summary>
+        /// <returns></returns>
         public override int GetHashCode() => HashCode.Combine(Position, OldValue, NewValue);
 
         /// <summary>
@@ -75,7 +86,10 @@ namespace SadRogue.Primitives.GridViews
         /// <returns>True if all the changes are equivalent; false otherwise.</returns>
         public static bool operator !=(ValueChange<T> left, ValueChange<T> right) => !left.Equals(right);
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a string representing the object, including its position, old value, and new value.
+        /// </summary>
+        /// <returns></returns>
         public override string ToString() => $"{Position}: {OldValue} -> {NewValue}";
     }
 
@@ -214,10 +228,16 @@ namespace SadRogue.Primitives.GridViews
             return positions.Count == _changes.Count;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns an enumerator of the changes in the diff.
+        /// </summary>
+        /// <returns></returns>
         public IEnumerator<ValueChange<T>> GetEnumerator() => _changes.GetEnumerator();
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns an enumerator of the changes in the diff.
+        /// </summary>
+        /// <returns></returns>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
 	<!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0-alpha9</Version>
+	<Version>1.0.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -16,8 +16,6 @@
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>
-    - Modified Area interface to have an indexer instead of the Positions property
-	- Removed default value for the DefaultValue parameter in UnboundedViewport to conform to nullability constraints
   </PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/docs/api/SadRogue.Primitives.AdjacencyRule.Types.html
+++ b/docs/api/SadRogue.Primitives.AdjacencyRule.Types.html
@@ -122,7 +122,7 @@ types to a primitive type (for cases like a switch statement).</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L46" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L45" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.AdjacencyRule.html
+++ b/docs/api/SadRogue.Primitives.AdjacencyRule.html
@@ -74,32 +74,33 @@
   <h1 id="SadRogue_Primitives_AdjacencyRule" data-uid="SadRogue.Primitives.AdjacencyRule" class="text-break">Struct AdjacencyRule
   </h1>
   <div class="markdown level0 summary"><p>Structure representing a method for determining which coordinates are adjacent to a given
-coordinate, and which directions those neighbors are in. Cannot be instantiated -- premade
+coordinate, and which directions those neighbors are in. Cannot be instantiated -- pre-made
 static instances are provided.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_AdjacencyRule_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct AdjacencyRule : IEquatable&lt;AdjacencyRule&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct AdjacencyRule : IEquatable&lt;AdjacencyRule&gt;, IMatchable&lt;AdjacencyRule&gt;</code></pre>
   </div>
   <h3 id="fields">Fields
   </h3>
@@ -108,7 +109,7 @@ public struct AdjacencyRule : IEquatable&lt;AdjacencyRule&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Cardinals.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Cardinals%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L19">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L21">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_AdjacencyRule_Cardinals" data-uid="SadRogue.Primitives.AdjacencyRule.Cardinals">Cardinals</h4>
   <div class="markdown level1 summary"><p>Represents method of determining adjacency where neighbors are considered adjacent if
@@ -117,8 +118,7 @@ they are in a cardinal direction, eg. 4-way (manhattan-based) connectivity.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly AdjacencyRule Cardinals</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly AdjacencyRule Cardinals</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -140,7 +140,7 @@ public static readonly AdjacencyRule Cardinals</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Diagonals.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Diagonals%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L26">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L27">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_AdjacencyRule_Diagonals" data-uid="SadRogue.Primitives.AdjacencyRule.Diagonals">Diagonals</h4>
   <div class="markdown level1 summary"><p>Represents method of determining adjacency where neighbors are considered adjacent only
@@ -149,8 +149,7 @@ if they are in a diagonal direction.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly AdjacencyRule Diagonals</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly AdjacencyRule Diagonals</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -181,8 +180,7 @@ adjacent (eg. 8-way connectivity).</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly AdjacencyRule EightWay</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly AdjacencyRule EightWay</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -204,7 +202,7 @@ public static readonly AdjacencyRule EightWay</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Type.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Type%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L68">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L67">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_AdjacencyRule_Type" data-uid="SadRogue.Primitives.AdjacencyRule.Type">Type</h4>
   <div class="markdown level1 summary"><p>Enum value representing the method of determining adjacency -- useful for using
@@ -213,7 +211,8 @@ public static readonly AdjacencyRule EightWay</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly AdjacencyRule.Types Type</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly AdjacencyRule.Types Type</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -237,7 +236,7 @@ public static readonly AdjacencyRule EightWay</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighbors.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighbors%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L98">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L74">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighbors_" data-uid="SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighbors*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighbors" data-uid="SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighbors">DirectionsOfNeighbors()</h4>
@@ -247,7 +246,8 @@ method. Cardinals are returned before any diagonals.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Direction&gt; DirectionsOfNeighbors()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Direction&gt; DirectionsOfNeighbors()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -259,7 +259,7 @@ method. Cardinals are returned before any diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</td>
         <td><p>Directions that lead to neighboring locations.</p>
 </td>
       </tr>
@@ -270,7 +270,7 @@ method. Cardinals are returned before any diagonals.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighborsClockwise_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighborsClockwise(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L138">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L118">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighborsClockwise_" data-uid="SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighborsClockwise*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighborsClockwise_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighborsClockwise(SadRogue.Primitives.Direction)">DirectionsOfNeighborsClockwise(Direction)</h4>
@@ -281,7 +281,8 @@ direction.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Direction&gt; DirectionsOfNeighborsClockwise(Direction startingDirection = default(Direction))</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Direction&gt; DirectionsOfNeighborsClockwise(Direction startingDirection = default(Direction))</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -313,7 +314,7 @@ for diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</td>
         <td><p>Directions that lead to neighboring locations.</p>
 </td>
       </tr>
@@ -324,7 +325,7 @@ for diagonals.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighborsCounterClockwise_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighborsCounterClockwise(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L200">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L175">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighborsCounterClockwise_" data-uid="SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighborsCounterClockwise*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_DirectionsOfNeighborsCounterClockwise_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.AdjacencyRule.DirectionsOfNeighborsCounterClockwise(SadRogue.Primitives.Direction)">DirectionsOfNeighborsCounterClockwise(Direction)</h4>
@@ -335,7 +336,8 @@ starting direction.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Direction&gt; DirectionsOfNeighborsCounterClockwise(Direction startingDirection = default(Direction))</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Direction&gt; DirectionsOfNeighborsCounterClockwise(Direction startingDirection = default(Direction))</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -367,7 +369,7 @@ for diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</td>
         <td><p>Directions that lead to neighboring locations.</p>
 </td>
       </tr>
@@ -378,7 +380,7 @@ for diagonals.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Equals_SadRogue_Primitives_AdjacencyRule_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Equals(SadRogue.Primitives.AdjacencyRule)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L314">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L342">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_Equals_" data-uid="SadRogue.Primitives.AdjacencyRule.Equals*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_Equals_SadRogue_Primitives_AdjacencyRule_" data-uid="SadRogue.Primitives.AdjacencyRule.Equals(SadRogue.Primitives.AdjacencyRule)">Equals(AdjacencyRule)</h4>
@@ -387,7 +389,8 @@ for diagonals.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(AdjacencyRule other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(AdjacencyRule other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -417,7 +420,7 @@ for diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two directions are the same, false if not.</p>
 </td>
       </tr>
@@ -428,7 +431,7 @@ for diagonals.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L323">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L352">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_Equals_" data-uid="SadRogue.Primitives.AdjacencyRule.Equals*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_Equals_System_Object_" data-uid="SadRogue.Primitives.AdjacencyRule.Equals(System.Object)">Equals(Object)</h4>
@@ -437,7 +440,8 @@ for diagonals.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -450,7 +454,7 @@ for diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td><p>The object to compare the current AdjacencyRule to.</p>
 </td>
@@ -467,20 +471,20 @@ for diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is an AdjacencyRule, and the two adjacency rules are equal, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L329">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L359">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_GetHashCode_" data-uid="SadRogue.Primitives.AdjacencyRule.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_GetHashCode" data-uid="SadRogue.Primitives.AdjacencyRule.GetHashCode">GetHashCode()</h4>
@@ -489,7 +493,8 @@ for diagonals.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -501,19 +506,70 @@ for diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Matches_SadRogue_Primitives_AdjacencyRule_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Matches(SadRogue.Primitives.AdjacencyRule)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L228">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_Matches_" data-uid="SadRogue.Primitives.AdjacencyRule.Matches*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_Matches_SadRogue_Primitives_AdjacencyRule_" data-uid="SadRogue.Primitives.AdjacencyRule.Matches(SadRogue.Primitives.AdjacencyRule)">Matches(AdjacencyRule)</h4>
+  <div class="markdown level1 summary"><p>True if the given AdjacencyRule has the same Type the current one.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(AdjacencyRule other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>AdjacencyRule to compare.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two directions are the same, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Neighbors_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Neighbors(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L259">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L237">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_Neighbors_" data-uid="SadRogue.Primitives.AdjacencyRule.Neighbors*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_Neighbors_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.AdjacencyRule.Neighbors(SadRogue.Primitives.Point)">Neighbors(Point)</h4>
@@ -523,7 +579,8 @@ Cardinals are returned before any diagonals.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; Neighbors(Point startingLocation)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; Neighbors(Point startingLocation)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -553,7 +610,65 @@ Cardinals are returned before any diagonals.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>All neighbors of the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_Neighbors_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.Neighbors(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L251">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_Neighbors_" data-uid="SadRogue.Primitives.AdjacencyRule.Neighbors*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_Neighbors_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.AdjacencyRule.Neighbors(System.Int32,System.Int32)">Neighbors(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Gets all neighbors of the specified location, based on the current adjacency method.
+Cardinals are returned before any diagonals.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; Neighbors(int startingLocationX, int startingLocationY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startingLocationX</span></td>
+        <td><p>X-value of the location to return neighbors for.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startingLocationY</span></td>
+        <td><p>Y-value of the location to return neighbors for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All neighbors of the given location.</p>
 </td>
       </tr>
@@ -564,7 +679,7 @@ Cardinals are returned before any diagonals.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L280">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L269">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsClockwise*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">NeighborsClockwise(Point, Direction)</h4>
@@ -575,7 +690,8 @@ starting direction.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; NeighborsClockwise(Point startingLocation, Direction startingDirection = default(Direction))</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; NeighborsClockwise(Point startingLocation, Direction startingDirection = default(Direction))</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -614,7 +730,75 @@ for DIAGONALS.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>All neighbors of the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_System_Int32_System_Int32_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(System.Int32%2CSystem.Int32%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L290">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsClockwise*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_System_Int32_System_Int32_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(System.Int32,System.Int32,SadRogue.Primitives.Direction)">NeighborsClockwise(Int32, Int32, Direction)</h4>
+  <div class="markdown level1 summary"><p>Gets all neighbors of the specified location, based on the current adjacency method.
+Neighbors are returned in clockwise order, starting with the neighbor in the given
+starting direction.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; NeighborsClockwise(int startingLocationX, int startingLocationY, Direction startingDirection = default(Direction))</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startingLocationX</span></td>
+        <td><p>X-value of the location to return neighbors for.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startingLocationY</span></td>
+        <td><p>Y-value of the location to return neighbors for.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">startingDirection</span></td>
+        <td><p>The neighbor in this direction will be returned first, proceeding clockwise.
+If <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_None">None</a> is specified, the default starting direction
+is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a> for CARDINALS/EIGHT_WAY, and <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_UpRight">UpRight</a>
+for DIAGONALS.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All neighbors of the given location.</p>
 </td>
       </tr>
@@ -625,7 +809,7 @@ for DIAGONALS.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L301">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L309">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">NeighborsCounterClockwise(Point, Direction)</h4>
@@ -636,7 +820,8 @@ starting direction.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; NeighborsCounterClockwise(Point startingLocation, Direction startingDirection = default(Direction))</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; NeighborsCounterClockwise(Point startingLocation, Direction startingDirection = default(Direction))</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -675,7 +860,7 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All neighbors of the given location.</p>
 </td>
       </tr>
@@ -683,19 +868,229 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_ToAdjacencyRule_SadRogue_Primitives_AdjacencyRule_Types_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule(SadRogue.Primitives.AdjacencyRule.Types)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_System_Int32_System_Int32_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(System.Int32%2CSystem.Int32%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L75">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L331">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_AdjacencyRule_ToAdjacencyRule_" data-uid="SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule*"></a>
-  <h4 id="SadRogue_Primitives_AdjacencyRule_ToAdjacencyRule_SadRogue_Primitives_AdjacencyRule_Types_" data-uid="SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule(SadRogue.Primitives.AdjacencyRule.Types)">ToAdjacencyRule(AdjacencyRule.Types)</h4>
-  <div class="markdown level1 summary"><p>Gets the <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a> class instance representing the adjacency type specified.</p>
+  <a id="SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_System_Int32_System_Int32_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(System.Int32,System.Int32,SadRogue.Primitives.Direction)">NeighborsCounterClockwise(Int32, Int32, Direction)</h4>
+  <div class="markdown level1 summary"><p>Gets all neighbors of the specified location, based on the current adjacency method.
+Neighbors are returned in counter-clockwise order, starting with the neighbor in the given
+starting direction.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static AdjacencyRule ToAdjacencyRule(AdjacencyRule.Types adjacencyRuleType)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; NeighborsCounterClockwise(int startingLocationX, int startingLocationY, Direction startingDirection = default(Direction))</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startingLocationX</span></td>
+        <td><p>X-value of the location to return neighbors for.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startingLocationY</span></td>
+        <td><p>Y-value of the location to return neighbors for.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">startingDirection</span></td>
+        <td><p>The neighbor in this direction will be returned first, proceeding counter-clockwise.
+If <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_None">None</a> is specified, the default starting direction
+is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a> for CARDINALS/EIGHT_WAY, and
+<a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_UpLeft">UpLeft</a> for DIAGONALS.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>All neighbors of the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L407">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_ToString_" data-uid="SadRogue.Primitives.AdjacencyRule.ToString*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_ToString" data-uid="SadRogue.Primitives.AdjacencyRule.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_op_Equality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.op_Equality(SadRogue.Primitives.AdjacencyRule%2CSadRogue.Primitives.AdjacencyRule)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L368">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_op_Equality_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Equality*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_op_Equality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Equality(SadRogue.Primitives.AdjacencyRule,SadRogue.Primitives.AdjacencyRule)">Equality(AdjacencyRule, AdjacencyRule)</h4>
+  <div class="markdown level1 summary"><p>True if the two adjacency rules have the same Type.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(AdjacencyRule lhs, AdjacencyRule rhs)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
+        <td><span class="parametername">lhs</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
+        <td><span class="parametername">rhs</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two adjacency rules are equal, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_op_Implicit_SadRogue_Primitives_AdjacencyRule__SadRogue_Primitives_AdjacencyRule_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule)~SadRogue.Primitives.AdjacencyRule.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L386">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_op_Implicit_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_op_Implicit_SadRogue_Primitives_AdjacencyRule__SadRogue_Primitives_AdjacencyRule_Types" data-uid="SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule)~SadRogue.Primitives.AdjacencyRule.Types">Implicit(AdjacencyRule to AdjacencyRule.Types)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts an AdjacencyRule to its corresponding <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_Type">Type</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator AdjacencyRule.Types(AdjacencyRule rule)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
+        <td><span class="parametername">rule</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.Types.html">AdjacencyRule.Types</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_op_Implicit_SadRogue_Primitives_AdjacencyRule_Types__SadRogue_Primitives_AdjacencyRule.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule.Types)~SadRogue.Primitives.AdjacencyRule%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L393">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_AdjacencyRule_op_Implicit_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_AdjacencyRule_op_Implicit_SadRogue_Primitives_AdjacencyRule_Types__SadRogue_Primitives_AdjacencyRule" data-uid="SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule.Types)~SadRogue.Primitives.AdjacencyRule">Implicit(AdjacencyRule.Types to AdjacencyRule)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts an <a class="xref" href="SadRogue.Primitives.AdjacencyRule.Types.html">AdjacencyRule.Types</a> enum value to its corresponding AdjacencyRule.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator AdjacencyRule(AdjacencyRule.Types type)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -709,98 +1104,7 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
     <tbody>
       <tr>
         <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.Types.html">AdjacencyRule.Types</a></td>
-        <td><span class="parametername">adjacencyRuleType</span></td>
-        <td><p>The enum value for the adjacency method.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
-        <td><p>The <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a> class representing the given adjacency method type.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L353">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_AdjacencyRule_ToString_" data-uid="SadRogue.Primitives.AdjacencyRule.ToString*"></a>
-  <h4 id="SadRogue_Primitives_AdjacencyRule_ToString" data-uid="SadRogue.Primitives.AdjacencyRule.ToString">ToString()</h4>
-  <div class="markdown level1 summary"><p>Returns a string representation of the <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
-  </div>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.String</span></td>
-        <td><p>A string representation of the <a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a>.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
-  <h3 id="operators">Operators
-  </h3>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_op_Equality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.op_Equality(SadRogue.Primitives.AdjacencyRule%2CSadRogue.Primitives.AdjacencyRule)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L337">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_AdjacencyRule_op_Equality_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Equality*"></a>
-  <h4 id="SadRogue_Primitives_AdjacencyRule_op_Equality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Equality(SadRogue.Primitives.AdjacencyRule,SadRogue.Primitives.AdjacencyRule)">Equality(AdjacencyRule, AdjacencyRule)</h4>
-  <div class="markdown level1 summary"><p>True if the two adjacency rules have the same Type.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(AdjacencyRule lhs, AdjacencyRule rhs)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
-        <td><span class="parametername">lhs</span></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
-        <td><span class="parametername">rhs</span></td>
+        <td><span class="parametername">type</span></td>
         <td></td>
       </tr>
     </tbody>
@@ -815,9 +1119,8 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the two adjacency rules are equal, false if not.</p>
-</td>
+        <td><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></td>
+        <td></td>
       </tr>
     </tbody>
   </table>
@@ -826,7 +1129,7 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule_op_Inequality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule.op_Inequality(SadRogue.Primitives.AdjacencyRule%2CSadRogue.Primitives.AdjacencyRule)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L347">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L379">View Source</a>
   </span>
   <a id="SadRogue_Primitives_AdjacencyRule_op_Inequality_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_AdjacencyRule_op_Inequality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_" data-uid="SadRogue.Primitives.AdjacencyRule.op_Inequality(SadRogue.Primitives.AdjacencyRule,SadRogue.Primitives.AdjacencyRule)">Inequality(AdjacencyRule, AdjacencyRule)</h4>
@@ -835,7 +1138,8 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(AdjacencyRule lhs, AdjacencyRule rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(AdjacencyRule lhs, AdjacencyRule rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -869,7 +1173,7 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the types are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -877,7 +1181,10 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -890,7 +1197,7 @@ is used, which is <a class="xref" href="SadRogue.Primitives.Direction.html#SadRo
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_AdjacencyRule.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.AdjacencyRule%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L11" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/AdjacencyRule.cs/#L14" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Area.html
+++ b/docs/api/SadRogue.Primitives.Area.html
@@ -79,34 +79,43 @@ unique position in the area.</p>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">Area</span></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
     <div><a class="xref" href="SadRogue.Primitives.IReadOnlyArea.html">IReadOnlyArea</a></div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.IReadOnlyArea.html">IReadOnlyArea</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Area_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public class Area : IReadOnlyArea</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public class Area : IReadOnlyArea, IMatchable&lt;IReadOnlyArea&gt;, IEnumerable&lt;Point&gt;, IEnumerable</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -115,7 +124,7 @@ public class Area : IReadOnlyArea</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area__ctor.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L23">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L27">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area__ctor_" data-uid="SadRogue.Primitives.Area.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Area__ctor" data-uid="SadRogue.Primitives.Area.#ctor">Area()</h4>
@@ -126,6 +135,74 @@ public class Area : IReadOnlyArea</code></pre>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">public Area()</code></pre>
   </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area__ctor_SadRogue_Primitives_Point___.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.%23ctor(SadRogue.Primitives.Point%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L51">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Area__ctor_" data-uid="SadRogue.Primitives.Area.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_Area__ctor_SadRogue_Primitives_Point___" data-uid="SadRogue.Primitives.Area.#ctor(SadRogue.Primitives.Point[])">Area(Point[])</h4>
+  <div class="markdown level1 summary"><p>Constructor that takes initial points to add to the area.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Area(params Point[] initialPoints)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a>[]</td>
+        <td><span class="parametername">initialPoints</span></td>
+        <td><p>Initial points to add to the area.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.%23ctor(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L43">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Area__ctor_" data-uid="SadRogue.Primitives.Area.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_Area__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Area.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.Point})">Area(IEnumerable&lt;Point&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor that takes initial points to add to the area.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Area(IEnumerable&lt;Point&gt; initialPoints)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><span class="parametername">initialPoints</span></td>
+        <td><p>Initial points to add to the area.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="properties">Properties
   </h3>
   <span class="small pull-right mobile-hide">
@@ -133,7 +210,7 @@ public class Area : IReadOnlyArea</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Bounds.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Bounds%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L38">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L61">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Bounds_" data-uid="SadRogue.Primitives.Area.Bounds*"></a>
   <h4 id="SadRogue_Primitives_Area_Bounds" data-uid="SadRogue.Primitives.Area.Bounds">Bounds</h4>
@@ -164,7 +241,7 @@ public class Area : IReadOnlyArea</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Count.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L54">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L75">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Count_" data-uid="SadRogue.Primitives.Area.Count*"></a>
   <h4 id="SadRogue_Primitives_Area_Count" data-uid="SadRogue.Primitives.Area.Count">Count</h4>
@@ -185,27 +262,45 @@ public class Area : IReadOnlyArea</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Positions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Positions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L59">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L56">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Area_Positions_" data-uid="SadRogue.Primitives.Area.Positions*"></a>
-  <h4 id="SadRogue_Primitives_Area_Positions" data-uid="SadRogue.Primitives.Area.Positions">Positions</h4>
-  <div class="markdown level1 summary"><p>List of all (unique) positions in the area.</p>
+  <a id="SadRogue_Primitives_Area_Item_" data-uid="SadRogue.Primitives.Area.Item*"></a>
+  <h4 id="SadRogue_Primitives_Area_Item_System_Int32_" data-uid="SadRogue.Primitives.Area.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Returns positions from the area in the same fashion you would via a list.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IReadOnlyList&lt;Point&gt; Positions { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">public Point this[int index] { get; }</code></pre>
   </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">index</span></td>
+        <td><p>Index of list to retrieve.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -216,7 +311,7 @@ public class Area : IReadOnlyArea</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IReadOnlyList</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -228,7 +323,7 @@ public class Area : IReadOnlyArea</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Add_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Add(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L269">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L252">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Add_" data-uid="SadRogue.Primitives.Area.Add*"></a>
   <h4 id="SadRogue_Primitives_Area_Add_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.Add(SadRogue.Primitives.IReadOnlyArea)">Add(IReadOnlyArea)</h4>
@@ -262,7 +357,7 @@ public class Area : IReadOnlyArea</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Add_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Add(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L211">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L193">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Add_" data-uid="SadRogue.Primitives.Area.Add*"></a>
   <h4 id="SadRogue_Primitives_Area_Add_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Area.Add(SadRogue.Primitives.Point)">Add(Point)</h4>
@@ -301,7 +396,7 @@ this is an average case O(1) operation.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Add_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Add(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L257">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L242">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Add_" data-uid="SadRogue.Primitives.Area.Add*"></a>
   <h4 id="SadRogue_Primitives_Area_Add_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Area.Add(SadRogue.Primitives.Rectangle)">Add(Rectangle)</h4>
@@ -335,7 +430,7 @@ this is an average case O(1) operation.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Add_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Add(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L245">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L232">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Add_" data-uid="SadRogue.Primitives.Area.Add*"></a>
   <h4 id="SadRogue_Primitives_Area_Add_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Area.Add(System.Collections.Generic.IEnumerable{SadRogue.Primitives.Point})">Add(IEnumerable&lt;Point&gt;)</h4>
@@ -358,7 +453,7 @@ the list.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">positions</span></td>
         <td><p>Positions to add to the list.</p>
 </td>
@@ -367,10 +462,55 @@ the list.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Add_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Add(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L224">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Area_Add_" data-uid="SadRogue.Primitives.Area.Add*"></a>
+  <h4 id="SadRogue_Primitives_Area_Add_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Area.Add(System.Int32,System.Int32)">Add(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Adds the given position to the list of points within the area if it is not already in the
+list, or does nothing otherwise.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void Add(int positionX, int positionY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionX</span></td>
+        <td><p>X-value of the position to add.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionY</span></td>
+        <td><p>Y-value of the position to add.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_Area_Add_System_Int32_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Because the class uses a hash set internally to determine what points have already been added,
+this is an average case O(1) operation.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Contains_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Contains(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L291">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L282">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Contains_" data-uid="SadRogue.Primitives.Area.Contains*"></a>
   <h4 id="SadRogue_Primitives_Area_Contains_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.Contains(SadRogue.Primitives.IReadOnlyArea)">Contains(IReadOnlyArea)</h4>
@@ -409,7 +549,7 @@ the list.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the given area is completely contained within the current one, false otherwise.</p>
 </td>
       </tr>
@@ -420,7 +560,7 @@ the list.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Contains_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Contains(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L282">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L263">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Contains_" data-uid="SadRogue.Primitives.Area.Contains*"></a>
   <h4 id="SadRogue_Primitives_Area_Contains_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Area.Contains(SadRogue.Primitives.Point)">Contains(Point)</h4>
@@ -459,7 +599,7 @@ the list.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the specified position is within the area, false otherwise.</p>
 </td>
       </tr>
@@ -467,20 +607,19 @@ the list.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Contains_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Contains(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L317">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L272">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Area_Equals_" data-uid="SadRogue.Primitives.Area.Equals*"></a>
-  <h4 id="SadRogue_Primitives_Area_Equals_System_Object_" data-uid="SadRogue.Primitives.Area.Equals(System.Object)">Equals(Object)</h4>
-  <div class="markdown level1 summary"><p>Returns true if the given object is an Area and the two areas contain exactly the same points,
-false otherwise.</p>
+  <a id="SadRogue_Primitives_Area_Contains_" data-uid="SadRogue.Primitives.Area.Contains*"></a>
+  <h4 id="SadRogue_Primitives_Area_Contains_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Area.Contains(System.Int32,System.Int32)">Contains(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Determines whether or not the given position is within the area or not.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">public bool Contains(int positionX, int positionY)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -493,9 +632,15 @@ false otherwise.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
-        <td><span class="parametername">obj</span></td>
-        <td><p>Object to compare</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionX</span></td>
+        <td><p>X-value of the position to check.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionY</span></td>
+        <td><p>Y-value of the position to check.</p>
 </td>
       </tr>
     </tbody>
@@ -510,20 +655,18 @@ false otherwise.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the object given is a area and contains exactly the same points, false otherwise.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the specified position is within the area, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
-  <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.Object.Equals(System.Object)</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_GetDifference_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.GetDifference(SadRogue.Primitives.IReadOnlyArea%2CSadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L69">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L85">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_GetDifference_" data-uid="SadRogue.Primitives.Area.GetDifference*"></a>
   <h4 id="SadRogue_Primitives_Area_GetDifference_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.GetDifference(SadRogue.Primitives.IReadOnlyArea,SadRogue.Primitives.IReadOnlyArea)">GetDifference(IReadOnlyArea, IReadOnlyArea)</h4>
@@ -576,19 +719,19 @@ false otherwise.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L332">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L435">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Area_GetHashCode_" data-uid="SadRogue.Primitives.Area.GetHashCode*"></a>
-  <h4 id="SadRogue_Primitives_Area_GetHashCode" data-uid="SadRogue.Primitives.Area.GetHashCode">GetHashCode()</h4>
-  <div class="markdown level1 summary"><p>Returns hash of the underlying set.</p>
+  <a id="SadRogue_Primitives_Area_GetEnumerator_" data-uid="SadRogue.Primitives.Area.GetEnumerator*"></a>
+  <h4 id="SadRogue_Primitives_Area_GetEnumerator" data-uid="SadRogue.Primitives.Area.GetEnumerator">GetEnumerator()</h4>
+  <div class="markdown level1 summary"><p>Returns an enumerator that iterates through all positions in the Area, in the order they were added.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">public IEnumerator&lt;Point&gt; GetEnumerator()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -600,20 +743,18 @@ false otherwise.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
-        <td><p>Hash code for the underlying set.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>An enumerator that iterates through all the positions in the Area, in the order they were added.</p>
 </td>
       </tr>
     </tbody>
   </table>
-  <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.Object.GetHashCode()</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_GetIntersection_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.GetIntersection(SadRogue.Primitives.IReadOnlyArea%2CSadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L92">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L106">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_GetIntersection_" data-uid="SadRogue.Primitives.Area.GetIntersection*"></a>
   <h4 id="SadRogue_Primitives_Area_GetIntersection_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.GetIntersection(SadRogue.Primitives.IReadOnlyArea,SadRogue.Primitives.IReadOnlyArea)">GetIntersection(IReadOnlyArea, IReadOnlyArea)</h4>
@@ -667,7 +808,7 @@ false otherwise.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_GetUnion_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.GetUnion(SadRogue.Primitives.IReadOnlyArea%2CSadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L123">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L129">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_GetUnion_" data-uid="SadRogue.Primitives.Area.GetUnion*"></a>
   <h4 id="SadRogue_Primitives_Area_GetUnion_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.GetUnion(SadRogue.Primitives.IReadOnlyArea,SadRogue.Primitives.IReadOnlyArea)">GetUnion(IReadOnlyArea, IReadOnlyArea)</h4>
@@ -721,7 +862,7 @@ false otherwise.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Intersects_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Intersects(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L342">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L302">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Intersects_" data-uid="SadRogue.Primitives.Area.Intersects*"></a>
   <h4 id="SadRogue_Primitives_Area_Intersects_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.Intersects(SadRogue.Primitives.IReadOnlyArea)">Intersects(IReadOnlyArea)</h4>
@@ -763,8 +904,57 @@ check the number of positions in the result (0 if no intersection).</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the given map area intersects the current one, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Matches_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Matches(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L162">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Area_Matches_" data-uid="SadRogue.Primitives.Area.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Area_Matches_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.Matches(SadRogue.Primitives.IReadOnlyArea)">Matches(IReadOnlyArea)</h4>
+  <div class="markdown level1 summary"><p>Compares for equality. Returns true if the two areas contain exactly the same points.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(IReadOnlyArea other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.IReadOnlyArea.html">IReadOnlyArea</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the areas contain exactly the same points, false otherwise.</p>
 </td>
       </tr>
     </tbody>
@@ -774,7 +964,7 @@ check the number of positions in the result (0 if no intersection).</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L455">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L397">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
   <h4 id="SadRogue_Primitives_Area_Remove_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.Area.Remove(SadRogue.Primitives.IReadOnlyArea)">Remove(IReadOnlyArea)</h4>
@@ -808,7 +998,7 @@ check the number of positions in the result (0 if no intersection).</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L379">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L329">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
   <h4 id="SadRogue_Primitives_Area_Remove_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Area.Remove(SadRogue.Primitives.Point)">Remove(Point)</h4>
@@ -844,7 +1034,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L461">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L404">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
   <h4 id="SadRogue_Primitives_Area_Remove_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Area.Remove(SadRogue.Primitives.Rectangle)">Remove(Rectangle)</h4>
@@ -878,7 +1068,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_System_Collections_Generic_HashSet_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(System.Collections.Generic.HashSet%7BSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L413">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L366">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
   <h4 id="SadRogue_Primitives_Area_Remove_System_Collections_Generic_HashSet_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Area.Remove(System.Collections.Generic.HashSet{SadRogue.Primitives.Point})">Remove(HashSet&lt;Point&gt;)</h4>
@@ -900,7 +1090,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.HashSet</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.hashset-1">HashSet</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">positions</span></td>
         <td><p>Positions to remove.</p>
 </td>
@@ -912,7 +1102,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L439">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L384">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
   <h4 id="SadRogue_Primitives_Area_Remove_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Area.Remove(System.Collections.Generic.IEnumerable{SadRogue.Primitives.Point})">Remove(IEnumerable&lt;Point&gt;)</h4>
@@ -934,7 +1124,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">positions</span></td>
         <td><p>Positions to remove.</p>
 </td>
@@ -946,7 +1136,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_System_Func_SadRogue_Primitives_Point_System_Boolean__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(System.Func%7BSadRogue.Primitives.Point%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L385">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L346">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
   <h4 id="SadRogue_Primitives_Area_Remove_System_Func_SadRogue_Primitives_Point_System_Boolean__" data-uid="SadRogue.Primitives.Area.Remove(System.Func{SadRogue.Primitives.Point,System.Boolean})">Remove(Func&lt;Point, Boolean&gt;)</h4>
@@ -968,9 +1158,51 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Func</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <span class="xref">System.Boolean</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a>&gt;</td>
         <td><span class="parametername">predicate</span></td>
         <td><p>Predicate returning true for positions that should be removed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_Remove_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.Remove(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L339">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Area_Remove_" data-uid="SadRogue.Primitives.Area.Remove*"></a>
+  <h4 id="SadRogue_Primitives_Area_Remove_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Area.Remove(System.Int32,System.Int32)">Remove(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Removes the given position specified from the area. Particularly when the remove operation
+operation changes the bounds, this operation can be expensive, so if you must do multiple
+remove operations, it would be best to group them into 1 using <a class="xref" href="SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Remove_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__">Remove(IEnumerable&lt;Point&gt;)</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void Remove(int positionX, int positionY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionX</span></td>
+        <td><p>X-value of the position to remove.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionY</span></td>
+        <td><p>Y-value of the position to remove.</p>
 </td>
       </tr>
     </tbody>
@@ -980,7 +1212,7 @@ remove operations, it would be best to group them into 1 using <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L468">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L412">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_ToString_" data-uid="SadRogue.Primitives.Area.ToString*"></a>
   <h4 id="SadRogue_Primitives_Area_ToString" data-uid="SadRogue.Primitives.Area.ToString">ToString()</h4>
@@ -1002,14 +1234,14 @@ eg. [(1, 2), (3, 4), (5, 6)].</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
         <td><p>A string representation of those coordinates in the area.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.Object.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
   <h3 id="operators">Operators
   </h3>
   <span class="small pull-right mobile-hide">
@@ -1017,7 +1249,7 @@ eg. [(1, 2), (3, 4), (5, 6)].</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_op_Addition_SadRogue_Primitives_Area_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.op_Addition(SadRogue.Primitives.Area%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L149">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L147">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Area_op_Addition_" data-uid="SadRogue.Primitives.Area.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Area_op_Addition_SadRogue_Primitives_Area_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Area.op_Addition(SadRogue.Primitives.Area,SadRogue.Primitives.Point)">Addition(Area, Point)</h4>
@@ -1067,44 +1299,24 @@ eg. [(1, 2), (3, 4), (5, 6)].</p>
       </tr>
     </tbody>
   </table>
+  <h3 id="eii">Explicit Interface Implementations
+  </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_op_Equality_SadRogue_Primitives_Area_SadRogue_Primitives_Area_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.op_Equality(SadRogue.Primitives.Area%2CSadRogue.Primitives.Area)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L167">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L441">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Area_op_Equality_" data-uid="SadRogue.Primitives.Area.op_Equality*"></a>
-  <h4 id="SadRogue_Primitives_Area_op_Equality_SadRogue_Primitives_Area_SadRogue_Primitives_Area_" data-uid="SadRogue.Primitives.Area.op_Equality(SadRogue.Primitives.Area,SadRogue.Primitives.Area)">Equality(Area, Area)</h4>
-  <div class="markdown level1 summary"><p>Compares for equality. Returns true if the two areas contain exactly the same points.</p>
+  <a id="SadRogue_Primitives_Area_System_Collections_IEnumerable_GetEnumerator_" data-uid="SadRogue.Primitives.Area.System#Collections#IEnumerable#GetEnumerator*"></a>
+  <h4 id="SadRogue_Primitives_Area_System_Collections_IEnumerable_GetEnumerator" data-uid="SadRogue.Primitives.Area.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h4>
+  <div class="markdown level1 summary"><p>Returns an enumerator that iterates through all positions in the Area, in the order they were added.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Area lhs, Area rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Area.html">Area</a></td>
-        <td><span class="parametername">lhs</span></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Area.html">Area</a></td>
-        <td><span class="parametername">rhs</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1115,62 +1327,8 @@ eg. [(1, 2), (3, 4), (5, 6)].</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the areas contain exactly the same points, false otherwise.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area_op_Inequality_SadRogue_Primitives_Area_SadRogue_Primitives_Area_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area.op_Inequality(SadRogue.Primitives.Area%2CSadRogue.Primitives.Area)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L139">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Area_op_Inequality_" data-uid="SadRogue.Primitives.Area.op_Inequality*"></a>
-  <h4 id="SadRogue_Primitives_Area_op_Inequality_SadRogue_Primitives_Area_SadRogue_Primitives_Area_" data-uid="SadRogue.Primitives.Area.op_Inequality(SadRogue.Primitives.Area,SadRogue.Primitives.Area)">Inequality(Area, Area)</h4>
-  <div class="markdown level1 summary"><p>Inequality comparison -- true if the two areas do NOT contain exactly the same points.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Area lhs, Area rhs)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Area.html">Area</a></td>
-        <td><span class="parametername">lhs</span></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Area.html">Area</a></td>
-        <td><span class="parametername">rhs</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the areas do NOT contain exactly the same points, false otherwise.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></td>
+        <td><p>An enumerator that iterates through all the positions in the Area, in the order they were added.</p>
 </td>
       </tr>
     </tbody>
@@ -1178,6 +1336,15 @@ eg. [(1, 2), (3, 4), (5, 6)].</p>
   <h3 id="implements">Implements</h3>
   <div>
       <a class="xref" href="SadRogue.Primitives.IReadOnlyArea.html">IReadOnlyArea</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">System.Collections.Generic.IEnumerable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">System.Collections.IEnumerable</a>
   </div>
 </article>
           </div>
@@ -1190,7 +1357,7 @@ eg. [(1, 2), (3, 4), (5, 6)].</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Area.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Area%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L12" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Area.cs/#L15" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.BoundedRectangle.html
+++ b/docs/api/SadRogue.Primitives.BoundedRectangle.html
@@ -73,44 +73,50 @@
   
   <h1 id="SadRogue_Primitives_BoundedRectangle" data-uid="SadRogue.Primitives.BoundedRectangle" class="text-break">Class BoundedRectangle
   </h1>
-  <div class="markdown level0 summary"><p>This class defines a 2D rectanglar area, whose area is automatically &quot;locked&quot; to
+  <div class="markdown level0 summary"><p>This class defines a 2D rectangular area, whose area is automatically &quot;locked&quot; to
 being inside a rectangular bounding box as it is changed. A typical use might be
 keeping track of a camera's view area.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">BoundedRectangle</span></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_BoundedRectangle_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public class BoundedRectangle : IEquatable&lt;BoundedRectangle&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public class BoundedRectangle : IMatchable&lt;BoundedRectangle&gt;</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -119,7 +125,7 @@ public class BoundedRectangle : IEquatable&lt;BoundedRectangle&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle__ctor_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.%23ctor(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L25">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L26">View Source</a>
   </span>
   <a id="SadRogue_Primitives_BoundedRectangle__ctor_" data-uid="SadRogue.Primitives.BoundedRectangle.#ctor*"></a>
   <h4 id="SadRogue_Primitives_BoundedRectangle__ctor_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.#ctor(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">BoundedRectangle(Rectangle, Rectangle)</h4>
@@ -161,7 +167,7 @@ public class BoundedRectangle : IEquatable&lt;BoundedRectangle&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_Area.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.Area%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L37">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L38">View Source</a>
   </span>
   <a id="SadRogue_Primitives_BoundedRectangle_Area_" data-uid="SadRogue.Primitives.BoundedRectangle.Area*"></a>
   <h4 id="SadRogue_Primitives_BoundedRectangle_Area" data-uid="SadRogue.Primitives.BoundedRectangle.Area">Area</h4>
@@ -193,7 +199,7 @@ Use <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html#SadRogue_Pri
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_BoundingBox.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.BoundingBox%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L46">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L44">View Source</a>
   </span>
   <a id="SadRogue_Primitives_BoundedRectangle_BoundingBox_" data-uid="SadRogue.Primitives.BoundedRectangle.BoundingBox*"></a>
   <h4 id="SadRogue_Primitives_BoundedRectangle_BoundingBox" data-uid="SadRogue.Primitives.BoundedRectangle.BoundingBox">BoundingBox</h4>
@@ -224,19 +230,19 @@ Use <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html#SadRogue_Pri
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_Equals_SadRogue_Primitives_BoundedRectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.Equals(SadRogue.Primitives.BoundedRectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_Matches_SadRogue_Primitives_BoundedRectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.Matches(SadRogue.Primitives.BoundedRectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L53">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L51">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_BoundedRectangle_Equals_" data-uid="SadRogue.Primitives.BoundedRectangle.Equals*"></a>
-  <h4 id="SadRogue_Primitives_BoundedRectangle_Equals_SadRogue_Primitives_BoundedRectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.Equals(SadRogue.Primitives.BoundedRectangle)">Equals(BoundedRectangle)</h4>
+  <a id="SadRogue_Primitives_BoundedRectangle_Matches_" data-uid="SadRogue.Primitives.BoundedRectangle.Matches*"></a>
+  <h4 id="SadRogue_Primitives_BoundedRectangle_Matches_SadRogue_Primitives_BoundedRectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.Matches(SadRogue.Primitives.BoundedRectangle)">Matches(BoundedRectangle)</h4>
   <div class="markdown level1 summary"><p>True if the given BoundedRectangle has the same Bounds and Area as the current one.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(BoundedRectangle other)</code></pre>
+    <pre><code class="lang-csharp hljs">public bool Matches(BoundedRectangle other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -266,7 +272,7 @@ Use <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html#SadRogue_Pri
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two BoundedRectangles are the same, false if not.</p>
 </td>
       </tr>
@@ -274,95 +280,10 @@ Use <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html#SadRogue_Pri
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L62">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_BoundedRectangle_Equals_" data-uid="SadRogue.Primitives.BoundedRectangle.Equals*"></a>
-  <h4 id="SadRogue_Primitives_BoundedRectangle_Equals_System_Object_" data-uid="SadRogue.Primitives.BoundedRectangle.Equals(System.Object)">Equals(Object)</h4>
-  <div class="markdown level1 summary"><p>Same as operator == in this case; returns false if <code data-dev-comment-type="paramref" class="paramref">obj</code> is not a BoundedRectangle.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Object</span></td>
-        <td><span class="parametername">obj</span></td>
-        <td><p>The object to compare the current BoundedRectangle to.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a BoundedRectangle, and the two BoundedRectangles are the same, false otherwise.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.Object.Equals(System.Object)</span></div>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L68">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_BoundedRectangle_GetHashCode_" data-uid="SadRogue.Primitives.BoundedRectangle.GetHashCode*"></a>
-  <h4 id="SadRogue_Primitives_BoundedRectangle_GetHashCode" data-uid="SadRogue.Primitives.BoundedRectangle.GetHashCode">GetHashCode()</h4>
-  <div class="markdown level1 summary"><p>Returns a hash-map value for the current object.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
-  </div>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Int32</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.Object.GetHashCode()</span></div>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_SetArea_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.SetArea(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L92">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L58">View Source</a>
   </span>
   <a id="SadRogue_Primitives_BoundedRectangle_SetArea_" data-uid="SadRogue.Primitives.BoundedRectangle.SetArea*"></a>
   <h4 id="SadRogue_Primitives_BoundedRectangle_SetArea_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.SetArea(SadRogue.Primitives.Rectangle)">SetArea(Rectangle)</h4>
@@ -396,7 +317,7 @@ Use <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html#SadRogue_Pri
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_SetBoundingBox_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.SetBoundingBox(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L106">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L70">View Source</a>
   </span>
   <a id="SadRogue_Primitives_BoundedRectangle_SetBoundingBox_" data-uid="SadRogue.Primitives.BoundedRectangle.SetBoundingBox*"></a>
   <h4 id="SadRogue_Primitives_BoundedRectangle_SetBoundingBox_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.SetBoundingBox(SadRogue.Primitives.Rectangle)">SetBoundingBox(Rectangle)</h4>
@@ -426,119 +347,9 @@ as needed.</p>
       </tr>
     </tbody>
   </table>
-  <h3 id="operators">Operators
-  </h3>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_op_Equality_SadRogue_Primitives_BoundedRectangle_SadRogue_Primitives_BoundedRectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.op_Equality(SadRogue.Primitives.BoundedRectangle%2CSadRogue.Primitives.BoundedRectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L76">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_BoundedRectangle_op_Equality_" data-uid="SadRogue.Primitives.BoundedRectangle.op_Equality*"></a>
-  <h4 id="SadRogue_Primitives_BoundedRectangle_op_Equality_SadRogue_Primitives_BoundedRectangle_SadRogue_Primitives_BoundedRectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.op_Equality(SadRogue.Primitives.BoundedRectangle,SadRogue.Primitives.BoundedRectangle)">Equality(BoundedRectangle, BoundedRectangle)</h4>
-  <div class="markdown level1 summary"><p>True if the two BoundedRectangle objects are equivalent.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(BoundedRectangle lhs, BoundedRectangle rhs)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></td>
-        <td><span class="parametername">lhs</span></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></td>
-        <td><span class="parametername">rhs</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the two BoundedRectangle objects are equivalent, false if not.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle_op_Inequality_SadRogue_Primitives_BoundedRectangle_SadRogue_Primitives_BoundedRectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle.op_Inequality(SadRogue.Primitives.BoundedRectangle%2CSadRogue.Primitives.BoundedRectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L86">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_BoundedRectangle_op_Inequality_" data-uid="SadRogue.Primitives.BoundedRectangle.op_Inequality*"></a>
-  <h4 id="SadRogue_Primitives_BoundedRectangle_op_Inequality_SadRogue_Primitives_BoundedRectangle_SadRogue_Primitives_BoundedRectangle_" data-uid="SadRogue.Primitives.BoundedRectangle.op_Inequality(SadRogue.Primitives.BoundedRectangle,SadRogue.Primitives.BoundedRectangle)">Inequality(BoundedRectangle, BoundedRectangle)</h4>
-  <div class="markdown level1 summary"><p>True if the types are not equal.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(BoundedRectangle lhs, BoundedRectangle rhs)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></td>
-        <td><span class="parametername">lhs</span></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></td>
-        <td><span class="parametername">rhs</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the types are not equal, false if they are both equal.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -551,7 +362,7 @@ as needed.</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_BoundedRectangle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.BoundedRectangle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L10" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/BoundedRectangle.cs/#L11" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Color.html
+++ b/docs/api/SadRogue.Primitives.Color.html
@@ -78,18 +78,19 @@
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
@@ -97,8 +98,7 @@
   <h5 id="SadRogue_Primitives_Color_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">[DataContract]
-[Serializable]
-public struct Color : IEquatable&lt;Color&gt;</code></pre>
+public struct Color : IEquatable&lt;Color&gt;, IMatchable&lt;Color&gt;</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -135,7 +135,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">alpha</span></td>
         <td><p>The alpha component value from 0 to 255.</p>
 </td>
@@ -147,7 +147,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_SadRogue_Primitives_Color_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(SadRogue.Primitives.Color%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L204">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L202">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_SadRogue_Primitives_Color_System_Single_" data-uid="SadRogue.Primitives.Color.#ctor(SadRogue.Primitives.Color,System.Single)">Color(Color, Single)</h4>
@@ -175,7 +175,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">alpha</span></td>
         <td><p>Alpha component value from 0.0f to 1.0f.</p>
 </td>
@@ -187,7 +187,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_System_Byte_System_Byte_System_Byte_System_Byte_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(System.Byte%2CSystem.Byte%2CSystem.Byte%2CSystem.Byte)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L290">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L282">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_System_Byte_System_Byte_System_Byte_System_Byte_" data-uid="SadRogue.Primitives.Color.#ctor(System.Byte,System.Byte,System.Byte,System.Byte)">Color(Byte, Byte, Byte, Byte)</h4>
@@ -209,22 +209,22 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">r</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">g</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">b</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">alpha</span></td>
         <td></td>
       </tr>
@@ -238,7 +238,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L238">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L234">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Color.#ctor(System.Int32,System.Int32,System.Int32)">Color(Int32, Int32, Int32)</h4>
@@ -260,19 +260,19 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">r</span></td>
         <td><p>Red component value from 0 to 255.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">g</span></td>
         <td><p>Green component value from 0 to 255.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">b</span></td>
         <td><p>Blue component value from 0 to 255.</p>
 </td>
@@ -284,7 +284,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L263">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L257">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Color.#ctor(System.Int32,System.Int32,System.Int32,System.Int32)">Color(Int32, Int32, Int32, Int32)</h4>
@@ -306,25 +306,25 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">r</span></td>
         <td><p>Red component value from 0 to 255.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">g</span></td>
         <td><p>Green component value from 0 to 255.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">b</span></td>
         <td><p>Blue component value from 0 to 255.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">alpha</span></td>
         <td><p>Alpha component value from 0 to 255.</p>
 </td>
@@ -336,7 +336,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_System_Single_System_Single_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(System.Single%2CSystem.Single%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L215">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L213">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_System_Single_System_Single_System_Single_" data-uid="SadRogue.Primitives.Color.#ctor(System.Single,System.Single,System.Single)">Color(Single, Single, Single)</h4>
@@ -358,19 +358,19 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">r</span></td>
         <td><p>Red component value from 0.0f to 1.0f.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">g</span></td>
         <td><p>Green component value from 0.0f to 1.0f.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">b</span></td>
         <td><p>Blue component value from 0.0f to 1.0f.</p>
 </td>
@@ -382,7 +382,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_System_Single_System_Single_System_Single_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(System.Single%2CSystem.Single%2CSystem.Single%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L227">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L224">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_System_Single_System_Single_System_Single_System_Single_" data-uid="SadRogue.Primitives.Color.#ctor(System.Single,System.Single,System.Single,System.Single)">Color(Single, Single, Single, Single)</h4>
@@ -404,25 +404,25 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">r</span></td>
         <td><p>Red component value from 0.0f to 1.0f.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">g</span></td>
         <td><p>Green component value from 0.0f to 1.0f.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">b</span></td>
         <td><p>Blue component value from 0.0f to 1.0f.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">alpha</span></td>
         <td><p>Alpha component value from 0.0f to 1.0f.</p>
 </td>
@@ -434,7 +434,7 @@ public struct Color : IEquatable&lt;Color&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color__ctor_System_UInt32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.%23ctor(System.UInt32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L177">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L178">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color__ctor_" data-uid="SadRogue.Primitives.Color.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Color__ctor_System_UInt32_" data-uid="SadRogue.Primitives.Color.#ctor(System.UInt32)">Color(UInt32)</h4>
@@ -444,8 +444,7 @@ The value is a 32-bit unsigned integer, with R in the least significant octet.</
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[CLSCompliant(false)]
-public Color(uint packedValue)</code></pre>
+    <pre><code class="lang-csharp hljs">public Color(uint packedValue)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -458,7 +457,7 @@ public Color(uint packedValue)</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.UInt32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.uint32">UInt32</a></td>
         <td><span class="parametername">packedValue</span></td>
         <td><p>The packed value.</p>
 </td>
@@ -469,10 +468,40 @@ public Color(uint packedValue)</code></pre>
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AliceBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AliceBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L473">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_AliceBlue" data-uid="SadRogue.Primitives.Color.AliceBlue">AliceBlue</h4>
+  <div class="markdown level1 summary"><p>AliceBlue color (R:240,G:248,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color AliceBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiBlack.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiBlack%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L385">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L379">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiBlack" data-uid="SadRogue.Primitives.Color.AnsiBlack">AnsiBlack</h4>
   <div class="markdown level1 summary"><p>The black ansi color (0, 0, 0).</p>
@@ -480,7 +509,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiBlack</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiBlack</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -502,7 +531,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiBlackBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiBlackBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L418">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L419">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiBlackBright" data-uid="SadRogue.Primitives.Color.AnsiBlackBright">AnsiBlackBright</h4>
   <div class="markdown level1 summary"><p>The BlackBright ansi color (85, 85, 85).</p>
@@ -510,7 +539,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiBlackBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiBlackBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -532,7 +561,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L401">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L399">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiBlue" data-uid="SadRogue.Primitives.Color.AnsiBlue">AnsiBlue</h4>
   <div class="markdown level1 summary"><p>The Blue ansi color (0, 0, 170).</p>
@@ -540,7 +569,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiBlue</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiBlue</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -562,7 +591,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiBlueBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiBlueBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L434">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L439">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiBlueBright" data-uid="SadRogue.Primitives.Color.AnsiBlueBright">AnsiBlueBright</h4>
   <div class="markdown level1 summary"><p>The BlueBright ansi color (85, 85, 255).</p>
@@ -570,7 +599,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiBlueBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiBlueBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -600,7 +629,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiCyan</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiCyan</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -622,7 +651,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiCyanBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiCyanBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L442">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L449">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiCyanBright" data-uid="SadRogue.Primitives.Color.AnsiCyanBright">AnsiCyanBright</h4>
   <div class="markdown level1 summary"><p>The CyanBright ansi color (85, 255, 255).</p>
@@ -630,7 +659,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiCyanBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiCyanBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -652,7 +681,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L393">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L389">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiGreen" data-uid="SadRogue.Primitives.Color.AnsiGreen">AnsiGreen</h4>
   <div class="markdown level1 summary"><p>The Green ansi color 0, 170, 0).</p>
@@ -660,7 +689,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiGreen</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiGreen</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -682,7 +711,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiGreenBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiGreenBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L426">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L429">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiGreenBright" data-uid="SadRogue.Primitives.Color.AnsiGreenBright">AnsiGreenBright</h4>
   <div class="markdown level1 summary"><p>The GreenBright ansi color (85, 255, 85).</p>
@@ -690,7 +719,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiGreenBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiGreenBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -712,7 +741,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiMagenta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiMagenta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L405">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L404">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiMagenta" data-uid="SadRogue.Primitives.Color.AnsiMagenta">AnsiMagenta</h4>
   <div class="markdown level1 summary"><p>The Magenta ansi color (170, 0, 170).</p>
@@ -720,7 +749,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiMagenta</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiMagenta</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -742,7 +771,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiMagentaBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiMagentaBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L438">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L444">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiMagentaBright" data-uid="SadRogue.Primitives.Color.AnsiMagentaBright">AnsiMagentaBright</h4>
   <div class="markdown level1 summary"><p>The MagentaBright ansi color (255, 85, 255).</p>
@@ -750,7 +779,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiMagentaBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiMagentaBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -772,7 +801,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L389">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L384">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiRed" data-uid="SadRogue.Primitives.Color.AnsiRed">AnsiRed</h4>
   <div class="markdown level1 summary"><p>The Red ansi color (170, 0, 0).</p>
@@ -780,7 +809,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiRed</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiRed</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -802,7 +831,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiRedBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiRedBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L422">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L424">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiRedBright" data-uid="SadRogue.Primitives.Color.AnsiRedBright">AnsiRedBright</h4>
   <div class="markdown level1 summary"><p>The RedBright ansi color (255, 85, 85).</p>
@@ -810,7 +839,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiRedBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiRedBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -832,7 +861,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L413">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L414">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiWhite" data-uid="SadRogue.Primitives.Color.AnsiWhite">AnsiWhite</h4>
   <div class="markdown level1 summary"><p>The White ansi color (170, 170, 170).</p>
@@ -840,7 +869,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiWhite</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiWhite</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -862,7 +891,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiWhiteBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiWhiteBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L446">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L454">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiWhiteBright" data-uid="SadRogue.Primitives.Color.AnsiWhiteBright">AnsiWhiteBright</h4>
   <div class="markdown level1 summary"><p>The WhiteBright ansi color (255, 255, 255).</p>
@@ -870,7 +899,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiWhiteBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiWhiteBright</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -892,7 +921,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L397">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L394">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiYellow" data-uid="SadRogue.Primitives.Color.AnsiYellow">AnsiYellow</h4>
   <div class="markdown level1 summary"><p>The Yellow ansi color (170, 85, 0).</p>
@@ -900,7 +929,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiYellow</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiYellow</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -922,7 +951,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AnsiYellowBright.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AnsiYellowBright%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L430">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L434">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Color_AnsiYellowBright" data-uid="SadRogue.Primitives.Color.AnsiYellowBright">AnsiYellowBright</h4>
   <div class="markdown level1 summary"><p>The YellowBright ansi color (255, 255, 85).</p>
@@ -930,7 +959,4267 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AnsiYellowBright</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Color AnsiYellowBright</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AntiqueWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AntiqueWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L478">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_AntiqueWhite" data-uid="SadRogue.Primitives.Color.AntiqueWhite">AntiqueWhite</h4>
+  <div class="markdown level1 summary"><p>AntiqueWhite color (R:250,G:235,B:215,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color AntiqueWhite</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Aqua.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Aqua%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L483">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Aqua" data-uid="SadRogue.Primitives.Color.Aqua">Aqua</h4>
+  <div class="markdown level1 summary"><p>Aqua color (R:0,G:255,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Aqua</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Aquamarine.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Aquamarine%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L488">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Aquamarine" data-uid="SadRogue.Primitives.Color.Aquamarine">Aquamarine</h4>
+  <div class="markdown level1 summary"><p>Aquamarine color (R:127,G:255,B:212,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Aquamarine</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Azure.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Azure%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L493">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Azure" data-uid="SadRogue.Primitives.Color.Azure">Azure</h4>
+  <div class="markdown level1 summary"><p>Azure color (R:240,G:255,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Azure</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Beige.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Beige%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L498">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Beige" data-uid="SadRogue.Primitives.Color.Beige">Beige</h4>
+  <div class="markdown level1 summary"><p>Beige color (R:245,G:245,B:220,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Beige</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Bisque.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Bisque%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L503">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Bisque" data-uid="SadRogue.Primitives.Color.Bisque">Bisque</h4>
+  <div class="markdown level1 summary"><p>Bisque color (R:255,G:228,B:196,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Bisque</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Black.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Black%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L508">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Black" data-uid="SadRogue.Primitives.Color.Black">Black</h4>
+  <div class="markdown level1 summary"><p>Black color (R:0,G:0,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Black</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_BlanchedAlmond.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.BlanchedAlmond%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L513">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_BlanchedAlmond" data-uid="SadRogue.Primitives.Color.BlanchedAlmond">BlanchedAlmond</h4>
+  <div class="markdown level1 summary"><p>BlanchedAlmond color (R:255,G:235,B:205,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color BlanchedAlmond</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Blue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Blue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L518">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Blue" data-uid="SadRogue.Primitives.Color.Blue">Blue</h4>
+  <div class="markdown level1 summary"><p>Blue color (R:0,G:0,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Blue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_BlueViolet.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.BlueViolet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L523">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_BlueViolet" data-uid="SadRogue.Primitives.Color.BlueViolet">BlueViolet</h4>
+  <div class="markdown level1 summary"><p>BlueViolet color (R:138,G:43,B:226,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color BlueViolet</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Brown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Brown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L528">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Brown" data-uid="SadRogue.Primitives.Color.Brown">Brown</h4>
+  <div class="markdown level1 summary"><p>Brown color (R:165,G:42,B:42,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Brown</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_BurlyWood.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.BurlyWood%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L533">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_BurlyWood" data-uid="SadRogue.Primitives.Color.BurlyWood">BurlyWood</h4>
+  <div class="markdown level1 summary"><p>BurlyWood color (R:222,G:184,B:135,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color BurlyWood</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_CadetBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.CadetBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L538">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_CadetBlue" data-uid="SadRogue.Primitives.Color.CadetBlue">CadetBlue</h4>
+  <div class="markdown level1 summary"><p>CadetBlue color (R:95,G:158,B:160,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color CadetBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Chartreuse.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Chartreuse%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L543">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Chartreuse" data-uid="SadRogue.Primitives.Color.Chartreuse">Chartreuse</h4>
+  <div class="markdown level1 summary"><p>Chartreuse color (R:127,G:255,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Chartreuse</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Chocolate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Chocolate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L548">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Chocolate" data-uid="SadRogue.Primitives.Color.Chocolate">Chocolate</h4>
+  <div class="markdown level1 summary"><p>Chocolate color (R:210,G:105,B:30,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Chocolate</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Coral.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Coral%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L553">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Coral" data-uid="SadRogue.Primitives.Color.Coral">Coral</h4>
+  <div class="markdown level1 summary"><p>Coral color (R:255,G:127,B:80,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Coral</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_CornflowerBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.CornflowerBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L558">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_CornflowerBlue" data-uid="SadRogue.Primitives.Color.CornflowerBlue">CornflowerBlue</h4>
+  <div class="markdown level1 summary"><p>CornflowerBlue color (R:100,G:149,B:237,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color CornflowerBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Cornsilk.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Cornsilk%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L563">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Cornsilk" data-uid="SadRogue.Primitives.Color.Cornsilk">Cornsilk</h4>
+  <div class="markdown level1 summary"><p>Cornsilk color (R:255,G:248,B:220,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Cornsilk</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Crimson.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Crimson%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L568">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Crimson" data-uid="SadRogue.Primitives.Color.Crimson">Crimson</h4>
+  <div class="markdown level1 summary"><p>Crimson color (R:220,G:20,B:60,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Crimson</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Cyan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Cyan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L573">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Cyan" data-uid="SadRogue.Primitives.Color.Cyan">Cyan</h4>
+  <div class="markdown level1 summary"><p>Cyan color (R:0,G:255,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Cyan</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L578">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkBlue" data-uid="SadRogue.Primitives.Color.DarkBlue">DarkBlue</h4>
+  <div class="markdown level1 summary"><p>DarkBlue color (R:0,G:0,B:139,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkCyan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkCyan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L583">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkCyan" data-uid="SadRogue.Primitives.Color.DarkCyan">DarkCyan</h4>
+  <div class="markdown level1 summary"><p>DarkCyan color (R:0,G:139,B:139,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkCyan</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkGoldenrod.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkGoldenrod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L588">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkGoldenrod" data-uid="SadRogue.Primitives.Color.DarkGoldenrod">DarkGoldenrod</h4>
+  <div class="markdown level1 summary"><p>DarkGoldenrod color (R:184,G:134,B:11,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkGoldenrod</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L593">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkGray" data-uid="SadRogue.Primitives.Color.DarkGray">DarkGray</h4>
+  <div class="markdown level1 summary"><p>DarkGray color (R:169,G:169,B:169,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkGray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L598">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkGreen" data-uid="SadRogue.Primitives.Color.DarkGreen">DarkGreen</h4>
+  <div class="markdown level1 summary"><p>DarkGreen color (R:0,G:100,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkKhaki.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkKhaki%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L603">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkKhaki" data-uid="SadRogue.Primitives.Color.DarkKhaki">DarkKhaki</h4>
+  <div class="markdown level1 summary"><p>DarkKhaki color (R:189,G:183,B:107,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkKhaki</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkMagenta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkMagenta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L608">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkMagenta" data-uid="SadRogue.Primitives.Color.DarkMagenta">DarkMagenta</h4>
+  <div class="markdown level1 summary"><p>DarkMagenta color (R:139,G:0,B:139,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkMagenta</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkOliveGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkOliveGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L613">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkOliveGreen" data-uid="SadRogue.Primitives.Color.DarkOliveGreen">DarkOliveGreen</h4>
+  <div class="markdown level1 summary"><p>DarkOliveGreen color (R:85,G:107,B:47,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkOliveGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkOrange.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkOrange%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L618">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkOrange" data-uid="SadRogue.Primitives.Color.DarkOrange">DarkOrange</h4>
+  <div class="markdown level1 summary"><p>DarkOrange color (R:255,G:140,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkOrange</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkOrchid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkOrchid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L623">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkOrchid" data-uid="SadRogue.Primitives.Color.DarkOrchid">DarkOrchid</h4>
+  <div class="markdown level1 summary"><p>DarkOrchid color (R:153,G:50,B:204,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkOrchid</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L628">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkRed" data-uid="SadRogue.Primitives.Color.DarkRed">DarkRed</h4>
+  <div class="markdown level1 summary"><p>DarkRed color (R:139,G:0,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkRed</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSalmon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSalmon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L633">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkSalmon" data-uid="SadRogue.Primitives.Color.DarkSalmon">DarkSalmon</h4>
+  <div class="markdown level1 summary"><p>DarkSalmon color (R:233,G:150,B:122,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkSalmon</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L638">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkSeaGreen" data-uid="SadRogue.Primitives.Color.DarkSeaGreen">DarkSeaGreen</h4>
+  <div class="markdown level1 summary"><p>DarkSeaGreen color (R:143,G:188,B:139,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkSeaGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSlateBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSlateBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L643">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkSlateBlue" data-uid="SadRogue.Primitives.Color.DarkSlateBlue">DarkSlateBlue</h4>
+  <div class="markdown level1 summary"><p>DarkSlateBlue color (R:72,G:61,B:139,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkSlateBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSlateGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSlateGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L648">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkSlateGray" data-uid="SadRogue.Primitives.Color.DarkSlateGray">DarkSlateGray</h4>
+  <div class="markdown level1 summary"><p>DarkSlateGray color (R:47,G:79,B:79,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkSlateGray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkTurquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkTurquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L653">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkTurquoise" data-uid="SadRogue.Primitives.Color.DarkTurquoise">DarkTurquoise</h4>
+  <div class="markdown level1 summary"><p>DarkTurquoise color (R:0,G:206,B:209,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkTurquoise</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkViolet.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkViolet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L658">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DarkViolet" data-uid="SadRogue.Primitives.Color.DarkViolet">DarkViolet</h4>
+  <div class="markdown level1 summary"><p>DarkViolet color (R:148,G:0,B:211,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DarkViolet</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DeepPink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DeepPink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L663">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DeepPink" data-uid="SadRogue.Primitives.Color.DeepPink">DeepPink</h4>
+  <div class="markdown level1 summary"><p>DeepPink color (R:255,G:20,B:147,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DeepPink</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DeepSkyBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DeepSkyBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L668">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DeepSkyBlue" data-uid="SadRogue.Primitives.Color.DeepSkyBlue">DeepSkyBlue</h4>
+  <div class="markdown level1 summary"><p>DeepSkyBlue color (R:0,G:191,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DeepSkyBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DimGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DimGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L673">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DimGray" data-uid="SadRogue.Primitives.Color.DimGray">DimGray</h4>
+  <div class="markdown level1 summary"><p>DimGray color (R:105,G:105,B:105,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DimGray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DodgerBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DodgerBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L678">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_DodgerBlue" data-uid="SadRogue.Primitives.Color.DodgerBlue">DodgerBlue</h4>
+  <div class="markdown level1 summary"><p>DodgerBlue color (R:30,G:144,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color DodgerBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Firebrick.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Firebrick%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L683">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Firebrick" data-uid="SadRogue.Primitives.Color.Firebrick">Firebrick</h4>
+  <div class="markdown level1 summary"><p>Firebrick color (R:178,G:34,B:34,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Firebrick</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_FloralWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.FloralWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L688">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_FloralWhite" data-uid="SadRogue.Primitives.Color.FloralWhite">FloralWhite</h4>
+  <div class="markdown level1 summary"><p>FloralWhite color (R:255,G:250,B:240,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color FloralWhite</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_ForestGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.ForestGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L693">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_ForestGreen" data-uid="SadRogue.Primitives.Color.ForestGreen">ForestGreen</h4>
+  <div class="markdown level1 summary"><p>ForestGreen color (R:34,G:139,B:34,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color ForestGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Fuchsia.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Fuchsia%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L698">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Fuchsia" data-uid="SadRogue.Primitives.Color.Fuchsia">Fuchsia</h4>
+  <div class="markdown level1 summary"><p>Fuchsia color (R:255,G:0,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Fuchsia</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Gainsboro.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Gainsboro%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L703">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Gainsboro" data-uid="SadRogue.Primitives.Color.Gainsboro">Gainsboro</h4>
+  <div class="markdown level1 summary"><p>Gainsboro color (R:220,G:220,B:220,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Gainsboro</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GhostWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GhostWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L708">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_GhostWhite" data-uid="SadRogue.Primitives.Color.GhostWhite">GhostWhite</h4>
+  <div class="markdown level1 summary"><p>GhostWhite color (R:248,G:248,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color GhostWhite</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Gold.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Gold%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L713">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Gold" data-uid="SadRogue.Primitives.Color.Gold">Gold</h4>
+  <div class="markdown level1 summary"><p>Gold color (R:255,G:215,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Gold</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Goldenrod.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Goldenrod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L718">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Goldenrod" data-uid="SadRogue.Primitives.Color.Goldenrod">Goldenrod</h4>
+  <div class="markdown level1 summary"><p>Goldenrod color (R:218,G:165,B:32,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Goldenrod</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Gray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Gray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L723">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Gray" data-uid="SadRogue.Primitives.Color.Gray">Gray</h4>
+  <div class="markdown level1 summary"><p>Gray color (R:128,G:128,B:128,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Gray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Green.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Green%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L728">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Green" data-uid="SadRogue.Primitives.Color.Green">Green</h4>
+  <div class="markdown level1 summary"><p>Green color (R:0,G:128,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Green</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GreenYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GreenYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L733">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_GreenYellow" data-uid="SadRogue.Primitives.Color.GreenYellow">GreenYellow</h4>
+  <div class="markdown level1 summary"><p>GreenYellow color (R:173,G:255,B:47,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color GreenYellow</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Honeydew.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Honeydew%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L738">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Honeydew" data-uid="SadRogue.Primitives.Color.Honeydew">Honeydew</h4>
+  <div class="markdown level1 summary"><p>Honeydew color (R:240,G:255,B:240,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Honeydew</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_HotPink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.HotPink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L743">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_HotPink" data-uid="SadRogue.Primitives.Color.HotPink">HotPink</h4>
+  <div class="markdown level1 summary"><p>HotPink color (R:255,G:105,B:180,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color HotPink</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_IndianRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.IndianRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L748">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_IndianRed" data-uid="SadRogue.Primitives.Color.IndianRed">IndianRed</h4>
+  <div class="markdown level1 summary"><p>IndianRed color (R:205,G:92,B:92,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color IndianRed</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Indigo.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Indigo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L753">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Indigo" data-uid="SadRogue.Primitives.Color.Indigo">Indigo</h4>
+  <div class="markdown level1 summary"><p>Indigo color (R:75,G:0,B:130,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Indigo</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Ivory.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Ivory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L758">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Ivory" data-uid="SadRogue.Primitives.Color.Ivory">Ivory</h4>
+  <div class="markdown level1 summary"><p>Ivory color (R:255,G:255,B:240,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Ivory</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Khaki.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Khaki%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L763">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Khaki" data-uid="SadRogue.Primitives.Color.Khaki">Khaki</h4>
+  <div class="markdown level1 summary"><p>Khaki color (R:240,G:230,B:140,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Khaki</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Lavender.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Lavender%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L768">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Lavender" data-uid="SadRogue.Primitives.Color.Lavender">Lavender</h4>
+  <div class="markdown level1 summary"><p>Lavender color (R:230,G:230,B:250,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Lavender</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LavenderBlush.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LavenderBlush%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L773">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LavenderBlush" data-uid="SadRogue.Primitives.Color.LavenderBlush">LavenderBlush</h4>
+  <div class="markdown level1 summary"><p>LavenderBlush color (R:255,G:240,B:245,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LavenderBlush</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LawnGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LawnGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L778">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LawnGreen" data-uid="SadRogue.Primitives.Color.LawnGreen">LawnGreen</h4>
+  <div class="markdown level1 summary"><p>LawnGreen color (R:124,G:252,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LawnGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LemonChiffon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LemonChiffon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L783">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LemonChiffon" data-uid="SadRogue.Primitives.Color.LemonChiffon">LemonChiffon</h4>
+  <div class="markdown level1 summary"><p>LemonChiffon color (R:255,G:250,B:205,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LemonChiffon</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L788">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightBlue" data-uid="SadRogue.Primitives.Color.LightBlue">LightBlue</h4>
+  <div class="markdown level1 summary"><p>LightBlue color (R:173,G:216,B:230,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightCoral.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightCoral%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L793">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightCoral" data-uid="SadRogue.Primitives.Color.LightCoral">LightCoral</h4>
+  <div class="markdown level1 summary"><p>LightCoral color (R:240,G:128,B:128,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightCoral</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightCyan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightCyan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L798">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightCyan" data-uid="SadRogue.Primitives.Color.LightCyan">LightCyan</h4>
+  <div class="markdown level1 summary"><p>LightCyan color (R:224,G:255,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightCyan</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightGoldenrodYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightGoldenrodYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L803">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightGoldenrodYellow" data-uid="SadRogue.Primitives.Color.LightGoldenrodYellow">LightGoldenrodYellow</h4>
+  <div class="markdown level1 summary"><p>LightGoldenrodYellow color (R:250,G:250,B:210,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightGoldenrodYellow</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L808">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightGray" data-uid="SadRogue.Primitives.Color.LightGray">LightGray</h4>
+  <div class="markdown level1 summary"><p>LightGray color (R:211,G:211,B:211,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightGray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L813">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightGreen" data-uid="SadRogue.Primitives.Color.LightGreen">LightGreen</h4>
+  <div class="markdown level1 summary"><p>LightGreen color (R:144,G:238,B:144,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightPink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightPink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L818">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightPink" data-uid="SadRogue.Primitives.Color.LightPink">LightPink</h4>
+  <div class="markdown level1 summary"><p>LightPink color (R:255,G:182,B:193,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightPink</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSalmon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSalmon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L823">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightSalmon" data-uid="SadRogue.Primitives.Color.LightSalmon">LightSalmon</h4>
+  <div class="markdown level1 summary"><p>LightSalmon color (R:255,G:160,B:122,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightSalmon</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L828">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightSeaGreen" data-uid="SadRogue.Primitives.Color.LightSeaGreen">LightSeaGreen</h4>
+  <div class="markdown level1 summary"><p>LightSeaGreen color (R:32,G:178,B:170,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightSeaGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSkyBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSkyBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L833">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightSkyBlue" data-uid="SadRogue.Primitives.Color.LightSkyBlue">LightSkyBlue</h4>
+  <div class="markdown level1 summary"><p>LightSkyBlue color (R:135,G:206,B:250,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightSkyBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSlateGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSlateGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L838">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightSlateGray" data-uid="SadRogue.Primitives.Color.LightSlateGray">LightSlateGray</h4>
+  <div class="markdown level1 summary"><p>LightSlateGray color (R:119,G:136,B:153,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightSlateGray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSteelBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSteelBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L843">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightSteelBlue" data-uid="SadRogue.Primitives.Color.LightSteelBlue">LightSteelBlue</h4>
+  <div class="markdown level1 summary"><p>LightSteelBlue color (R:176,G:196,B:222,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightSteelBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L848">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LightYellow" data-uid="SadRogue.Primitives.Color.LightYellow">LightYellow</h4>
+  <div class="markdown level1 summary"><p>LightYellow color (R:255,G:255,B:224,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LightYellow</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Lime.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Lime%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L853">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Lime" data-uid="SadRogue.Primitives.Color.Lime">Lime</h4>
+  <div class="markdown level1 summary"><p>Lime color (R:0,G:255,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Lime</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LimeGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LimeGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L858">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_LimeGreen" data-uid="SadRogue.Primitives.Color.LimeGreen">LimeGreen</h4>
+  <div class="markdown level1 summary"><p>LimeGreen color (R:50,G:205,B:50,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color LimeGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Linen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Linen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L863">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Linen" data-uid="SadRogue.Primitives.Color.Linen">Linen</h4>
+  <div class="markdown level1 summary"><p>Linen color (R:250,G:240,B:230,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Linen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Magenta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Magenta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L868">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Magenta" data-uid="SadRogue.Primitives.Color.Magenta">Magenta</h4>
+  <div class="markdown level1 summary"><p>Magenta color (R:255,G:0,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Magenta</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Maroon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Maroon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L873">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Maroon" data-uid="SadRogue.Primitives.Color.Maroon">Maroon</h4>
+  <div class="markdown level1 summary"><p>Maroon color (R:128,G:0,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Maroon</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumAquamarine.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumAquamarine%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L878">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumAquamarine" data-uid="SadRogue.Primitives.Color.MediumAquamarine">MediumAquamarine</h4>
+  <div class="markdown level1 summary"><p>MediumAquamarine color (R:102,G:205,B:170,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumAquamarine</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L884">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumBlue" data-uid="SadRogue.Primitives.Color.MediumBlue">MediumBlue</h4>
+  <div class="markdown level1 summary"><p>MediumBlue color (R:0,G:0,B:205,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumOrchid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumOrchid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L889">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumOrchid" data-uid="SadRogue.Primitives.Color.MediumOrchid">MediumOrchid</h4>
+  <div class="markdown level1 summary"><p>MediumOrchid color (R:186,G:85,B:211,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumOrchid</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumPurple.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumPurple%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L894">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumPurple" data-uid="SadRogue.Primitives.Color.MediumPurple">MediumPurple</h4>
+  <div class="markdown level1 summary"><p>MediumPurple color (R:147,G:112,B:219,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumPurple</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumSeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumSeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L899">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumSeaGreen" data-uid="SadRogue.Primitives.Color.MediumSeaGreen">MediumSeaGreen</h4>
+  <div class="markdown level1 summary"><p>MediumSeaGreen color (R:60,G:179,B:113,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumSeaGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumSlateBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumSlateBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L904">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumSlateBlue" data-uid="SadRogue.Primitives.Color.MediumSlateBlue">MediumSlateBlue</h4>
+  <div class="markdown level1 summary"><p>MediumSlateBlue color (R:123,G:104,B:238,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumSlateBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumSpringGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumSpringGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L909">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumSpringGreen" data-uid="SadRogue.Primitives.Color.MediumSpringGreen">MediumSpringGreen</h4>
+  <div class="markdown level1 summary"><p>MediumSpringGreen color (R:0,G:250,B:154,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumSpringGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumTurquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumTurquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L914">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumTurquoise" data-uid="SadRogue.Primitives.Color.MediumTurquoise">MediumTurquoise</h4>
+  <div class="markdown level1 summary"><p>MediumTurquoise color (R:72,G:209,B:204,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumTurquoise</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumVioletRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumVioletRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L919">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MediumVioletRed" data-uid="SadRogue.Primitives.Color.MediumVioletRed">MediumVioletRed</h4>
+  <div class="markdown level1 summary"><p>MediumVioletRed color (R:199,G:21,B:133,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MediumVioletRed</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MidnightBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MidnightBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L924">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MidnightBlue" data-uid="SadRogue.Primitives.Color.MidnightBlue">MidnightBlue</h4>
+  <div class="markdown level1 summary"><p>MidnightBlue color (R:25,G:25,B:112,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MidnightBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MintCream.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MintCream%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L929">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MintCream" data-uid="SadRogue.Primitives.Color.MintCream">MintCream</h4>
+  <div class="markdown level1 summary"><p>MintCream color (R:245,G:255,B:250,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MintCream</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MistyRose.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MistyRose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L934">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MistyRose" data-uid="SadRogue.Primitives.Color.MistyRose">MistyRose</h4>
+  <div class="markdown level1 summary"><p>MistyRose color (R:255,G:228,B:225,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MistyRose</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Moccasin.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Moccasin%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L939">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Moccasin" data-uid="SadRogue.Primitives.Color.Moccasin">Moccasin</h4>
+  <div class="markdown level1 summary"><p>Moccasin color (R:255,G:228,B:181,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Moccasin</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MonoGameOrange.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MonoGameOrange%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L944">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_MonoGameOrange" data-uid="SadRogue.Primitives.Color.MonoGameOrange">MonoGameOrange</h4>
+  <div class="markdown level1 summary"><p>MonoGame orange theme color (R:231,G:60,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color MonoGameOrange</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_NavajoWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.NavajoWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L949">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_NavajoWhite" data-uid="SadRogue.Primitives.Color.NavajoWhite">NavajoWhite</h4>
+  <div class="markdown level1 summary"><p>NavajoWhite color (R:255,G:222,B:173,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color NavajoWhite</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Navy.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Navy%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L954">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Navy" data-uid="SadRogue.Primitives.Color.Navy">Navy</h4>
+  <div class="markdown level1 summary"><p>Navy color (R:0,G:0,B:128,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Navy</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_OldLace.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.OldLace%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L959">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_OldLace" data-uid="SadRogue.Primitives.Color.OldLace">OldLace</h4>
+  <div class="markdown level1 summary"><p>OldLace color (R:253,G:245,B:230,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color OldLace</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Olive.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Olive%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L964">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Olive" data-uid="SadRogue.Primitives.Color.Olive">Olive</h4>
+  <div class="markdown level1 summary"><p>Olive color (R:128,G:128,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Olive</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_OliveDrab.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.OliveDrab%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L969">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_OliveDrab" data-uid="SadRogue.Primitives.Color.OliveDrab">OliveDrab</h4>
+  <div class="markdown level1 summary"><p>OliveDrab color (R:107,G:142,B:35,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color OliveDrab</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Orange.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Orange%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L974">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Orange" data-uid="SadRogue.Primitives.Color.Orange">Orange</h4>
+  <div class="markdown level1 summary"><p>Orange color (R:255,G:165,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Orange</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_OrangeRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.OrangeRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L979">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_OrangeRed" data-uid="SadRogue.Primitives.Color.OrangeRed">OrangeRed</h4>
+  <div class="markdown level1 summary"><p>OrangeRed color (R:255,G:69,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color OrangeRed</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Orchid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Orchid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L984">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Orchid" data-uid="SadRogue.Primitives.Color.Orchid">Orchid</h4>
+  <div class="markdown level1 summary"><p>Orchid color (R:218,G:112,B:214,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Orchid</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleGoldenrod.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleGoldenrod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L989">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PaleGoldenrod" data-uid="SadRogue.Primitives.Color.PaleGoldenrod">PaleGoldenrod</h4>
+  <div class="markdown level1 summary"><p>PaleGoldenrod color (R:238,G:232,B:170,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PaleGoldenrod</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L994">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PaleGreen" data-uid="SadRogue.Primitives.Color.PaleGreen">PaleGreen</h4>
+  <div class="markdown level1 summary"><p>PaleGreen color (R:152,G:251,B:152,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PaleGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleTurquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleTurquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L999">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PaleTurquoise" data-uid="SadRogue.Primitives.Color.PaleTurquoise">PaleTurquoise</h4>
+  <div class="markdown level1 summary"><p>PaleTurquoise color (R:175,G:238,B:238,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PaleTurquoise</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleVioletRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleVioletRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1004">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PaleVioletRed" data-uid="SadRogue.Primitives.Color.PaleVioletRed">PaleVioletRed</h4>
+  <div class="markdown level1 summary"><p>PaleVioletRed color (R:219,G:112,B:147,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PaleVioletRed</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PapayaWhip.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PapayaWhip%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1009">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PapayaWhip" data-uid="SadRogue.Primitives.Color.PapayaWhip">PapayaWhip</h4>
+  <div class="markdown level1 summary"><p>PapayaWhip color (R:255,G:239,B:213,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PapayaWhip</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PeachPuff.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PeachPuff%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1014">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PeachPuff" data-uid="SadRogue.Primitives.Color.PeachPuff">PeachPuff</h4>
+  <div class="markdown level1 summary"><p>PeachPuff color (R:255,G:218,B:185,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PeachPuff</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Peru.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Peru%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1019">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Peru" data-uid="SadRogue.Primitives.Color.Peru">Peru</h4>
+  <div class="markdown level1 summary"><p>Peru color (R:205,G:133,B:63,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Peru</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Pink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Pink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1024">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Pink" data-uid="SadRogue.Primitives.Color.Pink">Pink</h4>
+  <div class="markdown level1 summary"><p>Pink color (R:255,G:192,B:203,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Pink</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Plum.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Plum%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1029">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Plum" data-uid="SadRogue.Primitives.Color.Plum">Plum</h4>
+  <div class="markdown level1 summary"><p>Plum color (R:221,G:160,B:221,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Plum</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PowderBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PowderBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1034">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_PowderBlue" data-uid="SadRogue.Primitives.Color.PowderBlue">PowderBlue</h4>
+  <div class="markdown level1 summary"><p>PowderBlue color (R:176,G:224,B:230,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color PowderBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Purple.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Purple%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1039">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Purple" data-uid="SadRogue.Primitives.Color.Purple">Purple</h4>
+  <div class="markdown level1 summary"><p>Purple color (R:128,G:0,B:128,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Purple</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Red.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Red%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1044">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Red" data-uid="SadRogue.Primitives.Color.Red">Red</h4>
+  <div class="markdown level1 summary"><p>Red color (R:255,G:0,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Red</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_RosyBrown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.RosyBrown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1049">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_RosyBrown" data-uid="SadRogue.Primitives.Color.RosyBrown">RosyBrown</h4>
+  <div class="markdown level1 summary"><p>RosyBrown color (R:188,G:143,B:143,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color RosyBrown</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_RoyalBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.RoyalBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1054">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_RoyalBlue" data-uid="SadRogue.Primitives.Color.RoyalBlue">RoyalBlue</h4>
+  <div class="markdown level1 summary"><p>RoyalBlue color (R:65,G:105,B:225,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color RoyalBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SaddleBrown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SaddleBrown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1059">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SaddleBrown" data-uid="SadRogue.Primitives.Color.SaddleBrown">SaddleBrown</h4>
+  <div class="markdown level1 summary"><p>SaddleBrown color (R:139,G:69,B:19,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SaddleBrown</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Salmon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Salmon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1064">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Salmon" data-uid="SadRogue.Primitives.Color.Salmon">Salmon</h4>
+  <div class="markdown level1 summary"><p>Salmon color (R:250,G:128,B:114,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Salmon</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SandyBrown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SandyBrown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1069">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SandyBrown" data-uid="SadRogue.Primitives.Color.SandyBrown">SandyBrown</h4>
+  <div class="markdown level1 summary"><p>SandyBrown color (R:244,G:164,B:96,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SandyBrown</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1074">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SeaGreen" data-uid="SadRogue.Primitives.Color.SeaGreen">SeaGreen</h4>
+  <div class="markdown level1 summary"><p>SeaGreen color (R:46,G:139,B:87,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SeaGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SeaShell.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SeaShell%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1079">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SeaShell" data-uid="SadRogue.Primitives.Color.SeaShell">SeaShell</h4>
+  <div class="markdown level1 summary"><p>SeaShell color (R:255,G:245,B:238,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SeaShell</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Sienna.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Sienna%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1084">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Sienna" data-uid="SadRogue.Primitives.Color.Sienna">Sienna</h4>
+  <div class="markdown level1 summary"><p>Sienna color (R:160,G:82,B:45,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Sienna</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Silver.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Silver%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1089">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Silver" data-uid="SadRogue.Primitives.Color.Silver">Silver</h4>
+  <div class="markdown level1 summary"><p>Silver color (R:192,G:192,B:192,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Silver</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SkyBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SkyBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1094">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SkyBlue" data-uid="SadRogue.Primitives.Color.SkyBlue">SkyBlue</h4>
+  <div class="markdown level1 summary"><p>SkyBlue color (R:135,G:206,B:235,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SkyBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SlateBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SlateBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1099">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SlateBlue" data-uid="SadRogue.Primitives.Color.SlateBlue">SlateBlue</h4>
+  <div class="markdown level1 summary"><p>SlateBlue color (R:106,G:90,B:205,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SlateBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SlateGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SlateGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1104">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SlateGray" data-uid="SadRogue.Primitives.Color.SlateGray">SlateGray</h4>
+  <div class="markdown level1 summary"><p>SlateGray color (R:112,G:128,B:144,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SlateGray</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Snow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Snow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1109">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Snow" data-uid="SadRogue.Primitives.Color.Snow">Snow</h4>
+  <div class="markdown level1 summary"><p>Snow color (R:255,G:250,B:250,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Snow</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SpringGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SpringGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1114">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SpringGreen" data-uid="SadRogue.Primitives.Color.SpringGreen">SpringGreen</h4>
+  <div class="markdown level1 summary"><p>SpringGreen color (R:0,G:255,B:127,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SpringGreen</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SteelBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SteelBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1119">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_SteelBlue" data-uid="SadRogue.Primitives.Color.SteelBlue">SteelBlue</h4>
+  <div class="markdown level1 summary"><p>SteelBlue color (R:70,G:130,B:180,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color SteelBlue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Tan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Tan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1124">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Tan" data-uid="SadRogue.Primitives.Color.Tan">Tan</h4>
+  <div class="markdown level1 summary"><p>Tan color (R:210,G:180,B:140,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Tan</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Teal.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Teal%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1129">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Teal" data-uid="SadRogue.Primitives.Color.Teal">Teal</h4>
+  <div class="markdown level1 summary"><p>Teal color (R:0,G:128,B:128,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Teal</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Thistle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Thistle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1134">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Thistle" data-uid="SadRogue.Primitives.Color.Thistle">Thistle</h4>
+  <div class="markdown level1 summary"><p>Thistle color (R:216,G:191,B:216,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Thistle</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Tomato.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Tomato%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1139">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Tomato" data-uid="SadRogue.Primitives.Color.Tomato">Tomato</h4>
+  <div class="markdown level1 summary"><p>Tomato color (R:255,G:99,B:71,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Tomato</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Transparent.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Transparent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L468">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Transparent" data-uid="SadRogue.Primitives.Color.Transparent">Transparent</h4>
+  <div class="markdown level1 summary"><p>Transparent color (R:0,G:0,B:0,A:0).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Transparent</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_TransparentBlack.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.TransparentBlack%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L463">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_TransparentBlack" data-uid="SadRogue.Primitives.Color.TransparentBlack">TransparentBlack</h4>
+  <div class="markdown level1 summary"><p>TransparentBlack color (R:0,G:0,B:0,A:0).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color TransparentBlack</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Turquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Turquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1144">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Turquoise" data-uid="SadRogue.Primitives.Color.Turquoise">Turquoise</h4>
+  <div class="markdown level1 summary"><p>Turquoise color (R:64,G:224,B:208,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Turquoise</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Violet.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Violet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1149">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Violet" data-uid="SadRogue.Primitives.Color.Violet">Violet</h4>
+  <div class="markdown level1 summary"><p>Violet color (R:238,G:130,B:238,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Violet</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Wheat.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Wheat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1154">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Wheat" data-uid="SadRogue.Primitives.Color.Wheat">Wheat</h4>
+  <div class="markdown level1 summary"><p>Wheat color (R:245,G:222,B:179,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Wheat</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_White.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.White%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1159">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_White" data-uid="SadRogue.Primitives.Color.White">White</h4>
+  <div class="markdown level1 summary"><p>White color (R:255,G:255,B:255,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color White</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_WhiteSmoke.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.WhiteSmoke%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1164">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_WhiteSmoke" data-uid="SadRogue.Primitives.Color.WhiteSmoke">WhiteSmoke</h4>
+  <div class="markdown level1 summary"><p>WhiteSmoke color (R:245,G:245,B:245,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color WhiteSmoke</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Yellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Yellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1169">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_Yellow" data-uid="SadRogue.Primitives.Color.Yellow">Yellow</h4>
+  <div class="markdown level1 summary"><p>Yellow color (R:255,G:255,B:0,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color Yellow</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_YellowGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.YellowGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1174">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_Color_YellowGreen" data-uid="SadRogue.Primitives.Color.YellowGreen">YellowGreen</h4>
+  <div class="markdown level1 summary"><p>YellowGreen color (R:154,G:205,B:50,A:255).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static readonly Color YellowGreen</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -954,7 +5243,7 @@ public Color(uint packedValue)</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_A.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.A%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L340">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L330">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_A_" data-uid="SadRogue.Primitives.Color.A*"></a>
   <h4 id="SadRogue_Primitives_Color_A" data-uid="SadRogue.Primitives.Color.A">A</h4>
@@ -963,8 +5252,7 @@ public Color(uint packedValue)</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[DataMember]
-public byte A { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">public byte A { get; }</code></pre>
   </div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -976,162 +5264,7 @@ public byte A { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AliceBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AliceBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L471">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_AliceBlue_" data-uid="SadRogue.Primitives.Color.AliceBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_AliceBlue" data-uid="SadRogue.Primitives.Color.AliceBlue">AliceBlue</h4>
-  <div class="markdown level1 summary"><p>AliceBlue color (R:240,G:248,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AliceBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_AntiqueWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.AntiqueWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L480">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_AntiqueWhite_" data-uid="SadRogue.Primitives.Color.AntiqueWhite*"></a>
-  <h4 id="SadRogue_Primitives_Color_AntiqueWhite" data-uid="SadRogue.Primitives.Color.AntiqueWhite">AntiqueWhite</h4>
-  <div class="markdown level1 summary"><p>AntiqueWhite color (R:250,G:235,B:215,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color AntiqueWhite { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Aqua.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Aqua%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L489">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Aqua_" data-uid="SadRogue.Primitives.Color.Aqua*"></a>
-  <h4 id="SadRogue_Primitives_Color_Aqua" data-uid="SadRogue.Primitives.Color.Aqua">Aqua</h4>
-  <div class="markdown level1 summary"><p>Aqua color (R:0,G:255,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Aqua { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Aquamarine.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Aquamarine%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L498">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Aquamarine_" data-uid="SadRogue.Primitives.Color.Aquamarine*"></a>
-  <h4 id="SadRogue_Primitives_Color_Aquamarine" data-uid="SadRogue.Primitives.Color.Aquamarine">Aquamarine</h4>
-  <div class="markdown level1 summary"><p>Aquamarine color (R:127,G:255,B:212,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Aquamarine { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Azure.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Azure%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L507">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Azure_" data-uid="SadRogue.Primitives.Color.Azure*"></a>
-  <h4 id="SadRogue_Primitives_Color_Azure" data-uid="SadRogue.Primitives.Color.Azure">Azure</h4>
-  <div class="markdown level1 summary"><p>Azure color (R:240,G:255,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Azure { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -1141,7 +5274,7 @@ public byte A { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_B.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.B%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L295">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L288">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_B_" data-uid="SadRogue.Primitives.Color.B*"></a>
   <h4 id="SadRogue_Primitives_Color_B" data-uid="SadRogue.Primitives.Color.B">B</h4>
@@ -1150,8 +5283,7 @@ public byte A { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[DataMember]
-public byte B { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">public byte B { get; }</code></pre>
   </div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1163,1278 +5295,7 @@ public byte B { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Beige.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Beige%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L516">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Beige_" data-uid="SadRogue.Primitives.Color.Beige*"></a>
-  <h4 id="SadRogue_Primitives_Color_Beige" data-uid="SadRogue.Primitives.Color.Beige">Beige</h4>
-  <div class="markdown level1 summary"><p>Beige color (R:245,G:245,B:220,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Beige { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Bisque.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Bisque%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L525">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Bisque_" data-uid="SadRogue.Primitives.Color.Bisque*"></a>
-  <h4 id="SadRogue_Primitives_Color_Bisque" data-uid="SadRogue.Primitives.Color.Bisque">Bisque</h4>
-  <div class="markdown level1 summary"><p>Bisque color (R:255,G:228,B:196,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Bisque { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Black.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Black%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L534">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Black_" data-uid="SadRogue.Primitives.Color.Black*"></a>
-  <h4 id="SadRogue_Primitives_Color_Black" data-uid="SadRogue.Primitives.Color.Black">Black</h4>
-  <div class="markdown level1 summary"><p>Black color (R:0,G:0,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Black { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_BlanchedAlmond.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.BlanchedAlmond%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L543">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_BlanchedAlmond_" data-uid="SadRogue.Primitives.Color.BlanchedAlmond*"></a>
-  <h4 id="SadRogue_Primitives_Color_BlanchedAlmond" data-uid="SadRogue.Primitives.Color.BlanchedAlmond">BlanchedAlmond</h4>
-  <div class="markdown level1 summary"><p>BlanchedAlmond color (R:255,G:235,B:205,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color BlanchedAlmond { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Blue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Blue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L552">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Blue_" data-uid="SadRogue.Primitives.Color.Blue*"></a>
-  <h4 id="SadRogue_Primitives_Color_Blue" data-uid="SadRogue.Primitives.Color.Blue">Blue</h4>
-  <div class="markdown level1 summary"><p>Blue color (R:0,G:0,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Blue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_BlueViolet.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.BlueViolet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L561">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_BlueViolet_" data-uid="SadRogue.Primitives.Color.BlueViolet*"></a>
-  <h4 id="SadRogue_Primitives_Color_BlueViolet" data-uid="SadRogue.Primitives.Color.BlueViolet">BlueViolet</h4>
-  <div class="markdown level1 summary"><p>BlueViolet color (R:138,G:43,B:226,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color BlueViolet { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Brown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Brown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L570">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Brown_" data-uid="SadRogue.Primitives.Color.Brown*"></a>
-  <h4 id="SadRogue_Primitives_Color_Brown" data-uid="SadRogue.Primitives.Color.Brown">Brown</h4>
-  <div class="markdown level1 summary"><p>Brown color (R:165,G:42,B:42,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Brown { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_BurlyWood.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.BurlyWood%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L579">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_BurlyWood_" data-uid="SadRogue.Primitives.Color.BurlyWood*"></a>
-  <h4 id="SadRogue_Primitives_Color_BurlyWood" data-uid="SadRogue.Primitives.Color.BurlyWood">BurlyWood</h4>
-  <div class="markdown level1 summary"><p>BurlyWood color (R:222,G:184,B:135,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color BurlyWood { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_CadetBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.CadetBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L588">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_CadetBlue_" data-uid="SadRogue.Primitives.Color.CadetBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_CadetBlue" data-uid="SadRogue.Primitives.Color.CadetBlue">CadetBlue</h4>
-  <div class="markdown level1 summary"><p>CadetBlue color (R:95,G:158,B:160,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color CadetBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Chartreuse.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Chartreuse%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L597">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Chartreuse_" data-uid="SadRogue.Primitives.Color.Chartreuse*"></a>
-  <h4 id="SadRogue_Primitives_Color_Chartreuse" data-uid="SadRogue.Primitives.Color.Chartreuse">Chartreuse</h4>
-  <div class="markdown level1 summary"><p>Chartreuse color (R:127,G:255,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Chartreuse { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Chocolate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Chocolate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L606">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Chocolate_" data-uid="SadRogue.Primitives.Color.Chocolate*"></a>
-  <h4 id="SadRogue_Primitives_Color_Chocolate" data-uid="SadRogue.Primitives.Color.Chocolate">Chocolate</h4>
-  <div class="markdown level1 summary"><p>Chocolate color (R:210,G:105,B:30,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Chocolate { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Coral.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Coral%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L615">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Coral_" data-uid="SadRogue.Primitives.Color.Coral*"></a>
-  <h4 id="SadRogue_Primitives_Color_Coral" data-uid="SadRogue.Primitives.Color.Coral">Coral</h4>
-  <div class="markdown level1 summary"><p>Coral color (R:255,G:127,B:80,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Coral { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_CornflowerBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.CornflowerBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L624">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_CornflowerBlue_" data-uid="SadRogue.Primitives.Color.CornflowerBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_CornflowerBlue" data-uid="SadRogue.Primitives.Color.CornflowerBlue">CornflowerBlue</h4>
-  <div class="markdown level1 summary"><p>CornflowerBlue color (R:100,G:149,B:237,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color CornflowerBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Cornsilk.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Cornsilk%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L633">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Cornsilk_" data-uid="SadRogue.Primitives.Color.Cornsilk*"></a>
-  <h4 id="SadRogue_Primitives_Color_Cornsilk" data-uid="SadRogue.Primitives.Color.Cornsilk">Cornsilk</h4>
-  <div class="markdown level1 summary"><p>Cornsilk color (R:255,G:248,B:220,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Cornsilk { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Crimson.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Crimson%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L642">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Crimson_" data-uid="SadRogue.Primitives.Color.Crimson*"></a>
-  <h4 id="SadRogue_Primitives_Color_Crimson" data-uid="SadRogue.Primitives.Color.Crimson">Crimson</h4>
-  <div class="markdown level1 summary"><p>Crimson color (R:220,G:20,B:60,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Crimson { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Cyan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Cyan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L651">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Cyan_" data-uid="SadRogue.Primitives.Color.Cyan*"></a>
-  <h4 id="SadRogue_Primitives_Color_Cyan" data-uid="SadRogue.Primitives.Color.Cyan">Cyan</h4>
-  <div class="markdown level1 summary"><p>Cyan color (R:0,G:255,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Cyan { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L660">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkBlue_" data-uid="SadRogue.Primitives.Color.DarkBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkBlue" data-uid="SadRogue.Primitives.Color.DarkBlue">DarkBlue</h4>
-  <div class="markdown level1 summary"><p>DarkBlue color (R:0,G:0,B:139,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkCyan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkCyan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L669">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkCyan_" data-uid="SadRogue.Primitives.Color.DarkCyan*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkCyan" data-uid="SadRogue.Primitives.Color.DarkCyan">DarkCyan</h4>
-  <div class="markdown level1 summary"><p>DarkCyan color (R:0,G:139,B:139,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkCyan { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkGoldenrod.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkGoldenrod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L678">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkGoldenrod_" data-uid="SadRogue.Primitives.Color.DarkGoldenrod*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkGoldenrod" data-uid="SadRogue.Primitives.Color.DarkGoldenrod">DarkGoldenrod</h4>
-  <div class="markdown level1 summary"><p>DarkGoldenrod color (R:184,G:134,B:11,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkGoldenrod { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L687">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkGray_" data-uid="SadRogue.Primitives.Color.DarkGray*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkGray" data-uid="SadRogue.Primitives.Color.DarkGray">DarkGray</h4>
-  <div class="markdown level1 summary"><p>DarkGray color (R:169,G:169,B:169,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkGray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L696">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkGreen_" data-uid="SadRogue.Primitives.Color.DarkGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkGreen" data-uid="SadRogue.Primitives.Color.DarkGreen">DarkGreen</h4>
-  <div class="markdown level1 summary"><p>DarkGreen color (R:0,G:100,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkKhaki.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkKhaki%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L705">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkKhaki_" data-uid="SadRogue.Primitives.Color.DarkKhaki*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkKhaki" data-uid="SadRogue.Primitives.Color.DarkKhaki">DarkKhaki</h4>
-  <div class="markdown level1 summary"><p>DarkKhaki color (R:189,G:183,B:107,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkKhaki { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkMagenta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkMagenta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L714">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkMagenta_" data-uid="SadRogue.Primitives.Color.DarkMagenta*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkMagenta" data-uid="SadRogue.Primitives.Color.DarkMagenta">DarkMagenta</h4>
-  <div class="markdown level1 summary"><p>DarkMagenta color (R:139,G:0,B:139,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkMagenta { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkOliveGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkOliveGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L723">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkOliveGreen_" data-uid="SadRogue.Primitives.Color.DarkOliveGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkOliveGreen" data-uid="SadRogue.Primitives.Color.DarkOliveGreen">DarkOliveGreen</h4>
-  <div class="markdown level1 summary"><p>DarkOliveGreen color (R:85,G:107,B:47,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkOliveGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkOrange.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkOrange%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L732">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkOrange_" data-uid="SadRogue.Primitives.Color.DarkOrange*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkOrange" data-uid="SadRogue.Primitives.Color.DarkOrange">DarkOrange</h4>
-  <div class="markdown level1 summary"><p>DarkOrange color (R:255,G:140,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkOrange { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkOrchid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkOrchid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L741">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkOrchid_" data-uid="SadRogue.Primitives.Color.DarkOrchid*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkOrchid" data-uid="SadRogue.Primitives.Color.DarkOrchid">DarkOrchid</h4>
-  <div class="markdown level1 summary"><p>DarkOrchid color (R:153,G:50,B:204,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkOrchid { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L750">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkRed_" data-uid="SadRogue.Primitives.Color.DarkRed*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkRed" data-uid="SadRogue.Primitives.Color.DarkRed">DarkRed</h4>
-  <div class="markdown level1 summary"><p>DarkRed color (R:139,G:0,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkRed { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSalmon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSalmon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L759">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkSalmon_" data-uid="SadRogue.Primitives.Color.DarkSalmon*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkSalmon" data-uid="SadRogue.Primitives.Color.DarkSalmon">DarkSalmon</h4>
-  <div class="markdown level1 summary"><p>DarkSalmon color (R:233,G:150,B:122,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkSalmon { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L768">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkSeaGreen_" data-uid="SadRogue.Primitives.Color.DarkSeaGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkSeaGreen" data-uid="SadRogue.Primitives.Color.DarkSeaGreen">DarkSeaGreen</h4>
-  <div class="markdown level1 summary"><p>DarkSeaGreen color (R:143,G:188,B:139,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkSeaGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSlateBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSlateBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L777">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkSlateBlue_" data-uid="SadRogue.Primitives.Color.DarkSlateBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkSlateBlue" data-uid="SadRogue.Primitives.Color.DarkSlateBlue">DarkSlateBlue</h4>
-  <div class="markdown level1 summary"><p>DarkSlateBlue color (R:72,G:61,B:139,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkSlateBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkSlateGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkSlateGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L786">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkSlateGray_" data-uid="SadRogue.Primitives.Color.DarkSlateGray*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkSlateGray" data-uid="SadRogue.Primitives.Color.DarkSlateGray">DarkSlateGray</h4>
-  <div class="markdown level1 summary"><p>DarkSlateGray color (R:47,G:79,B:79,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkSlateGray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkTurquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkTurquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L795">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkTurquoise_" data-uid="SadRogue.Primitives.Color.DarkTurquoise*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkTurquoise" data-uid="SadRogue.Primitives.Color.DarkTurquoise">DarkTurquoise</h4>
-  <div class="markdown level1 summary"><p>DarkTurquoise color (R:0,G:206,B:209,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkTurquoise { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DarkViolet.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DarkViolet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L804">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DarkViolet_" data-uid="SadRogue.Primitives.Color.DarkViolet*"></a>
-  <h4 id="SadRogue_Primitives_Color_DarkViolet" data-uid="SadRogue.Primitives.Color.DarkViolet">DarkViolet</h4>
-  <div class="markdown level1 summary"><p>DarkViolet color (R:148,G:0,B:211,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DarkViolet { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DeepPink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DeepPink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L813">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DeepPink_" data-uid="SadRogue.Primitives.Color.DeepPink*"></a>
-  <h4 id="SadRogue_Primitives_Color_DeepPink" data-uid="SadRogue.Primitives.Color.DeepPink">DeepPink</h4>
-  <div class="markdown level1 summary"><p>DeepPink color (R:255,G:20,B:147,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DeepPink { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DeepSkyBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DeepSkyBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L822">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DeepSkyBlue_" data-uid="SadRogue.Primitives.Color.DeepSkyBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_DeepSkyBlue" data-uid="SadRogue.Primitives.Color.DeepSkyBlue">DeepSkyBlue</h4>
-  <div class="markdown level1 summary"><p>DeepSkyBlue color (R:0,G:191,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DeepSkyBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DimGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DimGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L831">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DimGray_" data-uid="SadRogue.Primitives.Color.DimGray*"></a>
-  <h4 id="SadRogue_Primitives_Color_DimGray" data-uid="SadRogue.Primitives.Color.DimGray">DimGray</h4>
-  <div class="markdown level1 summary"><p>DimGray color (R:105,G:105,B:105,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DimGray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_DodgerBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.DodgerBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L840">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_DodgerBlue_" data-uid="SadRogue.Primitives.Color.DodgerBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_DodgerBlue" data-uid="SadRogue.Primitives.Color.DodgerBlue">DodgerBlue</h4>
-  <div class="markdown level1 summary"><p>DodgerBlue color (R:30,G:144,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color DodgerBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Firebrick.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Firebrick%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L849">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Firebrick_" data-uid="SadRogue.Primitives.Color.Firebrick*"></a>
-  <h4 id="SadRogue_Primitives_Color_Firebrick" data-uid="SadRogue.Primitives.Color.Firebrick">Firebrick</h4>
-  <div class="markdown level1 summary"><p>Firebrick color (R:178,G:34,B:34,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Firebrick { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_FloralWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.FloralWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L858">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_FloralWhite_" data-uid="SadRogue.Primitives.Color.FloralWhite*"></a>
-  <h4 id="SadRogue_Primitives_Color_FloralWhite" data-uid="SadRogue.Primitives.Color.FloralWhite">FloralWhite</h4>
-  <div class="markdown level1 summary"><p>FloralWhite color (R:255,G:250,B:240,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color FloralWhite { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_ForestGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.ForestGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L867">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_ForestGreen_" data-uid="SadRogue.Primitives.Color.ForestGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_ForestGreen" data-uid="SadRogue.Primitives.Color.ForestGreen">ForestGreen</h4>
-  <div class="markdown level1 summary"><p>ForestGreen color (R:34,G:139,B:34,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color ForestGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Fuchsia.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Fuchsia%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L876">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Fuchsia_" data-uid="SadRogue.Primitives.Color.Fuchsia*"></a>
-  <h4 id="SadRogue_Primitives_Color_Fuchsia" data-uid="SadRogue.Primitives.Color.Fuchsia">Fuchsia</h4>
-  <div class="markdown level1 summary"><p>Fuchsia color (R:255,G:0,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Fuchsia { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -2444,7 +5305,7 @@ public byte B { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_G.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.G%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L310">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L302">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_G_" data-uid="SadRogue.Primitives.Color.G*"></a>
   <h4 id="SadRogue_Primitives_Color_G" data-uid="SadRogue.Primitives.Color.G">G</h4>
@@ -2453,8 +5314,7 @@ public byte B { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[DataMember]
-public byte G { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">public byte G { get; }</code></pre>
   </div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2466,1774 +5326,7 @@ public byte G { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Gainsboro.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Gainsboro%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L885">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Gainsboro_" data-uid="SadRogue.Primitives.Color.Gainsboro*"></a>
-  <h4 id="SadRogue_Primitives_Color_Gainsboro" data-uid="SadRogue.Primitives.Color.Gainsboro">Gainsboro</h4>
-  <div class="markdown level1 summary"><p>Gainsboro color (R:220,G:220,B:220,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Gainsboro { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GhostWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GhostWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L894">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_GhostWhite_" data-uid="SadRogue.Primitives.Color.GhostWhite*"></a>
-  <h4 id="SadRogue_Primitives_Color_GhostWhite" data-uid="SadRogue.Primitives.Color.GhostWhite">GhostWhite</h4>
-  <div class="markdown level1 summary"><p>GhostWhite color (R:248,G:248,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color GhostWhite { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Gold.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Gold%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L902">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Gold_" data-uid="SadRogue.Primitives.Color.Gold*"></a>
-  <h4 id="SadRogue_Primitives_Color_Gold" data-uid="SadRogue.Primitives.Color.Gold">Gold</h4>
-  <div class="markdown level1 summary"><p>Gold color (R:255,G:215,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Gold { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Goldenrod.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Goldenrod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L911">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Goldenrod_" data-uid="SadRogue.Primitives.Color.Goldenrod*"></a>
-  <h4 id="SadRogue_Primitives_Color_Goldenrod" data-uid="SadRogue.Primitives.Color.Goldenrod">Goldenrod</h4>
-  <div class="markdown level1 summary"><p>Goldenrod color (R:218,G:165,B:32,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Goldenrod { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Gray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Gray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L920">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Gray_" data-uid="SadRogue.Primitives.Color.Gray*"></a>
-  <h4 id="SadRogue_Primitives_Color_Gray" data-uid="SadRogue.Primitives.Color.Gray">Gray</h4>
-  <div class="markdown level1 summary"><p>Gray color (R:128,G:128,B:128,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Gray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Green.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Green%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L929">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Green_" data-uid="SadRogue.Primitives.Color.Green*"></a>
-  <h4 id="SadRogue_Primitives_Color_Green" data-uid="SadRogue.Primitives.Color.Green">Green</h4>
-  <div class="markdown level1 summary"><p>Green color (R:0,G:128,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Green { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GreenYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GreenYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L938">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_GreenYellow_" data-uid="SadRogue.Primitives.Color.GreenYellow*"></a>
-  <h4 id="SadRogue_Primitives_Color_GreenYellow" data-uid="SadRogue.Primitives.Color.GreenYellow">GreenYellow</h4>
-  <div class="markdown level1 summary"><p>GreenYellow color (R:173,G:255,B:47,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color GreenYellow { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Honeydew.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Honeydew%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L947">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Honeydew_" data-uid="SadRogue.Primitives.Color.Honeydew*"></a>
-  <h4 id="SadRogue_Primitives_Color_Honeydew" data-uid="SadRogue.Primitives.Color.Honeydew">Honeydew</h4>
-  <div class="markdown level1 summary"><p>Honeydew color (R:240,G:255,B:240,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Honeydew { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_HotPink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.HotPink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L956">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_HotPink_" data-uid="SadRogue.Primitives.Color.HotPink*"></a>
-  <h4 id="SadRogue_Primitives_Color_HotPink" data-uid="SadRogue.Primitives.Color.HotPink">HotPink</h4>
-  <div class="markdown level1 summary"><p>HotPink color (R:255,G:105,B:180,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color HotPink { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_IndianRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.IndianRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L965">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_IndianRed_" data-uid="SadRogue.Primitives.Color.IndianRed*"></a>
-  <h4 id="SadRogue_Primitives_Color_IndianRed" data-uid="SadRogue.Primitives.Color.IndianRed">IndianRed</h4>
-  <div class="markdown level1 summary"><p>IndianRed color (R:205,G:92,B:92,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color IndianRed { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Indigo.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Indigo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L974">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Indigo_" data-uid="SadRogue.Primitives.Color.Indigo*"></a>
-  <h4 id="SadRogue_Primitives_Color_Indigo" data-uid="SadRogue.Primitives.Color.Indigo">Indigo</h4>
-  <div class="markdown level1 summary"><p>Indigo color (R:75,G:0,B:130,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Indigo { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Ivory.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Ivory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L983">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Ivory_" data-uid="SadRogue.Primitives.Color.Ivory*"></a>
-  <h4 id="SadRogue_Primitives_Color_Ivory" data-uid="SadRogue.Primitives.Color.Ivory">Ivory</h4>
-  <div class="markdown level1 summary"><p>Ivory color (R:255,G:255,B:240,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Ivory { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Khaki.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Khaki%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L992">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Khaki_" data-uid="SadRogue.Primitives.Color.Khaki*"></a>
-  <h4 id="SadRogue_Primitives_Color_Khaki" data-uid="SadRogue.Primitives.Color.Khaki">Khaki</h4>
-  <div class="markdown level1 summary"><p>Khaki color (R:240,G:230,B:140,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Khaki { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Lavender.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Lavender%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1001">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Lavender_" data-uid="SadRogue.Primitives.Color.Lavender*"></a>
-  <h4 id="SadRogue_Primitives_Color_Lavender" data-uid="SadRogue.Primitives.Color.Lavender">Lavender</h4>
-  <div class="markdown level1 summary"><p>Lavender color (R:230,G:230,B:250,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Lavender { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LavenderBlush.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LavenderBlush%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1010">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LavenderBlush_" data-uid="SadRogue.Primitives.Color.LavenderBlush*"></a>
-  <h4 id="SadRogue_Primitives_Color_LavenderBlush" data-uid="SadRogue.Primitives.Color.LavenderBlush">LavenderBlush</h4>
-  <div class="markdown level1 summary"><p>LavenderBlush color (R:255,G:240,B:245,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LavenderBlush { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LawnGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LawnGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1019">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LawnGreen_" data-uid="SadRogue.Primitives.Color.LawnGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_LawnGreen" data-uid="SadRogue.Primitives.Color.LawnGreen">LawnGreen</h4>
-  <div class="markdown level1 summary"><p>LawnGreen color (R:124,G:252,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LawnGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LemonChiffon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LemonChiffon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1028">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LemonChiffon_" data-uid="SadRogue.Primitives.Color.LemonChiffon*"></a>
-  <h4 id="SadRogue_Primitives_Color_LemonChiffon" data-uid="SadRogue.Primitives.Color.LemonChiffon">LemonChiffon</h4>
-  <div class="markdown level1 summary"><p>LemonChiffon color (R:255,G:250,B:205,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LemonChiffon { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1037">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightBlue_" data-uid="SadRogue.Primitives.Color.LightBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightBlue" data-uid="SadRogue.Primitives.Color.LightBlue">LightBlue</h4>
-  <div class="markdown level1 summary"><p>LightBlue color (R:173,G:216,B:230,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightCoral.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightCoral%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1046">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightCoral_" data-uid="SadRogue.Primitives.Color.LightCoral*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightCoral" data-uid="SadRogue.Primitives.Color.LightCoral">LightCoral</h4>
-  <div class="markdown level1 summary"><p>LightCoral color (R:240,G:128,B:128,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightCoral { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightCyan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightCyan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1055">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightCyan_" data-uid="SadRogue.Primitives.Color.LightCyan*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightCyan" data-uid="SadRogue.Primitives.Color.LightCyan">LightCyan</h4>
-  <div class="markdown level1 summary"><p>LightCyan color (R:224,G:255,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightCyan { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightGoldenrodYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightGoldenrodYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1064">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightGoldenrodYellow_" data-uid="SadRogue.Primitives.Color.LightGoldenrodYellow*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightGoldenrodYellow" data-uid="SadRogue.Primitives.Color.LightGoldenrodYellow">LightGoldenrodYellow</h4>
-  <div class="markdown level1 summary"><p>LightGoldenrodYellow color (R:250,G:250,B:210,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightGoldenrodYellow { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1073">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightGray_" data-uid="SadRogue.Primitives.Color.LightGray*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightGray" data-uid="SadRogue.Primitives.Color.LightGray">LightGray</h4>
-  <div class="markdown level1 summary"><p>LightGray color (R:211,G:211,B:211,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightGray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1082">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightGreen_" data-uid="SadRogue.Primitives.Color.LightGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightGreen" data-uid="SadRogue.Primitives.Color.LightGreen">LightGreen</h4>
-  <div class="markdown level1 summary"><p>LightGreen color (R:144,G:238,B:144,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightPink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightPink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1091">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightPink_" data-uid="SadRogue.Primitives.Color.LightPink*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightPink" data-uid="SadRogue.Primitives.Color.LightPink">LightPink</h4>
-  <div class="markdown level1 summary"><p>LightPink color (R:255,G:182,B:193,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightPink { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSalmon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSalmon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1100">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightSalmon_" data-uid="SadRogue.Primitives.Color.LightSalmon*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightSalmon" data-uid="SadRogue.Primitives.Color.LightSalmon">LightSalmon</h4>
-  <div class="markdown level1 summary"><p>LightSalmon color (R:255,G:160,B:122,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightSalmon { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1109">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightSeaGreen_" data-uid="SadRogue.Primitives.Color.LightSeaGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightSeaGreen" data-uid="SadRogue.Primitives.Color.LightSeaGreen">LightSeaGreen</h4>
-  <div class="markdown level1 summary"><p>LightSeaGreen color (R:32,G:178,B:170,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightSeaGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSkyBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSkyBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1118">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightSkyBlue_" data-uid="SadRogue.Primitives.Color.LightSkyBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightSkyBlue" data-uid="SadRogue.Primitives.Color.LightSkyBlue">LightSkyBlue</h4>
-  <div class="markdown level1 summary"><p>LightSkyBlue color (R:135,G:206,B:250,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightSkyBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSlateGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSlateGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1127">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightSlateGray_" data-uid="SadRogue.Primitives.Color.LightSlateGray*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightSlateGray" data-uid="SadRogue.Primitives.Color.LightSlateGray">LightSlateGray</h4>
-  <div class="markdown level1 summary"><p>LightSlateGray color (R:119,G:136,B:153,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightSlateGray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightSteelBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightSteelBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1136">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightSteelBlue_" data-uid="SadRogue.Primitives.Color.LightSteelBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightSteelBlue" data-uid="SadRogue.Primitives.Color.LightSteelBlue">LightSteelBlue</h4>
-  <div class="markdown level1 summary"><p>LightSteelBlue color (R:176,G:196,B:222,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightSteelBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LightYellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LightYellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1145">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LightYellow_" data-uid="SadRogue.Primitives.Color.LightYellow*"></a>
-  <h4 id="SadRogue_Primitives_Color_LightYellow" data-uid="SadRogue.Primitives.Color.LightYellow">LightYellow</h4>
-  <div class="markdown level1 summary"><p>LightYellow color (R:255,G:255,B:224,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LightYellow { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Lime.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Lime%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1154">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Lime_" data-uid="SadRogue.Primitives.Color.Lime*"></a>
-  <h4 id="SadRogue_Primitives_Color_Lime" data-uid="SadRogue.Primitives.Color.Lime">Lime</h4>
-  <div class="markdown level1 summary"><p>Lime color (R:0,G:255,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Lime { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LimeGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LimeGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1163">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_LimeGreen_" data-uid="SadRogue.Primitives.Color.LimeGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_LimeGreen" data-uid="SadRogue.Primitives.Color.LimeGreen">LimeGreen</h4>
-  <div class="markdown level1 summary"><p>LimeGreen color (R:50,G:205,B:50,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color LimeGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Linen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Linen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1172">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Linen_" data-uid="SadRogue.Primitives.Color.Linen*"></a>
-  <h4 id="SadRogue_Primitives_Color_Linen" data-uid="SadRogue.Primitives.Color.Linen">Linen</h4>
-  <div class="markdown level1 summary"><p>Linen color (R:250,G:240,B:230,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Linen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Magenta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Magenta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1181">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Magenta_" data-uid="SadRogue.Primitives.Color.Magenta*"></a>
-  <h4 id="SadRogue_Primitives_Color_Magenta" data-uid="SadRogue.Primitives.Color.Magenta">Magenta</h4>
-  <div class="markdown level1 summary"><p>Magenta color (R:255,G:0,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Magenta { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Maroon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Maroon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1190">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Maroon_" data-uid="SadRogue.Primitives.Color.Maroon*"></a>
-  <h4 id="SadRogue_Primitives_Color_Maroon" data-uid="SadRogue.Primitives.Color.Maroon">Maroon</h4>
-  <div class="markdown level1 summary"><p>Maroon color (R:128,G:0,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Maroon { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumAquamarine.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumAquamarine%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1199">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumAquamarine_" data-uid="SadRogue.Primitives.Color.MediumAquamarine*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumAquamarine" data-uid="SadRogue.Primitives.Color.MediumAquamarine">MediumAquamarine</h4>
-  <div class="markdown level1 summary"><p>MediumAquamarine color (R:102,G:205,B:170,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumAquamarine { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1208">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumBlue_" data-uid="SadRogue.Primitives.Color.MediumBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumBlue" data-uid="SadRogue.Primitives.Color.MediumBlue">MediumBlue</h4>
-  <div class="markdown level1 summary"><p>MediumBlue color (R:0,G:0,B:205,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumOrchid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumOrchid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1217">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumOrchid_" data-uid="SadRogue.Primitives.Color.MediumOrchid*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumOrchid" data-uid="SadRogue.Primitives.Color.MediumOrchid">MediumOrchid</h4>
-  <div class="markdown level1 summary"><p>MediumOrchid color (R:186,G:85,B:211,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumOrchid { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumPurple.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumPurple%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1226">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumPurple_" data-uid="SadRogue.Primitives.Color.MediumPurple*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumPurple" data-uid="SadRogue.Primitives.Color.MediumPurple">MediumPurple</h4>
-  <div class="markdown level1 summary"><p>MediumPurple color (R:147,G:112,B:219,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumPurple { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumSeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumSeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1235">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumSeaGreen_" data-uid="SadRogue.Primitives.Color.MediumSeaGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumSeaGreen" data-uid="SadRogue.Primitives.Color.MediumSeaGreen">MediumSeaGreen</h4>
-  <div class="markdown level1 summary"><p>MediumSeaGreen color (R:60,G:179,B:113,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumSeaGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumSlateBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumSlateBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1244">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumSlateBlue_" data-uid="SadRogue.Primitives.Color.MediumSlateBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumSlateBlue" data-uid="SadRogue.Primitives.Color.MediumSlateBlue">MediumSlateBlue</h4>
-  <div class="markdown level1 summary"><p>MediumSlateBlue color (R:123,G:104,B:238,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumSlateBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumSpringGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumSpringGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1253">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumSpringGreen_" data-uid="SadRogue.Primitives.Color.MediumSpringGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumSpringGreen" data-uid="SadRogue.Primitives.Color.MediumSpringGreen">MediumSpringGreen</h4>
-  <div class="markdown level1 summary"><p>MediumSpringGreen color (R:0,G:250,B:154,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumSpringGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumTurquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumTurquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1262">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumTurquoise_" data-uid="SadRogue.Primitives.Color.MediumTurquoise*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumTurquoise" data-uid="SadRogue.Primitives.Color.MediumTurquoise">MediumTurquoise</h4>
-  <div class="markdown level1 summary"><p>MediumTurquoise color (R:72,G:209,B:204,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumTurquoise { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MediumVioletRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MediumVioletRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1271">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MediumVioletRed_" data-uid="SadRogue.Primitives.Color.MediumVioletRed*"></a>
-  <h4 id="SadRogue_Primitives_Color_MediumVioletRed" data-uid="SadRogue.Primitives.Color.MediumVioletRed">MediumVioletRed</h4>
-  <div class="markdown level1 summary"><p>MediumVioletRed color (R:199,G:21,B:133,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MediumVioletRed { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MidnightBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MidnightBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1280">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MidnightBlue_" data-uid="SadRogue.Primitives.Color.MidnightBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_MidnightBlue" data-uid="SadRogue.Primitives.Color.MidnightBlue">MidnightBlue</h4>
-  <div class="markdown level1 summary"><p>MidnightBlue color (R:25,G:25,B:112,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MidnightBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MintCream.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MintCream%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1289">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MintCream_" data-uid="SadRogue.Primitives.Color.MintCream*"></a>
-  <h4 id="SadRogue_Primitives_Color_MintCream" data-uid="SadRogue.Primitives.Color.MintCream">MintCream</h4>
-  <div class="markdown level1 summary"><p>MintCream color (R:245,G:255,B:250,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MintCream { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MistyRose.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MistyRose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1298">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MistyRose_" data-uid="SadRogue.Primitives.Color.MistyRose*"></a>
-  <h4 id="SadRogue_Primitives_Color_MistyRose" data-uid="SadRogue.Primitives.Color.MistyRose">MistyRose</h4>
-  <div class="markdown level1 summary"><p>MistyRose color (R:255,G:228,B:225,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MistyRose { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Moccasin.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Moccasin%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1307">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Moccasin_" data-uid="SadRogue.Primitives.Color.Moccasin*"></a>
-  <h4 id="SadRogue_Primitives_Color_Moccasin" data-uid="SadRogue.Primitives.Color.Moccasin">Moccasin</h4>
-  <div class="markdown level1 summary"><p>Moccasin color (R:255,G:228,B:181,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Moccasin { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_MonoGameOrange.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.MonoGameOrange%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1316">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_MonoGameOrange_" data-uid="SadRogue.Primitives.Color.MonoGameOrange*"></a>
-  <h4 id="SadRogue_Primitives_Color_MonoGameOrange" data-uid="SadRogue.Primitives.Color.MonoGameOrange">MonoGameOrange</h4>
-  <div class="markdown level1 summary"><p>MonoGame orange theme color (R:231,G:60,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color MonoGameOrange { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_NavajoWhite.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.NavajoWhite%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1325">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_NavajoWhite_" data-uid="SadRogue.Primitives.Color.NavajoWhite*"></a>
-  <h4 id="SadRogue_Primitives_Color_NavajoWhite" data-uid="SadRogue.Primitives.Color.NavajoWhite">NavajoWhite</h4>
-  <div class="markdown level1 summary"><p>NavajoWhite color (R:255,G:222,B:173,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color NavajoWhite { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Navy.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Navy%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1334">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Navy_" data-uid="SadRogue.Primitives.Color.Navy*"></a>
-  <h4 id="SadRogue_Primitives_Color_Navy" data-uid="SadRogue.Primitives.Color.Navy">Navy</h4>
-  <div class="markdown level1 summary"><p>Navy color (R:0,G:0,B:128,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Navy { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_OldLace.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.OldLace%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1343">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_OldLace_" data-uid="SadRogue.Primitives.Color.OldLace*"></a>
-  <h4 id="SadRogue_Primitives_Color_OldLace" data-uid="SadRogue.Primitives.Color.OldLace">OldLace</h4>
-  <div class="markdown level1 summary"><p>OldLace color (R:253,G:245,B:230,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color OldLace { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Olive.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Olive%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1352">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Olive_" data-uid="SadRogue.Primitives.Color.Olive*"></a>
-  <h4 id="SadRogue_Primitives_Color_Olive" data-uid="SadRogue.Primitives.Color.Olive">Olive</h4>
-  <div class="markdown level1 summary"><p>Olive color (R:128,G:128,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Olive { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_OliveDrab.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.OliveDrab%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1361">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_OliveDrab_" data-uid="SadRogue.Primitives.Color.OliveDrab*"></a>
-  <h4 id="SadRogue_Primitives_Color_OliveDrab" data-uid="SadRogue.Primitives.Color.OliveDrab">OliveDrab</h4>
-  <div class="markdown level1 summary"><p>OliveDrab color (R:107,G:142,B:35,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color OliveDrab { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Orange.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Orange%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1370">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Orange_" data-uid="SadRogue.Primitives.Color.Orange*"></a>
-  <h4 id="SadRogue_Primitives_Color_Orange" data-uid="SadRogue.Primitives.Color.Orange">Orange</h4>
-  <div class="markdown level1 summary"><p>Orange color (R:255,G:165,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Orange { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_OrangeRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.OrangeRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1379">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_OrangeRed_" data-uid="SadRogue.Primitives.Color.OrangeRed*"></a>
-  <h4 id="SadRogue_Primitives_Color_OrangeRed" data-uid="SadRogue.Primitives.Color.OrangeRed">OrangeRed</h4>
-  <div class="markdown level1 summary"><p>OrangeRed color (R:255,G:69,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color OrangeRed { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Orchid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Orchid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1388">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Orchid_" data-uid="SadRogue.Primitives.Color.Orchid*"></a>
-  <h4 id="SadRogue_Primitives_Color_Orchid" data-uid="SadRogue.Primitives.Color.Orchid">Orchid</h4>
-  <div class="markdown level1 summary"><p>Orchid color (R:218,G:112,B:214,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Orchid { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -4243,17 +5336,16 @@ public byte G { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PackedValue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PackedValue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1961">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1394">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_PackedValue_" data-uid="SadRogue.Primitives.Color.PackedValue*"></a>
   <h4 id="SadRogue_Primitives_Color_PackedValue" data-uid="SadRogue.Primitives.Color.PackedValue">PackedValue</h4>
-  <div class="markdown level1 summary"><p>Gets or sets packed value of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
+  <div class="markdown level1 summary"><p>Gets the packed value of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[CLSCompliant(false)]
-public uint PackedValue { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">public uint PackedValue { get; }</code></pre>
   </div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -4265,348 +5357,7 @@ public uint PackedValue { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.UInt32</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleGoldenrod.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleGoldenrod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1397">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PaleGoldenrod_" data-uid="SadRogue.Primitives.Color.PaleGoldenrod*"></a>
-  <h4 id="SadRogue_Primitives_Color_PaleGoldenrod" data-uid="SadRogue.Primitives.Color.PaleGoldenrod">PaleGoldenrod</h4>
-  <div class="markdown level1 summary"><p>PaleGoldenrod color (R:238,G:232,B:170,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PaleGoldenrod { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1406">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PaleGreen_" data-uid="SadRogue.Primitives.Color.PaleGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_PaleGreen" data-uid="SadRogue.Primitives.Color.PaleGreen">PaleGreen</h4>
-  <div class="markdown level1 summary"><p>PaleGreen color (R:152,G:251,B:152,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PaleGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleTurquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleTurquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1415">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PaleTurquoise_" data-uid="SadRogue.Primitives.Color.PaleTurquoise*"></a>
-  <h4 id="SadRogue_Primitives_Color_PaleTurquoise" data-uid="SadRogue.Primitives.Color.PaleTurquoise">PaleTurquoise</h4>
-  <div class="markdown level1 summary"><p>PaleTurquoise color (R:175,G:238,B:238,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PaleTurquoise { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PaleVioletRed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PaleVioletRed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1423">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PaleVioletRed_" data-uid="SadRogue.Primitives.Color.PaleVioletRed*"></a>
-  <h4 id="SadRogue_Primitives_Color_PaleVioletRed" data-uid="SadRogue.Primitives.Color.PaleVioletRed">PaleVioletRed</h4>
-  <div class="markdown level1 summary"><p>PaleVioletRed color (R:219,G:112,B:147,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PaleVioletRed { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PapayaWhip.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PapayaWhip%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1432">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PapayaWhip_" data-uid="SadRogue.Primitives.Color.PapayaWhip*"></a>
-  <h4 id="SadRogue_Primitives_Color_PapayaWhip" data-uid="SadRogue.Primitives.Color.PapayaWhip">PapayaWhip</h4>
-  <div class="markdown level1 summary"><p>PapayaWhip color (R:255,G:239,B:213,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PapayaWhip { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PeachPuff.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PeachPuff%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1441">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PeachPuff_" data-uid="SadRogue.Primitives.Color.PeachPuff*"></a>
-  <h4 id="SadRogue_Primitives_Color_PeachPuff" data-uid="SadRogue.Primitives.Color.PeachPuff">PeachPuff</h4>
-  <div class="markdown level1 summary"><p>PeachPuff color (R:255,G:218,B:185,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PeachPuff { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Peru.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Peru%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1450">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Peru_" data-uid="SadRogue.Primitives.Color.Peru*"></a>
-  <h4 id="SadRogue_Primitives_Color_Peru" data-uid="SadRogue.Primitives.Color.Peru">Peru</h4>
-  <div class="markdown level1 summary"><p>Peru color (R:205,G:133,B:63,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Peru { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Pink.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Pink%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1459">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Pink_" data-uid="SadRogue.Primitives.Color.Pink*"></a>
-  <h4 id="SadRogue_Primitives_Color_Pink" data-uid="SadRogue.Primitives.Color.Pink">Pink</h4>
-  <div class="markdown level1 summary"><p>Pink color (R:255,G:192,B:203,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Pink { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Plum.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Plum%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1468">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Plum_" data-uid="SadRogue.Primitives.Color.Plum*"></a>
-  <h4 id="SadRogue_Primitives_Color_Plum" data-uid="SadRogue.Primitives.Color.Plum">Plum</h4>
-  <div class="markdown level1 summary"><p>Plum color (R:221,G:160,B:221,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Plum { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_PowderBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.PowderBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1477">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_PowderBlue_" data-uid="SadRogue.Primitives.Color.PowderBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_PowderBlue" data-uid="SadRogue.Primitives.Color.PowderBlue">PowderBlue</h4>
-  <div class="markdown level1 summary"><p>PowderBlue color (R:176,G:224,B:230,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color PowderBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Purple.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Purple%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1486">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Purple_" data-uid="SadRogue.Primitives.Color.Purple*"></a>
-  <h4 id="SadRogue_Primitives_Color_Purple" data-uid="SadRogue.Primitives.Color.Purple">Purple</h4>
-  <div class="markdown level1 summary"><p>Purple color (R:128,G:0,B:128,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Purple { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.uint32">UInt32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -4616,7 +5367,7 @@ public uint PackedValue { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_R.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.R%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L325">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L316">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_R_" data-uid="SadRogue.Primitives.Color.R*"></a>
   <h4 id="SadRogue_Primitives_Color_R" data-uid="SadRogue.Primitives.Color.R">R</h4>
@@ -4625,8 +5376,7 @@ public uint PackedValue { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[DataMember]
-public byte R { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">public byte R { get; }</code></pre>
   </div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -4638,906 +5388,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Red.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Red%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1495">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Red_" data-uid="SadRogue.Primitives.Color.Red*"></a>
-  <h4 id="SadRogue_Primitives_Color_Red" data-uid="SadRogue.Primitives.Color.Red">Red</h4>
-  <div class="markdown level1 summary"><p>Red color (R:255,G:0,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Red { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_RosyBrown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.RosyBrown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1504">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_RosyBrown_" data-uid="SadRogue.Primitives.Color.RosyBrown*"></a>
-  <h4 id="SadRogue_Primitives_Color_RosyBrown" data-uid="SadRogue.Primitives.Color.RosyBrown">RosyBrown</h4>
-  <div class="markdown level1 summary"><p>RosyBrown color (R:188,G:143,B:143,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color RosyBrown { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_RoyalBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.RoyalBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1513">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_RoyalBlue_" data-uid="SadRogue.Primitives.Color.RoyalBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_RoyalBlue" data-uid="SadRogue.Primitives.Color.RoyalBlue">RoyalBlue</h4>
-  <div class="markdown level1 summary"><p>RoyalBlue color (R:65,G:105,B:225,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color RoyalBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SaddleBrown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SaddleBrown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1522">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SaddleBrown_" data-uid="SadRogue.Primitives.Color.SaddleBrown*"></a>
-  <h4 id="SadRogue_Primitives_Color_SaddleBrown" data-uid="SadRogue.Primitives.Color.SaddleBrown">SaddleBrown</h4>
-  <div class="markdown level1 summary"><p>SaddleBrown color (R:139,G:69,B:19,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SaddleBrown { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Salmon.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Salmon%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1531">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Salmon_" data-uid="SadRogue.Primitives.Color.Salmon*"></a>
-  <h4 id="SadRogue_Primitives_Color_Salmon" data-uid="SadRogue.Primitives.Color.Salmon">Salmon</h4>
-  <div class="markdown level1 summary"><p>Salmon color (R:250,G:128,B:114,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Salmon { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SandyBrown.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SandyBrown%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1540">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SandyBrown_" data-uid="SadRogue.Primitives.Color.SandyBrown*"></a>
-  <h4 id="SadRogue_Primitives_Color_SandyBrown" data-uid="SadRogue.Primitives.Color.SandyBrown">SandyBrown</h4>
-  <div class="markdown level1 summary"><p>SandyBrown color (R:244,G:164,B:96,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SandyBrown { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SeaGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SeaGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1549">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SeaGreen_" data-uid="SadRogue.Primitives.Color.SeaGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_SeaGreen" data-uid="SadRogue.Primitives.Color.SeaGreen">SeaGreen</h4>
-  <div class="markdown level1 summary"><p>SeaGreen color (R:46,G:139,B:87,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SeaGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SeaShell.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SeaShell%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1558">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SeaShell_" data-uid="SadRogue.Primitives.Color.SeaShell*"></a>
-  <h4 id="SadRogue_Primitives_Color_SeaShell" data-uid="SadRogue.Primitives.Color.SeaShell">SeaShell</h4>
-  <div class="markdown level1 summary"><p>SeaShell color (R:255,G:245,B:238,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SeaShell { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Sienna.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Sienna%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1567">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Sienna_" data-uid="SadRogue.Primitives.Color.Sienna*"></a>
-  <h4 id="SadRogue_Primitives_Color_Sienna" data-uid="SadRogue.Primitives.Color.Sienna">Sienna</h4>
-  <div class="markdown level1 summary"><p>Sienna color (R:160,G:82,B:45,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Sienna { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Silver.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Silver%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1576">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Silver_" data-uid="SadRogue.Primitives.Color.Silver*"></a>
-  <h4 id="SadRogue_Primitives_Color_Silver" data-uid="SadRogue.Primitives.Color.Silver">Silver</h4>
-  <div class="markdown level1 summary"><p>Silver color (R:192,G:192,B:192,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Silver { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SkyBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SkyBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1585">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SkyBlue_" data-uid="SadRogue.Primitives.Color.SkyBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_SkyBlue" data-uid="SadRogue.Primitives.Color.SkyBlue">SkyBlue</h4>
-  <div class="markdown level1 summary"><p>SkyBlue color (R:135,G:206,B:235,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SkyBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SlateBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SlateBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1594">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SlateBlue_" data-uid="SadRogue.Primitives.Color.SlateBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_SlateBlue" data-uid="SadRogue.Primitives.Color.SlateBlue">SlateBlue</h4>
-  <div class="markdown level1 summary"><p>SlateBlue color (R:106,G:90,B:205,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SlateBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SlateGray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SlateGray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1603">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SlateGray_" data-uid="SadRogue.Primitives.Color.SlateGray*"></a>
-  <h4 id="SadRogue_Primitives_Color_SlateGray" data-uid="SadRogue.Primitives.Color.SlateGray">SlateGray</h4>
-  <div class="markdown level1 summary"><p>SlateGray color (R:112,G:128,B:144,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SlateGray { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Snow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Snow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1612">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Snow_" data-uid="SadRogue.Primitives.Color.Snow*"></a>
-  <h4 id="SadRogue_Primitives_Color_Snow" data-uid="SadRogue.Primitives.Color.Snow">Snow</h4>
-  <div class="markdown level1 summary"><p>Snow color (R:255,G:250,B:250,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Snow { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SpringGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SpringGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1621">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SpringGreen_" data-uid="SadRogue.Primitives.Color.SpringGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_SpringGreen" data-uid="SadRogue.Primitives.Color.SpringGreen">SpringGreen</h4>
-  <div class="markdown level1 summary"><p>SpringGreen color (R:0,G:255,B:127,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SpringGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_SteelBlue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.SteelBlue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1630">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_SteelBlue_" data-uid="SadRogue.Primitives.Color.SteelBlue*"></a>
-  <h4 id="SadRogue_Primitives_Color_SteelBlue" data-uid="SadRogue.Primitives.Color.SteelBlue">SteelBlue</h4>
-  <div class="markdown level1 summary"><p>SteelBlue color (R:70,G:130,B:180,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color SteelBlue { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Tan.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Tan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1639">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Tan_" data-uid="SadRogue.Primitives.Color.Tan*"></a>
-  <h4 id="SadRogue_Primitives_Color_Tan" data-uid="SadRogue.Primitives.Color.Tan">Tan</h4>
-  <div class="markdown level1 summary"><p>Tan color (R:210,G:180,B:140,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Tan { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Teal.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Teal%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1648">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Teal_" data-uid="SadRogue.Primitives.Color.Teal*"></a>
-  <h4 id="SadRogue_Primitives_Color_Teal" data-uid="SadRogue.Primitives.Color.Teal">Teal</h4>
-  <div class="markdown level1 summary"><p>Teal color (R:0,G:128,B:128,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Teal { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Thistle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Thistle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1657">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Thistle_" data-uid="SadRogue.Primitives.Color.Thistle*"></a>
-  <h4 id="SadRogue_Primitives_Color_Thistle" data-uid="SadRogue.Primitives.Color.Thistle">Thistle</h4>
-  <div class="markdown level1 summary"><p>Thistle color (R:216,G:191,B:216,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Thistle { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Tomato.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Tomato%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1666">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Tomato_" data-uid="SadRogue.Primitives.Color.Tomato*"></a>
-  <h4 id="SadRogue_Primitives_Color_Tomato" data-uid="SadRogue.Primitives.Color.Tomato">Tomato</h4>
-  <div class="markdown level1 summary"><p>Tomato color (R:255,G:99,B:71,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Tomato { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Transparent.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Transparent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L462">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Transparent_" data-uid="SadRogue.Primitives.Color.Transparent*"></a>
-  <h4 id="SadRogue_Primitives_Color_Transparent" data-uid="SadRogue.Primitives.Color.Transparent">Transparent</h4>
-  <div class="markdown level1 summary"><p>Transparent color (R:0,G:0,B:0,A:0).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Transparent { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_TransparentBlack.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.TransparentBlack%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L453">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_TransparentBlack_" data-uid="SadRogue.Primitives.Color.TransparentBlack*"></a>
-  <h4 id="SadRogue_Primitives_Color_TransparentBlack" data-uid="SadRogue.Primitives.Color.TransparentBlack">TransparentBlack</h4>
-  <div class="markdown level1 summary"><p>TransparentBlack color (R:0,G:0,B:0,A:0).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color TransparentBlack { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Turquoise.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Turquoise%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1675">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Turquoise_" data-uid="SadRogue.Primitives.Color.Turquoise*"></a>
-  <h4 id="SadRogue_Primitives_Color_Turquoise" data-uid="SadRogue.Primitives.Color.Turquoise">Turquoise</h4>
-  <div class="markdown level1 summary"><p>Turquoise color (R:64,G:224,B:208,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Turquoise { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Violet.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Violet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1684">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Violet_" data-uid="SadRogue.Primitives.Color.Violet*"></a>
-  <h4 id="SadRogue_Primitives_Color_Violet" data-uid="SadRogue.Primitives.Color.Violet">Violet</h4>
-  <div class="markdown level1 summary"><p>Violet color (R:238,G:130,B:238,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Violet { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Wheat.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Wheat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1693">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Wheat_" data-uid="SadRogue.Primitives.Color.Wheat*"></a>
-  <h4 id="SadRogue_Primitives_Color_Wheat" data-uid="SadRogue.Primitives.Color.Wheat">Wheat</h4>
-  <div class="markdown level1 summary"><p>Wheat color (R:245,G:222,B:179,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Wheat { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_White.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.White%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1702">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_White_" data-uid="SadRogue.Primitives.Color.White*"></a>
-  <h4 id="SadRogue_Primitives_Color_White" data-uid="SadRogue.Primitives.Color.White">White</h4>
-  <div class="markdown level1 summary"><p>White color (R:255,G:255,B:255,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color White { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_WhiteSmoke.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.WhiteSmoke%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1711">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_WhiteSmoke_" data-uid="SadRogue.Primitives.Color.WhiteSmoke*"></a>
-  <h4 id="SadRogue_Primitives_Color_WhiteSmoke" data-uid="SadRogue.Primitives.Color.WhiteSmoke">WhiteSmoke</h4>
-  <div class="markdown level1 summary"><p>WhiteSmoke color (R:245,G:245,B:245,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color WhiteSmoke { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Yellow.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Yellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1720">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_Yellow_" data-uid="SadRogue.Primitives.Color.Yellow*"></a>
-  <h4 id="SadRogue_Primitives_Color_Yellow" data-uid="SadRogue.Primitives.Color.Yellow">Yellow</h4>
-  <div class="markdown level1 summary"><p>Yellow color (R:255,G:255,B:0,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Yellow { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_YellowGreen.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.YellowGreen%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1729">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Color_YellowGreen_" data-uid="SadRogue.Primitives.Color.YellowGreen*"></a>
-  <h4 id="SadRogue_Primitives_Color_YellowGreen" data-uid="SadRogue.Primitives.Color.YellowGreen">YellowGreen</h4>
-  <div class="markdown level1 summary"><p>YellowGreen color (R:154,G:205,B:50,A:255).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color YellowGreen { get; }</code></pre>
-  </div>
-  <h5 class="propertyValue">Property Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -5549,7 +5400,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Deconstruct_System_Byte__System_Byte__System_Byte__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Deconstruct(System.Byte%40%2CSystem.Byte%40%2CSystem.Byte%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L2048">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1487">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Deconstruct_" data-uid="SadRogue.Primitives.Color.Deconstruct*"></a>
   <h4 id="SadRogue_Primitives_Color_Deconstruct_System_Byte__System_Byte__System_Byte__" data-uid="SadRogue.Primitives.Color.Deconstruct(System.Byte@,System.Byte@,System.Byte@)">Deconstruct(out Byte, out Byte, out Byte)</h4>
@@ -5558,7 +5409,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out byte r, out byte g, out byte b)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out byte r, out byte g, out byte b)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5571,17 +5423,17 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">r</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">g</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">b</span></td>
         <td></td>
       </tr>
@@ -5592,7 +5444,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Deconstruct_System_Byte__System_Byte__System_Byte__System_Byte__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Deconstruct(System.Byte%40%2CSystem.Byte%40%2CSystem.Byte%40%2CSystem.Byte%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L2062">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1502">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Deconstruct_" data-uid="SadRogue.Primitives.Color.Deconstruct*"></a>
   <h4 id="SadRogue_Primitives_Color_Deconstruct_System_Byte__System_Byte__System_Byte__System_Byte__" data-uid="SadRogue.Primitives.Color.Deconstruct(System.Byte@,System.Byte@,System.Byte@,System.Byte@)">Deconstruct(out Byte, out Byte, out Byte, out Byte)</h4>
@@ -5601,7 +5453,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out byte r, out byte g, out byte b, out byte a)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out byte r, out byte g, out byte b, out byte a)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5614,22 +5467,22 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">r</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">g</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">b</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Byte</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
         <td><span class="parametername">a</span></td>
         <td></td>
       </tr>
@@ -5640,7 +5493,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Deconstruct_System_Single__System_Single__System_Single__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Deconstruct(System.Single%40%2CSystem.Single%40%2CSystem.Single%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L2020">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1457">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Deconstruct_" data-uid="SadRogue.Primitives.Color.Deconstruct*"></a>
   <h4 id="SadRogue_Primitives_Color_Deconstruct_System_Single__System_Single__System_Single__" data-uid="SadRogue.Primitives.Color.Deconstruct(System.Single@,System.Single@,System.Single@)">Deconstruct(out Single, out Single, out Single)</h4>
@@ -5649,7 +5502,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out float r, out float g, out float b)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out float r, out float g, out float b)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5662,17 +5516,17 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">r</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">g</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">b</span></td>
         <td></td>
       </tr>
@@ -5683,7 +5537,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Deconstruct_System_Single__System_Single__System_Single__System_Single__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Deconstruct(System.Single%40%2CSystem.Single%40%2CSystem.Single%40%2CSystem.Single%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L2034">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1472">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Deconstruct_" data-uid="SadRogue.Primitives.Color.Deconstruct*"></a>
   <h4 id="SadRogue_Primitives_Color_Deconstruct_System_Single__System_Single__System_Single__System_Single__" data-uid="SadRogue.Primitives.Color.Deconstruct(System.Single@,System.Single@,System.Single@,System.Single@)">Deconstruct(out Single, out Single, out Single, out Single)</h4>
@@ -5692,7 +5546,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out float r, out float g, out float b, out float a)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out float r, out float g, out float b, out float a)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5705,22 +5560,22 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">r</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">g</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">b</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">a</span></td>
         <td></td>
       </tr>
@@ -5731,7 +5586,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Equals_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Equals(SadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L2010">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1446">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Equals_" data-uid="SadRogue.Primitives.Color.Equals*"></a>
   <h4 id="SadRogue_Primitives_Color_Equals_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.Color.Equals(SadRogue.Primitives.Color)">Equals(Color)</h4>
@@ -5740,7 +5595,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(Color other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(Color other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5770,7 +5626,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p><code>true</code> if the instances are equal; <code>false</code> otherwise.</p>
 </td>
       </tr>
@@ -5781,7 +5637,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L379">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L371">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Equals_" data-uid="SadRogue.Primitives.Color.Equals*"></a>
   <h4 id="SadRogue_Primitives_Color_Equals_System_Object_" data-uid="SadRogue.Primitives.Color.Equals(System.Object)">Equals(Object)</h4>
@@ -5790,7 +5646,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5803,7 +5660,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td><p>The <a class="xref" href="SadRogue.Primitives.Color.html">Color</a> to compare.</p>
 </td>
@@ -5820,20 +5677,20 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p><code>true</code> if the instances are equal; <code>false</code> otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_FromHSL_System_Single_System_Single_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.FromHSL(System.Single%2CSystem.Single%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1886">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1332">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_FromHSL_" data-uid="SadRogue.Primitives.Color.FromHSL*"></a>
   <h4 id="SadRogue_Primitives_Color_FromHSL_System_Single_System_Single_System_Single_" data-uid="SadRogue.Primitives.Color.FromHSL(System.Single,System.Single,System.Single)">FromHSL(Single, Single, Single)</h4>
@@ -5842,7 +5699,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color FromHSL(float h, float s, float l)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Color FromHSL(float h, float s, float l)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5855,19 +5713,19 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">h</span></td>
         <td><p>The hue amount.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">s</span></td>
         <td><p>The saturation amount.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">l</span></td>
         <td><p>The luminance amount.</p>
 </td>
@@ -5897,7 +5755,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_FromNonPremultiplied_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.FromNonPremultiplied(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L2001">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1434">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_FromNonPremultiplied_" data-uid="SadRogue.Primitives.Color.FromNonPremultiplied*"></a>
   <h4 id="SadRogue_Primitives_Color_FromNonPremultiplied_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Color.FromNonPremultiplied(System.Int32,System.Int32,System.Int32,System.Int32)">FromNonPremultiplied(Int32, Int32, Int32, Int32)</h4>
@@ -5906,7 +5764,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color FromNonPremultiplied(int r, int g, int b, int a)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Color FromNonPremultiplied(int r, int g, int b, int a)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5919,25 +5778,25 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">r</span></td>
         <td><p>Red component value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">g</span></td>
         <td><p>Green component value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">b</span></td>
         <td><p>Blue component value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">a</span></td>
         <td><p>Alpha component value.</p>
 </td>
@@ -5965,7 +5824,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GetBrightness.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GetBrightness%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1747">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1191">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_GetBrightness_" data-uid="SadRogue.Primitives.Color.GetBrightness*"></a>
   <h4 id="SadRogue_Primitives_Color_GetBrightness" data-uid="SadRogue.Primitives.Color.GetBrightness">GetBrightness()</h4>
@@ -5974,7 +5833,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public float GetBrightness()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public float GetBrightness()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -5986,7 +5846,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><p>The brightness value.</p>
 </td>
       </tr>
@@ -6000,7 +5860,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L372">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L363">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_GetHashCode_" data-uid="SadRogue.Primitives.Color.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_Color_GetHashCode" data-uid="SadRogue.Primitives.Color.GetHashCode">GetHashCode()</h4>
@@ -6009,7 +5869,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6021,20 +5882,20 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>Hash code of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GetHue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GetHue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1785">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1227">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_GetHue_" data-uid="SadRogue.Primitives.Color.GetHue*"></a>
   <h4 id="SadRogue_Primitives_Color_GetHue" data-uid="SadRogue.Primitives.Color.GetHue">GetHue()</h4>
@@ -6043,7 +5904,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public float GetHue()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public float GetHue()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6055,7 +5917,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><p>The hue value.</p>
 </td>
       </tr>
@@ -6069,7 +5931,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GetLuma.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GetLuma%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1740">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1182">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_GetLuma_" data-uid="SadRogue.Primitives.Color.GetLuma*"></a>
   <h4 id="SadRogue_Primitives_Color_GetLuma" data-uid="SadRogue.Primitives.Color.GetLuma">GetLuma()</h4>
@@ -6078,7 +5940,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public float GetLuma()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public float GetLuma()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6090,7 +5953,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><p>A value based on this code: (color.R + color.R + color.B + color.G + color.G + color.G) / 6f</p>
 </td>
       </tr>
@@ -6101,7 +5964,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_GetSaturation.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.GetSaturation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1760">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1205">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_GetSaturation_" data-uid="SadRogue.Primitives.Color.GetSaturation*"></a>
   <h4 id="SadRogue_Primitives_Color_GetSaturation" data-uid="SadRogue.Primitives.Color.GetSaturation">GetSaturation()</h4>
@@ -6110,7 +5973,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public float GetSaturation()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public float GetSaturation()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6122,7 +5986,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><p>The saturation value.</p>
 </td>
       </tr>
@@ -6136,7 +6000,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Lerp_SadRogue_Primitives_Color_SadRogue_Primitives_Color_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Lerp(SadRogue.Primitives.Color%2CSadRogue.Primitives.Color%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1833">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1266">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Lerp_" data-uid="SadRogue.Primitives.Color.Lerp*"></a>
   <h4 id="SadRogue_Primitives_Color_Lerp_SadRogue_Primitives_Color_SadRogue_Primitives_Color_System_Single_" data-uid="SadRogue.Primitives.Color.Lerp(SadRogue.Primitives.Color,SadRogue.Primitives.Color,System.Single)">Lerp(Color, Color, Single)</h4>
@@ -6145,7 +6009,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Lerp(Color value1, Color value2, float amount)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Color Lerp(Color value1, Color value2, float amount)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6170,7 +6035,7 @@ public byte R { get; }</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">amount</span></td>
         <td><p>Interpolation factor.</p>
 </td>
@@ -6198,7 +6063,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_LerpSteps_SadRogue_Primitives_Color_SadRogue_Primitives_Color_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.LerpSteps(SadRogue.Primitives.Color%2CSadRogue.Primitives.Color%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1858">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1303">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_LerpSteps_" data-uid="SadRogue.Primitives.Color.LerpSteps*"></a>
   <h4 id="SadRogue_Primitives_Color_LerpSteps_SadRogue_Primitives_Color_SadRogue_Primitives_Color_System_Int32_" data-uid="SadRogue.Primitives.Color.LerpSteps(SadRogue.Primitives.Color,SadRogue.Primitives.Color,System.Int32)">LerpSteps(Color, Color, Int32)</h4>
@@ -6207,7 +6072,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color[] LerpSteps(Color startingColor, Color endingColor, int steps)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Color[] LerpSteps(Color startingColor, Color endingColor, int steps)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6232,7 +6098,7 @@ public byte R { get; }</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">steps</span></td>
         <td><p>The gradient steps in the array which uses <a class="xref" href="SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Lerp_SadRogue_Primitives_Color_SadRogue_Primitives_Color_System_Single_">Lerp(Color, Color, Single)</a>.</p>
 </td>
@@ -6257,10 +6123,59 @@ public byte R { get; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Matches_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Matches(SadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1282">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Color_Matches_" data-uid="SadRogue.Primitives.Color.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Color_Matches_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.Color.Matches(SadRogue.Primitives.Color)">Matches(Color)</h4>
+  <div class="markdown level1 summary"><p>Returns true if the colors represent the same color values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(Color other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_Multiply_SadRogue_Primitives_Color_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.Multiply(SadRogue.Primitives.Color%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1849">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1291">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_Multiply_" data-uid="SadRogue.Primitives.Color.Multiply*"></a>
   <h4 id="SadRogue_Primitives_Color_Multiply_SadRogue_Primitives_Color_System_Single_" data-uid="SadRogue.Primitives.Color.Multiply(SadRogue.Primitives.Color,System.Single)">Multiply(Color, Single)</h4>
@@ -6269,7 +6184,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color Multiply(Color value, float scale)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Color Multiply(Color value, float scale)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6288,7 +6204,7 @@ public byte R { get; }</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">scale</span></td>
         <td><p>Multiplicator.</p>
 </td>
@@ -6316,17 +6232,18 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1978">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1410">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_ToString_" data-uid="SadRogue.Primitives.Color.ToString*"></a>
   <h4 id="SadRogue_Primitives_Color_ToString" data-uid="SadRogue.Primitives.Color.ToString">ToString()</h4>
-  <div class="markdown level1 summary"><p>Returns a <span class="xref">System.String</span> representation of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a> in the format:
+  <div class="markdown level1 summary"><p>Returns a <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a> representation of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a> in the format:
 {R:[red] G:[green] B:[blue] A:[alpha]}</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override string ToString()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6338,14 +6255,14 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
-        <td><p><span class="xref">System.String</span> representation of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a> representation of this <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="operators">Operators
   </h3>
   <span class="small pull-right mobile-hide">
@@ -6353,7 +6270,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_op_Equality_SadRogue_Primitives_Color_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.op_Equality(SadRogue.Primitives.Color%2CSadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L358">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L347">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_op_Equality_" data-uid="SadRogue.Primitives.Color.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Color_op_Equality_SadRogue_Primitives_Color_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.Color.op_Equality(SadRogue.Primitives.Color,SadRogue.Primitives.Color)">Equality(Color, Color)</h4>
@@ -6362,7 +6279,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Color a, Color b)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Color a, Color b)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6398,7 +6316,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p><code>true</code> if the instances are equal; <code>false</code> otherwise.</p>
 </td>
       </tr>
@@ -6409,7 +6327,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_op_Inequality_SadRogue_Primitives_Color_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.op_Inequality(SadRogue.Primitives.Color%2CSadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L366">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L356">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_op_Inequality_" data-uid="SadRogue.Primitives.Color.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Color_op_Inequality_SadRogue_Primitives_Color_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.Color.op_Inequality(SadRogue.Primitives.Color,SadRogue.Primitives.Color)">Inequality(Color, Color)</h4>
@@ -6418,7 +6336,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Color a, Color b)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Color a, Color b)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6454,7 +6373,7 @@ public byte R { get; }</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p><code>true</code> if the instances are not equal; <code>false</code> otherwise.</p>
 </td>
       </tr>
@@ -6465,7 +6384,7 @@ public byte R { get; }</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color_op_Multiply_SadRogue_Primitives_Color_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color.op_Multiply(SadRogue.Primitives.Color%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1956">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L1387">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Color_op_Multiply_" data-uid="SadRogue.Primitives.Color.op_Multiply*"></a>
   <h4 id="SadRogue_Primitives_Color_op_Multiply_SadRogue_Primitives_Color_System_Single_" data-uid="SadRogue.Primitives.Color.op_Multiply(SadRogue.Primitives.Color,System.Single)">Multiply(Color, Single)</h4>
@@ -6474,7 +6393,8 @@ public byte R { get; }</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Color operator *(Color value, float scale)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Color operator *(Color value, float scale)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -6493,7 +6413,7 @@ public byte R { get; }</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">scale</span></td>
         <td><p>Multiplicator.</p>
 </td>
@@ -6518,7 +6438,14 @@ public byte R { get; }</code></pre>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.ColorExtensions.html#SadRogue_Primitives_ColorExtensions_Matches_SadRogue_Primitives_Color_SadRogue_Primitives_Color_">ColorExtensions.Matches(Color, Color)</a>
   </div>
 </article>
           </div>
@@ -6531,7 +6458,7 @@ public byte R { get; }</code></pre>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Color.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Color%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L15" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Color.cs/#L17" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.ColorExtensions.html
+++ b/docs/api/SadRogue.Primitives.ColorExtensions.html
@@ -1,0 +1,211 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class ColorExtensions
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class ColorExtensions
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.ColorExtensions">
+  
+  
+  <h1 id="SadRogue_Primitives_ColorExtensions" data-uid="SadRogue.Primitives.ColorExtensions" class="text-break">Class ColorExtensions
+  </h1>
+  <div class="markdown level0 summary"><p>Contains set of operators that match ones defined by other packages for interoperability,
+so syntax may be uniform.  Functionality is similar to the corresponding actual operators for Color.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><span class="xref">ColorExtensions</span></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_ColorExtensions_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static class ColorExtensions</code></pre>
+  </div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_ColorExtensions_Matches_SadRogue_Primitives_Color_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.ColorExtensions.Matches(SadRogue.Primitives.Color%2CSadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/ColorExtensions.cs/#L15">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_ColorExtensions_Matches_" data-uid="SadRogue.Primitives.ColorExtensions.Matches*"></a>
+  <h4 id="SadRogue_Primitives_ColorExtensions_Matches_SadRogue_Primitives_Color_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.ColorExtensions.Matches(SadRogue.Primitives.Color,SadRogue.Primitives.Color)">Matches(Color, Color)</h4>
+  <div class="markdown level1 summary"><p>Compares a two colors for equality.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool Matches(this Color self, Color other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_ColorExtensions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.ColorExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/ColorExtensions.cs/#L7" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.Direction.Types.html
+++ b/docs/api/SadRogue.Primitives.Direction.Types.html
@@ -152,7 +152,7 @@ types to a primitive type (for cases like a switch statement).</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L74" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L73" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Direction.html
+++ b/docs/api/SadRogue.Primitives.Direction.html
@@ -81,26 +81,27 @@ various orders, getting direction closest to a line, etc.</p>
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Direction_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct Direction : IEquatable&lt;Direction&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct Direction : IEquatable&lt;Direction&gt;, IMatchable&lt;Direction&gt;</code></pre>
   </div>
   <h5 id="SadRogue_Primitives_Direction_remarks"><strong>Remarks</strong></h5>
   <div class="markdown level0 remarks"><p>The static <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_YIncreasesUpward">YIncreasesUpward</a> flag defines the way that many algorithms
@@ -110,7 +111,7 @@ increase as you go downward.  If the coordinate plane is displayed on the screen
 the top left corner.  This default setting matches the typical console/computer graphic definition of the
 coordinate plane.  Setting the flag to true inverts this, so that the y-value of positions INCREASES
 as you proceed in the direction defined by <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a>.  This places the origin in the bottom
-left corner, and matches a typical mathmatical definition of a euclidean coordinate plane, as well as the scene
+left corner, and matches a typical mathematical definition of a euclidean coordinate plane, as well as the scene
 coordinate plane defined by Unity and other game engines.</p>
 </div>
   <h3 id="fields">Fields
@@ -120,7 +121,7 @@ coordinate plane defined by Unity and other game engines.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Down.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Down%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L125">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L124">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_Down" data-uid="SadRogue.Primitives.Direction.Down">Down</h4>
   <div class="markdown level1 summary"><p>Down direction.</p>
@@ -128,8 +129,7 @@ coordinate plane defined by Unity and other game engines.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction Down</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction Down</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -151,7 +151,7 @@ public static readonly Direction Down</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_DownLeft.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.DownLeft%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L131">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L129">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_DownLeft" data-uid="SadRogue.Primitives.Direction.DownLeft">DownLeft</h4>
   <div class="markdown level1 summary"><p>Down-left direction.</p>
@@ -159,8 +159,7 @@ public static readonly Direction Down</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction DownLeft</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction DownLeft</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -182,7 +181,7 @@ public static readonly Direction DownLeft</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_DownRight.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.DownRight%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L137">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L134">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_DownRight" data-uid="SadRogue.Primitives.Direction.DownRight">DownRight</h4>
   <div class="markdown level1 summary"><p>Down-right direction.</p>
@@ -190,8 +189,7 @@ public static readonly Direction DownLeft</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction DownRight</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction DownRight</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -213,7 +211,7 @@ public static readonly Direction DownRight</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Left.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Left%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L143">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L139">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_Left" data-uid="SadRogue.Primitives.Direction.Left">Left</h4>
   <div class="markdown level1 summary"><p>Left direction.</p>
@@ -221,8 +219,7 @@ public static readonly Direction DownRight</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction Left</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction Left</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -244,7 +241,7 @@ public static readonly Direction Left</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_None.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.None%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L149">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L144">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_None" data-uid="SadRogue.Primitives.Direction.None">None</h4>
   <div class="markdown level1 summary"><p>No direction.</p>
@@ -252,8 +249,7 @@ public static readonly Direction Left</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction None</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction None</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -275,7 +271,7 @@ public static readonly Direction None</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Right.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Right%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L155">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L149">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_Right" data-uid="SadRogue.Primitives.Direction.Right">Right</h4>
   <div class="markdown level1 summary"><p>Right direction.</p>
@@ -283,8 +279,7 @@ public static readonly Direction None</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction Right</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction Right</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -306,7 +301,7 @@ public static readonly Direction Right</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Type.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Type%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L199">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L190">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_Type" data-uid="SadRogue.Primitives.Direction.Type">Type</h4>
   <div class="markdown level1 summary"><p>Enum type corresponding to direction being represented.</p>
@@ -314,7 +309,8 @@ public static readonly Direction Right</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly Direction.Types Type</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly Direction.Types Type</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,7 +332,7 @@ public static readonly Direction Right</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Up.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Up%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L161">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L154">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_Up" data-uid="SadRogue.Primitives.Direction.Up">Up</h4>
   <div class="markdown level1 summary"><p>Up direction.</p>
@@ -344,8 +340,7 @@ public static readonly Direction Right</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction Up</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction Up</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -367,7 +362,7 @@ public static readonly Direction Up</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_UpLeft.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.UpLeft%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L167">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L159">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_UpLeft" data-uid="SadRogue.Primitives.Direction.UpLeft">UpLeft</h4>
   <div class="markdown level1 summary"><p>Up-left direction.</p>
@@ -375,8 +370,7 @@ public static readonly Direction Up</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction UpLeft</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction UpLeft</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -398,7 +392,7 @@ public static readonly Direction UpLeft</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_UpRight.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.UpRight%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L173">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L164">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Direction_UpRight" data-uid="SadRogue.Primitives.Direction.UpRight">UpRight</h4>
   <div class="markdown level1 summary"><p>Up-right direction.</p>
@@ -406,8 +400,7 @@ public static readonly Direction UpLeft</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Direction UpRight</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Direction UpRight</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -431,7 +424,7 @@ public static readonly Direction UpRight</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_DeltaX.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.DeltaX%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L189">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L180">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_DeltaX_" data-uid="SadRogue.Primitives.Direction.DeltaX*"></a>
   <h4 id="SadRogue_Primitives_Direction_DeltaX" data-uid="SadRogue.Primitives.Direction.DeltaX">DeltaX</h4>
@@ -452,7 +445,7 @@ public static readonly Direction UpRight</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -462,7 +455,7 @@ public static readonly Direction UpRight</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_DeltaY.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.DeltaY%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L194">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L185">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_DeltaY_" data-uid="SadRogue.Primitives.Direction.DeltaY*"></a>
   <h4 id="SadRogue_Primitives_Direction_DeltaY" data-uid="SadRogue.Primitives.Direction.DeltaY">DeltaY</h4>
@@ -483,7 +476,7 @@ public static readonly Direction UpRight</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -493,7 +486,7 @@ public static readonly Direction UpRight</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_YIncreasesUpward.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.YIncreasesUpward%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L184">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L175">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_YIncreasesUpward_" data-uid="SadRogue.Primitives.Direction.YIncreasesUpward*"></a>
   <h4 id="SadRogue_Primitives_Direction_YIncreasesUpward" data-uid="SadRogue.Primitives.Direction.YIncreasesUpward">YIncreasesUpward</h4>
@@ -516,7 +509,7 @@ routine.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -532,7 +525,7 @@ represent a negative change in y-value.  Changing this to false (which is the de
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Equals_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Equals(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L206">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L197">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_Equals_" data-uid="SadRogue.Primitives.Direction.Equals*"></a>
   <h4 id="SadRogue_Primitives_Direction_Equals_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.Equals(SadRogue.Primitives.Direction)">Equals(Direction)</h4>
@@ -541,7 +534,8 @@ represent a negative change in y-value.  Changing this to false (which is the de
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(Direction other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(Direction other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -571,7 +565,7 @@ represent a negative change in y-value.  Changing this to false (which is the de
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two directions are the same, false if not.</p>
 </td>
       </tr>
@@ -582,7 +576,7 @@ represent a negative change in y-value.  Changing this to false (which is the de
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L215">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L207">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_Equals_" data-uid="SadRogue.Primitives.Direction.Equals*"></a>
   <h4 id="SadRogue_Primitives_Direction_Equals_System_Object_" data-uid="SadRogue.Primitives.Direction.Equals(System.Object)">Equals(Object)</h4>
@@ -591,7 +585,8 @@ represent a negative change in y-value.  Changing this to false (which is the de
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -604,7 +599,7 @@ represent a negative change in y-value.  Changing this to false (which is the de
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td><p>The object to compare the current Direction to.</p>
 </td>
@@ -621,20 +616,20 @@ represent a negative change in y-value.  Changing this to false (which is the de
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a Direction, and the two directions are equal, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetCardinalDirection_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetCardinalDirection(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L291">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L342">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_GetCardinalDirection_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection*"></a>
   <h4 id="SadRogue_Primitives_Direction_GetCardinalDirection_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection(SadRogue.Primitives.Point)">GetCardinalDirection(Point)</h4>
@@ -645,7 +640,8 @@ with the given delta-change values. Rounds clockwise if exactly on a diagonal. S
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction GetCardinalDirection(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetCardinalDirection(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -687,7 +683,7 @@ change in x, deltaChange.Y is the change in y).</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetCardinalDirection_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetCardinalDirection(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L277">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L307">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_GetCardinalDirection_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection*"></a>
   <h4 id="SadRogue_Primitives_Direction_GetCardinalDirection_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">GetCardinalDirection(Point, Point)</h4>
@@ -698,7 +694,8 @@ line. Rounds clockwise if the heading is exactly on a diagonal direction. Simila
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction GetCardinalDirection(Point start, Point end)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetCardinalDirection(Point start, Point end)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -742,10 +739,140 @@ line. Rounds clockwise if the heading is exactly on a diagonal direction. Simila
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetCardinalDirection_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L383">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_GetCardinalDirection_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection*"></a>
+  <h4 id="SadRogue_Primitives_Direction_GetCardinalDirection_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32,System.Int32)">GetCardinalDirection(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the cardinal direction that most closely matches the degree heading of a line
+with the given delta-change values. Rounds clockwise if exactly on a diagonal. Similar to
+<a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetDirection_SadRogue_Primitives_Point_">GetDirection(Point)</a>, except this function returns only cardinal directions.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetCardinalDirection(int dx, int dy)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dx</span></td>
+        <td><p>Change in x along the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dy</span></td>
+        <td><p>Change in y along the line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><p>The cardinal direction that most closely matches the degree heading of the given line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetCardinalDirection_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L324">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_GetCardinalDirection_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection*"></a>
+  <h4 id="SadRogue_Primitives_Direction_GetCardinalDirection_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32,System.Int32,System.Int32,System.Int32)">GetCardinalDirection(Int32, Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the cardinal direction that most closely matches the degree heading of the given
+line. Rounds clockwise if the heading is exactly on a diagonal direction. Similar to
+<a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetDirection_SadRogue_Primitives_Point_SadRogue_Primitives_Point_">GetDirection(Point, Point)</a>, except this function returns only cardinal directions.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetCardinalDirection(int startX, int startY, int endX, int endY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startX</span></td>
+        <td><p>X-value of the starting coordinate of the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startY</span></td>
+        <td><p>Y-value of the starting coordinate of the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">endX</span></td>
+        <td><p>X-value of the ending coordinate of the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">endY</span></td>
+        <td><p>Y-value of the ending coordinate of the line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><p>The cardinal direction that most closely matches the heading indicated by the given line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetDirection_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetDirection(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L354">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L429">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_GetDirection_" data-uid="SadRogue.Primitives.Direction.GetDirection*"></a>
   <h4 id="SadRogue_Primitives_Direction_GetDirection_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Direction.GetDirection(SadRogue.Primitives.Point)">GetDirection(Point)</h4>
@@ -755,7 +882,8 @@ given delta-change values. Rounds clockwise if the heading is exactly between tw
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction GetDirection(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetDirection(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -797,7 +925,7 @@ change in x, deltaChange.Y is the change in y).</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetDirection_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetDirection(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L340">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L396">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_GetDirection_" data-uid="SadRogue.Primitives.Direction.GetDirection*"></a>
   <h4 id="SadRogue_Primitives_Direction_GetDirection_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Direction.GetDirection(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">GetDirection(Point, Point)</h4>
@@ -807,7 +935,8 @@ Rounds clockwise if the heading is exactly between two directions.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction GetDirection(Point start, Point end)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetDirection(Point start, Point end)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -851,10 +980,138 @@ Rounds clockwise if the heading is exactly between two directions.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetDirection_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetDirection(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L481">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_GetDirection_" data-uid="SadRogue.Primitives.Direction.GetDirection*"></a>
+  <h4 id="SadRogue_Primitives_Direction_GetDirection_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Direction.GetDirection(System.Int32,System.Int32)">GetDirection(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the direction that most closely matches the degree heading of a line with the
+given delta-change values. Rounds clockwise if the heading is exactly between two directions.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetDirection(int dx, int dy)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dx</span></td>
+        <td><p>Change in x-value across the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dy</span></td>
+        <td><p>Change in y-value across the line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><p>The direction that most closely matches the heading indicated by the given input.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetDirection_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetDirection(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L412">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_GetDirection_" data-uid="SadRogue.Primitives.Direction.GetDirection*"></a>
+  <h4 id="SadRogue_Primitives_Direction_GetDirection_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Direction.GetDirection(System.Int32,System.Int32,System.Int32,System.Int32)">GetDirection(Int32, Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the direction that most closely matches the degree heading of the given line.
+Rounds clockwise if the heading is exactly between two directions.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction GetDirection(int startX, int startY, int endX, int endY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startX</span></td>
+        <td><p>X-value of the starting coordinate of the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startY</span></td>
+        <td><p>Y-value of the starting coordinate of the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">endX</span></td>
+        <td><p>X-value of the ending coordinate of the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">endY</span></td>
+        <td><p>Y-value of the ending coordinate of the line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><p>The direction that most closely matches the heading indicated by the given line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L221">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L214">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_GetHashCode_" data-uid="SadRogue.Primitives.Direction.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_Direction_GetHashCode" data-uid="SadRogue.Primitives.Direction.GetHashCode">GetHashCode()</h4>
@@ -863,7 +1120,8 @@ Rounds clockwise if the heading is exactly between two directions.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -875,19 +1133,19 @@ Rounds clockwise if the heading is exactly between two directions.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_IsCardinal.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.IsCardinal%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L493">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L531">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_IsCardinal_" data-uid="SadRogue.Primitives.Direction.IsCardinal*"></a>
   <h4 id="SadRogue_Primitives_Direction_IsCardinal" data-uid="SadRogue.Primitives.Direction.IsCardinal">IsCardinal()</h4>
@@ -896,7 +1154,8 @@ Rounds clockwise if the heading is exactly between two directions.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool IsCardinal()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool IsCardinal()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -908,8 +1167,59 @@ Rounds clockwise if the heading is exactly between two directions.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the current direction is a cardinal direction, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_Matches_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.Matches(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L222">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_Matches_" data-uid="SadRogue.Primitives.Direction.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Direction_Matches_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.Matches(SadRogue.Primitives.Direction)">Matches(Direction)</h4>
+  <div class="markdown level1 summary"><p>True if the given direction has the same Type the current one.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(Direction other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Direction to compare.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two directions are the same, false if not.</p>
 </td>
       </tr>
     </tbody>
@@ -919,7 +1229,7 @@ Rounds clockwise if the heading is exactly between two directions.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_SetYIncreasesUpwardsUnsafe_System_Boolean_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.SetYIncreasesUpwardsUnsafe(System.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L250">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L280">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_SetYIncreasesUpwardsUnsafe_" data-uid="SadRogue.Primitives.Direction.SetYIncreasesUpwardsUnsafe*"></a>
   <h4 id="SadRogue_Primitives_Direction_SetYIncreasesUpwardsUnsafe_System_Boolean_" data-uid="SadRogue.Primitives.Direction.SetYIncreasesUpwardsUnsafe(System.Boolean)">SetYIncreasesUpwardsUnsafe(Boolean)</h4>
@@ -942,59 +1252,9 @@ It is intended that this value be set once to match your environment as part of 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><span class="parametername">newValue</span></td>
         <td><p>New value to assign to <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_YIncreasesUpward">YIncreasesUpward</a>.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_ToDirection_SadRogue_Primitives_Direction_Types_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.ToDirection(SadRogue.Primitives.Direction.Types)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L453">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Direction_ToDirection_" data-uid="SadRogue.Primitives.Direction.ToDirection*"></a>
-  <h4 id="SadRogue_Primitives_Direction_ToDirection_SadRogue_Primitives_Direction_Types_" data-uid="SadRogue.Primitives.Direction.ToDirection(SadRogue.Primitives.Direction.Types)">ToDirection(Direction.Types)</h4>
-  <div class="markdown level1 summary"><p>Gets the Direction class instance representing the direction type specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction ToDirection(Direction.Types directionType)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Direction.Types.html">Direction.Types</a></td>
-        <td><span class="parametername">directionType</span></td>
-        <td><p>The enum value for the direction.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
-        <td><p>The direction class representing the given direction.</p>
 </td>
       </tr>
     </tbody>
@@ -1004,7 +1264,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L499">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L539">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_ToString_" data-uid="SadRogue.Primitives.Direction.ToString*"></a>
   <h4 id="SadRogue_Primitives_Direction_ToString" data-uid="SadRogue.Primitives.Direction.ToString">ToString()</h4>
@@ -1013,7 +1273,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override string ToString()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1025,14 +1286,14 @@ It is intended that this value be set once to match your environment as part of 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
         <td><p>String representation of the direction.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="operators">Operators
   </h3>
   <span class="small pull-right mobile-hide">
@@ -1040,7 +1301,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Addition_SadRogue_Primitives_Direction_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Addition(SadRogue.Primitives.Direction%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L439">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L514">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Addition_" data-uid="SadRogue.Primitives.Direction.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Addition_SadRogue_Primitives_Direction_System_Int32_" data-uid="SadRogue.Primitives.Direction.op_Addition(SadRogue.Primitives.Direction,System.Int32)">Addition(Direction, Int32)</h4>
@@ -1049,7 +1310,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction operator +(Direction d, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction operator +(Direction d, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1067,7 +1329,7 @@ It is intended that this value be set once to match your environment as part of 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -1094,7 +1356,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Addition_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Addition(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L510">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L552">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Addition_" data-uid="SadRogue.Primitives.Direction.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Addition_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.op_Addition(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Direction)">Addition((Int32 x, Int32 y), Direction)</h4>
@@ -1103,7 +1365,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static (int x, int y) operator +((int x, int y) tuple, Direction d)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static (int x, int y) operator +((int x, int y) tuple, Direction d)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1116,7 +1379,7 @@ It is intended that this value be set once to match your environment as part of 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1137,7 +1400,7 @@ It is intended that this value be set once to match your environment as part of 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><p>Tuple (tuple.y + d.DeltaX, tuple.y + d.DeltaY).</p>
 </td>
       </tr>
@@ -1148,7 +1411,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Decrement_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Decrement(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L429">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L502">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Decrement_" data-uid="SadRogue.Primitives.Direction.op_Decrement*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Decrement_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.op_Decrement(SadRogue.Primitives.Direction)">Decrement(Direction)</h4>
@@ -1157,7 +1420,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction operator --(Direction d)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction operator --(Direction d)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1197,7 +1461,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Equality_SadRogue_Primitives_Direction_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Equality(SadRogue.Primitives.Direction%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L229">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L231">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Equality_" data-uid="SadRogue.Primitives.Direction.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Equality_SadRogue_Primitives_Direction_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.op_Equality(SadRogue.Primitives.Direction,SadRogue.Primitives.Direction)">Equality(Direction, Direction)</h4>
@@ -1206,7 +1470,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Direction lhs, Direction rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Direction lhs, Direction rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1240,9 +1505,107 @@ It is intended that this value be set once to match your environment as part of 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two directions are equal, false if not.</p>
 </td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Implicit_SadRogue_Primitives_Direction__SadRogue_Primitives_Direction_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction)~SadRogue.Primitives.Direction.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L249">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_op_Implicit_" data-uid="SadRogue.Primitives.Direction.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Direction_op_Implicit_SadRogue_Primitives_Direction__SadRogue_Primitives_Direction_Types" data-uid="SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction)~SadRogue.Primitives.Direction.Types">Implicit(Direction to Direction.Types)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts a Direction to its corresponding <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Type">Type</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Direction.Types(Direction direction)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">direction</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.Types.html">Direction.Types</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Implicit_SadRogue_Primitives_Direction_Types__SadRogue_Primitives_Direction.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction.Types)~SadRogue.Primitives.Direction%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L256">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Direction_op_Implicit_" data-uid="SadRogue.Primitives.Direction.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Direction_op_Implicit_SadRogue_Primitives_Direction_Types__SadRogue_Primitives_Direction" data-uid="SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction.Types)~SadRogue.Primitives.Direction">Implicit(Direction.Types to Direction)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts an <a class="xref" href="SadRogue.Primitives.Direction.Types.html">Direction.Types</a> enum value to its corresponding Direction.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Direction(Direction.Types type)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.Types.html">Direction.Types</a></td>
+        <td><span class="parametername">type</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td></td>
       </tr>
     </tbody>
   </table>
@@ -1251,7 +1614,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Increment_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Increment(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L446">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L523">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Increment_" data-uid="SadRogue.Primitives.Direction.op_Increment*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Increment_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.op_Increment(SadRogue.Primitives.Direction)">Increment(Direction)</h4>
@@ -1260,7 +1623,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction operator ++(Direction d)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction operator ++(Direction d)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1300,7 +1664,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Inequality_SadRogue_Primitives_Direction_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Inequality(SadRogue.Primitives.Direction%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L239">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L242">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Inequality_" data-uid="SadRogue.Primitives.Direction.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Inequality_SadRogue_Primitives_Direction_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Direction.op_Inequality(SadRogue.Primitives.Direction,SadRogue.Primitives.Direction)">Inequality(Direction, Direction)</h4>
@@ -1309,7 +1673,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Direction lhs, Direction rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Direction lhs, Direction rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1343,7 +1708,7 @@ It is intended that this value be set once to match your environment as part of 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the types are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -1354,7 +1719,7 @@ It is intended that this value be set once to match your environment as part of 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction_op_Subtraction_SadRogue_Primitives_Direction_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction.op_Subtraction(SadRogue.Primitives.Direction%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L422">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L493">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Direction_op_Subtraction_" data-uid="SadRogue.Primitives.Direction.op_Subtraction*"></a>
   <h4 id="SadRogue_Primitives_Direction_op_Subtraction_SadRogue_Primitives_Direction_System_Int32_" data-uid="SadRogue.Primitives.Direction.op_Subtraction(SadRogue.Primitives.Direction,System.Int32)">Subtraction(Direction, Int32)</h4>
@@ -1363,7 +1728,8 @@ It is intended that this value be set once to match your environment as part of 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Direction operator -(Direction d, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Direction operator -(Direction d, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1381,7 +1747,7 @@ It is intended that this value be set once to match your environment as part of 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -1405,7 +1771,10 @@ It is intended that this value be set once to match your environment as part of 
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -1418,7 +1787,7 @@ It is intended that this value be set once to match your environment as part of 
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Direction.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Direction%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L23" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Direction.cs/#L26" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Distance.Types.html
+++ b/docs/api/SadRogue.Primitives.Distance.Types.html
@@ -122,7 +122,7 @@ types to a primitive type (for cases like a switch statement).</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L53" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L52" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Distance.html
+++ b/docs/api/SadRogue.Primitives.Distance.html
@@ -80,26 +80,27 @@ various distance calculations.</p>
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Distance_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct Distance : IEquatable&lt;Distance&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct Distance : IEquatable&lt;Distance&gt;, IMatchable&lt;Distance&gt;</code></pre>
   </div>
   <h5 id="SadRogue_Primitives_Distance_remarks"><strong>Remarks</strong></h5>
   <div class="markdown level0 remarks"><p>Provides functions that calculate the distance between two points according to the distance
@@ -114,7 +115,7 @@ locations and a radius shape are implied by a distance calculation).</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Chebyshev.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Chebyshev%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L23">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L25">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Distance_Chebyshev" data-uid="SadRogue.Primitives.Distance.Chebyshev">Chebyshev</h4>
   <div class="markdown level1 summary"><p>Represents chebyshev distance (equivalent to 8-way movement with no extra cost for diagonals).</p>
@@ -122,8 +123,7 @@ locations and a radius shape are implied by a distance calculation).</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static Distance Chebyshev</code></pre>
+    <pre><code class="lang-csharp hljs">public static Distance Chebyshev</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -145,7 +145,7 @@ public static Distance Chebyshev</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Euclidean.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Euclidean%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L29">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L30">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Distance_Euclidean" data-uid="SadRogue.Primitives.Distance.Euclidean">Euclidean</h4>
   <div class="markdown level1 summary"><p>Represents euclidean distance (equivalent to 8-way movement with ~1.41 movement cost for diagonals).</p>
@@ -153,8 +153,7 @@ public static Distance Chebyshev</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static Distance Euclidean</code></pre>
+    <pre><code class="lang-csharp hljs">public static Distance Euclidean</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -184,8 +183,7 @@ public static Distance Euclidean</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static Distance Manhattan</code></pre>
+    <pre><code class="lang-csharp hljs">public static Distance Manhattan</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -216,7 +214,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly Distance.Types Type</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly Distance.Types Type</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -240,7 +239,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Calculate_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Calculate(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L174">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L158">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_Calculate_" data-uid="SadRogue.Primitives.Distance.Calculate*"></a>
   <h4 id="SadRogue_Primitives_Distance_Calculate_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Distance.Calculate(SadRogue.Primitives.Point)">Calculate(Point)</h4>
@@ -250,7 +249,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public double Calculate(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public double Calculate(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -280,7 +280,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The distance between two locations withe the given delta-change values.</p>
 </td>
       </tr>
@@ -291,7 +291,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Calculate_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Calculate(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L150">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L131">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_Calculate_" data-uid="SadRogue.Primitives.Distance.Calculate*"></a>
   <h4 id="SadRogue_Primitives_Distance_Calculate_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Distance.Calculate(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Calculate(Point, Point)</h4>
@@ -300,7 +300,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public double Calculate(Point start, Point end)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public double Calculate(Point start, Point end)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,7 +337,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The distance between the two points.</p>
 </td>
       </tr>
@@ -347,7 +348,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Calculate_System_Double_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Calculate(System.Double%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L182">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L168">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_Calculate_" data-uid="SadRogue.Primitives.Distance.Calculate*"></a>
   <h4 id="SadRogue_Primitives_Distance_Calculate_System_Double_System_Double_" data-uid="SadRogue.Primitives.Distance.Calculate(System.Double,System.Double)">Calculate(Double, Double)</h4>
@@ -356,7 +357,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public double Calculate(double dx, double dy)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public double Calculate(double dx, double dy)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -369,13 +371,13 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">dx</span></td>
         <td><p>The delta-x between the two locations.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">dy</span></td>
         <td><p>The delta-y between the two locations.</p>
 </td>
@@ -392,7 +394,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The distance between two locations with the given delta-change values.</p>
 </td>
       </tr>
@@ -403,7 +405,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Calculate_System_Double_System_Double_System_Double_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Calculate(System.Double%2CSystem.Double%2CSystem.Double%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L160">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L143">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_Calculate_" data-uid="SadRogue.Primitives.Distance.Calculate*"></a>
   <h4 id="SadRogue_Primitives_Distance_Calculate_System_Double_System_Double_System_Double_System_Double_" data-uid="SadRogue.Primitives.Distance.Calculate(System.Double,System.Double,System.Double,System.Double)">Calculate(Double, Double, Double, Double)</h4>
@@ -412,7 +414,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public double Calculate(double startX, double startY, double endX, double endY)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public double Calculate(double startX, double startY, double endX, double endY)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -425,25 +428,25 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">startX</span></td>
         <td><p>X-Coordinate of the starting point.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">startY</span></td>
         <td><p>Y-Coordinate of the starting point.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">endX</span></td>
         <td><p>X-Coordinate of the ending point.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">endY</span></td>
         <td><p>Y-Coordinate of the ending point.</p>
 </td>
@@ -460,7 +463,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The distance between the two points.</p>
 </td>
       </tr>
@@ -471,7 +474,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Equals_SadRogue_Primitives_Distance_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Equals(SadRogue.Primitives.Distance)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L210">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L189">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_Equals_" data-uid="SadRogue.Primitives.Distance.Equals*"></a>
   <h4 id="SadRogue_Primitives_Distance_Equals_SadRogue_Primitives_Distance_" data-uid="SadRogue.Primitives.Distance.Equals(SadRogue.Primitives.Distance)">Equals(Distance)</h4>
@@ -480,7 +483,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(Distance other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(Distance other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -510,7 +514,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two distance calculation methods are the same, false if not.</p>
 </td>
       </tr>
@@ -521,7 +525,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L219">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L199">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_Equals_" data-uid="SadRogue.Primitives.Distance.Equals*"></a>
   <h4 id="SadRogue_Primitives_Distance_Equals_System_Object_" data-uid="SadRogue.Primitives.Distance.Equals(System.Object)">Equals(Object)</h4>
@@ -530,7 +534,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -543,7 +548,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td><p>The object to compare the current Distance to.</p>
 </td>
@@ -560,20 +565,20 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a Distance, and the two distance calculations are equal, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L225">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L206">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_GetHashCode_" data-uid="SadRogue.Primitives.Distance.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_Distance_GetHashCode" data-uid="SadRogue.Primitives.Distance.GetHashCode">GetHashCode()</h4>
@@ -582,7 +587,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -594,28 +600,29 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_ToDistance_SadRogue_Primitives_Distance_Types_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.ToDistance(SadRogue.Primitives.Distance.Types)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_Matches_SadRogue_Primitives_Distance_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.Matches(SadRogue.Primitives.Distance)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L126">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L214">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Distance_ToDistance_" data-uid="SadRogue.Primitives.Distance.ToDistance*"></a>
-  <h4 id="SadRogue_Primitives_Distance_ToDistance_SadRogue_Primitives_Distance_Types_" data-uid="SadRogue.Primitives.Distance.ToDistance(SadRogue.Primitives.Distance.Types)">ToDistance(Distance.Types)</h4>
-  <div class="markdown level1 summary"><p>Gets the Distance class instance representing the distance type specified.</p>
+  <a id="SadRogue_Primitives_Distance_Matches_" data-uid="SadRogue.Primitives.Distance.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Distance_Matches_SadRogue_Primitives_Distance_" data-uid="SadRogue.Primitives.Distance.Matches(SadRogue.Primitives.Distance)">Matches(Distance)</h4>
+  <div class="markdown level1 summary"><p>True if the given Distance has the same Type the current one.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Distance ToDistance(Distance.Types distanceType)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(Distance other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -628,9 +635,9 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Distance.Types.html">Distance.Types</a></td>
-        <td><span class="parametername">distanceType</span></td>
-        <td><p>The enum value for the distance calculation method.</p>
+        <td><a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Distance to compare.</p>
 </td>
       </tr>
     </tbody>
@@ -645,8 +652,8 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a></td>
-        <td><p>The Distance class representing the given distance calculation.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two distance calculation methods are the same, false if not.</p>
 </td>
       </tr>
     </tbody>
@@ -656,7 +663,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L249">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L241">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_ToString_" data-uid="SadRogue.Primitives.Distance.ToString*"></a>
   <h4 id="SadRogue_Primitives_Distance_ToString" data-uid="SadRogue.Primitives.Distance.ToString">ToString()</h4>
@@ -665,7 +672,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override string ToString()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -677,14 +685,14 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
         <td><p>A string representation of the distance method represented.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="operators">Operators
   </h3>
   <span class="small pull-right mobile-hide">
@@ -692,7 +700,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_op_Equality_SadRogue_Primitives_Distance_SadRogue_Primitives_Distance_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.op_Equality(SadRogue.Primitives.Distance%2CSadRogue.Primitives.Distance)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L233">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L223">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_op_Equality_" data-uid="SadRogue.Primitives.Distance.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Distance_op_Equality_SadRogue_Primitives_Distance_SadRogue_Primitives_Distance_" data-uid="SadRogue.Primitives.Distance.op_Equality(SadRogue.Primitives.Distance,SadRogue.Primitives.Distance)">Equality(Distance, Distance)</h4>
@@ -701,7 +709,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Distance lhs, Distance rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Distance lhs, Distance rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -735,7 +744,7 @@ Distance types in switch statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two distance calculations are equal, false if not.</p>
 </td>
       </tr>
@@ -746,7 +755,7 @@ Distance types in switch statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_AdjacencyRule.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.AdjacencyRule%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L105">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L95">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_op_Implicit_" data-uid="SadRogue.Primitives.Distance.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_AdjacencyRule" data-uid="SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.AdjacencyRule">Implicit(Distance to AdjacencyRule)</h4>
@@ -755,7 +764,8 @@ Distance types in switch statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator AdjacencyRule(Distance distance)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator AdjacencyRule(Distance distance)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -795,10 +805,59 @@ distance calculation casted will be returned.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_Distance_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Distance.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L109">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Distance_op_Implicit_" data-uid="SadRogue.Primitives.Distance.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_Distance_Types" data-uid="SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Distance.Types">Implicit(Distance to Distance.Types)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts a Distance to its corresponding <a class="xref" href="SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_Type">Type</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Distance.Types(Distance distance)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a></td>
+        <td><span class="parametername">distance</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Distance.Types.html">Distance.Types</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_Radius.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Radius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L79">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L78">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_op_Implicit_" data-uid="SadRogue.Primitives.Distance.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_Radius" data-uid="SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Radius">Implicit(Distance to Radius)</h4>
@@ -807,7 +866,8 @@ distance calculation casted will be returned.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator Radius(Distance distance)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Radius(Distance distance)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -847,10 +907,59 @@ casted will be returned.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance_Types__SadRogue_Primitives_Distance.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance.Types)~SadRogue.Primitives.Distance%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L116">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Distance_op_Implicit_" data-uid="SadRogue.Primitives.Distance.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance_Types__SadRogue_Primitives_Distance" data-uid="SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance.Types)~SadRogue.Primitives.Distance">Implicit(Distance.Types to Distance)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts an <a class="xref" href="SadRogue.Primitives.Distance.Types.html">Distance.Types</a> enum value to its corresponding Distance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Distance(Distance.Types type)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Distance.Types.html">Distance.Types</a></td>
+        <td><span class="parametername">type</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Distance.html">Distance</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance_op_Inequality_SadRogue_Primitives_Distance_SadRogue_Primitives_Distance_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance.op_Inequality(SadRogue.Primitives.Distance%2CSadRogue.Primitives.Distance)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L243">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L234">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Distance_op_Inequality_" data-uid="SadRogue.Primitives.Distance.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Distance_op_Inequality_SadRogue_Primitives_Distance_SadRogue_Primitives_Distance_" data-uid="SadRogue.Primitives.Distance.op_Inequality(SadRogue.Primitives.Distance,SadRogue.Primitives.Distance)">Inequality(Distance, Distance)</h4>
@@ -859,7 +968,8 @@ casted will be returned.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Distance lhs, Distance rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Distance lhs, Distance rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -893,7 +1003,7 @@ casted will be returned.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the types are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -901,7 +1011,10 @@ casted will be returned.</p>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -914,7 +1027,7 @@ casted will be returned.</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Distance.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Distance%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L16" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Distance.cs/#L19" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Gradient.html
+++ b/docs/api/SadRogue.Primitives.Gradient.html
@@ -78,44 +78,45 @@
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">Gradient</span></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</div>
-    <div><span class="xref">System.Collections.IEnumerable</span></div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetHashCode()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Gradient_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable, IMatchable&lt;Gradient&gt;</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -124,7 +125,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient__ctor_SadRogue_Primitives_Color_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.%23ctor(SadRogue.Primitives.Color%2CSadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L84">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L124">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient__ctor_" data-uid="SadRogue.Primitives.Gradient.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Gradient__ctor_SadRogue_Primitives_Color_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.Gradient.#ctor(SadRogue.Primitives.Color,SadRogue.Primitives.Color)">Gradient(Color, Color)</h4>
@@ -164,7 +165,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient__ctor_SadRogue_Primitives_Color___.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.%23ctor(SadRogue.Primitives.Color%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L93">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L132">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient__ctor_" data-uid="SadRogue.Primitives.Gradient.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Gradient__ctor_SadRogue_Primitives_Color___" data-uid="SadRogue.Primitives.Gradient.#ctor(SadRogue.Primitives.Color[])">Gradient(Color[])</h4>
@@ -198,7 +199,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Color__System_Collections_Generic_IEnumerable_System_Single__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.%23ctor(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.Color%7D%2CSystem.Collections.Generic.IEnumerable%7BSystem.Single%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L60">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L104">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient__ctor_" data-uid="SadRogue.Primitives.Gradient.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Gradient__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Color__System_Collections_Generic_IEnumerable_System_Single__" data-uid="SadRogue.Primitives.Gradient.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.Color},System.Collections.Generic.IEnumerable{System.Single})">Gradient(IEnumerable&lt;Color&gt;, IEnumerable&lt;Single&gt;)</h4>
@@ -220,38 +221,72 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</td>
         <td><span class="parametername">colors</span></td>
         <td><p>The colors with the gradient.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<span class="xref">System.Single</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a>&gt;</td>
         <td><span class="parametername">stops</span></td>
         <td><p>The gradient stops where the colors are used.</p>
 </td>
       </tr>
     </tbody>
   </table>
-  <h3 id="properties">Properties
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GradientStop__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.%23ctor(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.GradientStop%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L162">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Gradient__ctor_" data-uid="SadRogue.Primitives.Gradient.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_Gradient__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GradientStop__" data-uid="SadRogue.Primitives.Gradient.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GradientStop})">Gradient(IEnumerable&lt;GradientStop&gt;)</h4>
+  <div class="markdown level1 summary"><p>Creates a new color gradient with the given colors/stops.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Gradient(IEnumerable&lt;GradientStop&gt; gradientStops)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</td>
+        <td><span class="parametername">gradientStops</span></td>
+        <td><p>Stops to include in the gradient.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_Stops.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.Stops%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L53">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L97">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Gradient_Stops_" data-uid="SadRogue.Primitives.Gradient.Stops*"></a>
   <h4 id="SadRogue_Primitives_Gradient_Stops" data-uid="SadRogue.Primitives.Gradient.Stops">Stops</h4>
   <div class="markdown level1 summary"><p>The color stops that define the gradient.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public GradientStop[] Stops { get; set; }</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly GradientStop[] Stops</code></pre>
   </div>
-  <h5 class="propertyValue">Property Value</h5>
+  <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
       <tr>
@@ -273,7 +308,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L125">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L168">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient_GetEnumerator_" data-uid="SadRogue.Primitives.Gradient.GetEnumerator*"></a>
   <h4 id="SadRogue_Primitives_Gradient_GetEnumerator" data-uid="SadRogue.Primitives.Gradient.GetEnumerator">GetEnumerator()</h4>
@@ -294,7 +329,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerator</span>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</td>
         <td><p>An enumerator</p>
 </td>
       </tr>
@@ -305,7 +340,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_Lerp_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.Lerp(System.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L187">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L228">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient_Lerp_" data-uid="SadRogue.Primitives.Gradient.Lerp*"></a>
   <h4 id="SadRogue_Primitives_Gradient_Lerp_System_Single_" data-uid="SadRogue.Primitives.Gradient.Lerp(System.Single)">Lerp(Single)</h4>
@@ -327,7 +362,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">amount</span></td>
         <td><p>The lerp amount.</p>
 </td>
@@ -352,10 +387,59 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_Matches_SadRogue_Primitives_Gradient_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.Matches(SadRogue.Primitives.Gradient)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L262">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Gradient_Matches_" data-uid="SadRogue.Primitives.Gradient.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Gradient_Matches_SadRogue_Primitives_Gradient_" data-uid="SadRogue.Primitives.Gradient.Matches(SadRogue.Primitives.Gradient)">Matches(Gradient)</h4>
+  <div class="markdown level1 summary"><p>Returns true if the given gradients contain precisely the same stops.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(Gradient other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the given gradients contain precisely the same stops; false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_ToColorArray_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.ToColorArray(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L138">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L181">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient_ToColorArray_" data-uid="SadRogue.Primitives.Gradient.ToColorArray*"></a>
   <h4 id="SadRogue_Primitives_Gradient_ToColorArray_System_Int32_" data-uid="SadRogue.Primitives.Gradient.ToColorArray(System.Int32)">ToColorArray(Int32)</h4>
@@ -377,7 +461,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">count</span></td>
         <td><p>The amount of colors to produce.</p>
 </td>
@@ -407,11 +491,12 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_op_Implicit_SadRogue_Primitives_Color__SadRogue_Primitives_Gradient.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.Gradient%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L212">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L255">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient_op_Implicit_" data-uid="SadRogue.Primitives.Gradient.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Gradient_op_Implicit_SadRogue_Primitives_Color__SadRogue_Primitives_Gradient" data-uid="SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.Gradient">Implicit(Color to Gradient)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Converts a color to a gradient.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -449,53 +534,6 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
       </tr>
     </tbody>
   </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_op_Implicit_SadRogue_Primitives_Gradient__SadRogue_Primitives_Color.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.Color%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L214">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Gradient_op_Implicit_" data-uid="SadRogue.Primitives.Gradient.op_Implicit*"></a>
-  <h4 id="SadRogue_Primitives_Gradient_op_Implicit_SadRogue_Primitives_Gradient__SadRogue_Primitives_Color" data-uid="SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.Color">Implicit(Gradient to Color)</h4>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator Color(Gradient gradient)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a></td>
-        <td><span class="parametername">gradient</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
   <h3 id="eii">Explicit Interface Implementations
   </h3>
   <span class="small pull-right mobile-hide">
@@ -503,7 +541,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L131">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L174">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Gradient_System_Collections_IEnumerable_GetEnumerator_" data-uid="SadRogue.Primitives.Gradient.System#Collections#IEnumerable#GetEnumerator*"></a>
   <h4 id="SadRogue_Primitives_Gradient_System_Collections_IEnumerable_GetEnumerator" data-uid="SadRogue.Primitives.Gradient.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h4>
@@ -524,7 +562,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.IEnumerator</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></td>
         <td><p>An enumerator.</p>
 </td>
       </tr>
@@ -532,10 +570,13 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.Collections.Generic.IEnumerable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">System.Collections.Generic.IEnumerable&lt;T&gt;</a>
   </div>
   <div>
-      <span class="xref">System.Collections.IEnumerable</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">System.Collections.IEnumerable</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -548,7 +589,7 @@ public class Gradient : IEnumerable&lt;GradientStop&gt;, IEnumerable</code></pre
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Gradient.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Gradient%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L47" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L91" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.GradientStop.html
+++ b/docs/api/SadRogue.Primitives.GradientStop.html
@@ -78,29 +78,30 @@
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.ValueType.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
     </div>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_GradientStop_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct GradientStop : IEquatable&lt;GradientStop&gt;, IMatchable&lt;GradientStop&gt;</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -109,7 +110,7 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop__ctor_SadRogue_Primitives_Color_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.%23ctor(SadRogue.Primitives.Color%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L28">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L31">View Source</a>
   </span>
   <a id="SadRogue_Primitives_GradientStop__ctor_" data-uid="SadRogue.Primitives.GradientStop.#ctor*"></a>
   <h4 id="SadRogue_Primitives_GradientStop__ctor_SadRogue_Primitives_Color_System_Single_" data-uid="SadRogue.Primitives.GradientStop.#ctor(SadRogue.Primitives.Color,System.Single)">GradientStop(Color, Single)</h4>
@@ -137,7 +138,7 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">stop</span></td>
         <td><p>The position of the stop.</p>
 </td>
@@ -151,7 +152,7 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_Color.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.Color%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L16">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L19">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_GradientStop_Color" data-uid="SadRogue.Primitives.GradientStop.Color">Color</h4>
   <div class="markdown level1 summary"><p>The color.</p>
@@ -159,7 +160,8 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly Color Color</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly Color Color</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -181,15 +183,16 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_Stop.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.Stop%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L21">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L24">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_GradientStop_Stop" data-uid="SadRogue.Primitives.GradientStop.Stop">Stop</h4>
-  <div class="markdown level1 summary"><p>The color stop in the gradiant this applies to.</p>
+  <div class="markdown level1 summary"><p>The color stop in the gradient this applies to.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly float Stop</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly float Stop</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -201,7 +204,7 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -213,15 +216,17 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_Equals_SadRogue_Primitives_GradientStop_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.Equals(SadRogue.Primitives.GradientStop)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L41">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L76">View Source</a>
   </span>
   <a id="SadRogue_Primitives_GradientStop_Equals_" data-uid="SadRogue.Primitives.GradientStop.Equals*"></a>
   <h4 id="SadRogue_Primitives_GradientStop_Equals_SadRogue_Primitives_GradientStop_" data-uid="SadRogue.Primitives.GradientStop.Equals(SadRogue.Primitives.GradientStop)">Equals(GradientStop)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Compares this gradient stop to the one given.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(GradientStop g)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(GradientStop g)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -250,8 +255,9 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if this gradient stop and the specified one have the same color and stop values; false otherwise.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -260,15 +266,17 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L39">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L68">View Source</a>
   </span>
   <a id="SadRogue_Primitives_GradientStop_Equals_" data-uid="SadRogue.Primitives.GradientStop.Equals*"></a>
   <h4 id="SadRogue_Primitives_GradientStop_Equals_System_Object_" data-uid="SadRogue.Primitives.GradientStop.Equals(System.Object)">Equals(Object)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Returns true if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a gradient stop with the same color and stop value.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -281,7 +289,7 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
@@ -297,27 +305,30 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a gradient stop with the same color and stop value.</p>
+</td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L37">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L60">View Source</a>
   </span>
   <a id="SadRogue_Primitives_GradientStop_GetHashCode_" data-uid="SadRogue.Primitives.GradientStop.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_GradientStop_GetHashCode" data-uid="SadRogue.Primitives.GradientStop.GetHashCode">GetHashCode()</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Gets a hash code based upon the stop's color and stop values.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -329,13 +340,64 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
-        <td></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><p>A hash code based upon the stop's color and stop values.</p>
+</td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_Matches_SadRogue_Primitives_GradientStop_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.Matches(SadRogue.Primitives.GradientStop)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L84">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GradientStop_Matches_" data-uid="SadRogue.Primitives.GradientStop.Matches*"></a>
+  <h4 id="SadRogue_Primitives_GradientStop_Matches_SadRogue_Primitives_GradientStop_" data-uid="SadRogue.Primitives.GradientStop.Matches(SadRogue.Primitives.GradientStop)">Matches(GradientStop)</h4>
+  <div class="markdown level1 summary"><p>Compares this gradient stop to the one given.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(GradientStop other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if this gradient stop and the specified one have the same color and stop values; false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="operators">Operators
   </h3>
   <span class="small pull-right mobile-hide">
@@ -343,15 +405,17 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_op_Equality_SadRogue_Primitives_GradientStop_SadRogue_Primitives_GradientStop_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.op_Equality(SadRogue.Primitives.GradientStop%2CSadRogue.Primitives.GradientStop)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L34">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L43">View Source</a>
   </span>
   <a id="SadRogue_Primitives_GradientStop_op_Equality_" data-uid="SadRogue.Primitives.GradientStop.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_GradientStop_op_Equality_SadRogue_Primitives_GradientStop_SadRogue_Primitives_GradientStop_" data-uid="SadRogue.Primitives.GradientStop.op_Equality(SadRogue.Primitives.GradientStop,SadRogue.Primitives.GradientStop)">Equality(GradientStop, GradientStop)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Compares two gradient stops based on their color and stop value.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(GradientStop lhs, GradientStop rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(GradientStop lhs, GradientStop rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,8 +449,9 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the gradients have the same color and stop; false otherwise.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -395,15 +460,17 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop_op_Inequality_SadRogue_Primitives_GradientStop_SadRogue_Primitives_GradientStop_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop.op_Inequality(SadRogue.Primitives.GradientStop%2CSadRogue.Primitives.GradientStop)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L35">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L53">View Source</a>
   </span>
   <a id="SadRogue_Primitives_GradientStop_op_Inequality_" data-uid="SadRogue.Primitives.GradientStop.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_GradientStop_op_Inequality_SadRogue_Primitives_GradientStop_SadRogue_Primitives_GradientStop_" data-uid="SadRogue.Primitives.GradientStop.op_Inequality(SadRogue.Primitives.GradientStop,SadRogue.Primitives.GradientStop)">Inequality(GradientStop, GradientStop)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Compares two gradient stops based on their color and stop value.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(GradientStop lhs, GradientStop rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(GradientStop lhs, GradientStop rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -437,14 +504,18 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the gradients have different color or stop values, false otherwise.</p>
+</td>
       </tr>
     </tbody>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -457,7 +528,7 @@ public struct GradientStop : IEquatable&lt;GradientStop&gt;</code></pre>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GradientStop.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GradientStop%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L10" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Gradient.cs/#L13" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.GridViews.ArrayView-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.ArrayView-1.html
@@ -1,0 +1,776 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class ArrayView&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class ArrayView&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.ArrayView`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_ArrayView_1" data-uid="SadRogue.Primitives.GridViews.ArrayView`1" class="text-break">Class ArrayView&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Implementation of <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> that uses a 1D array to store data.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">ArrayView&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.icloneable">ICloneable</a></div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView</a>&lt;T&gt;&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count">SettableGridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public sealed class ArrayView&lt;T&gt; : SettableGridViewBase&lt;T&gt;, ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;, ICloneable, IMatchable&lt;ArrayView&lt;T&gt;&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type of value being stored.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView_1_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>An <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> can be implicitly converted to its underlying 1D array,
+which allows exposing that array to code that works with 1D arrays.  Modifications in the array
+appear in the map view as well.</p>
+<p>If you need a 2D array instead of 1D, then you should use <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D&lt;T&gt;</a> instead.</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1__ctor__0___System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.%23ctor(%600%5B%5D%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L35">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1__ctor__0___System_Int32_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.#ctor(`0[],System.Int32)">ArrayView(T[], Int32)</h4>
+  <div class="markdown level1 summary"><p>Constructor.  Takes an existing 1D array to use as the underlying array, and
+the width of the 2D grid represented by that array.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ArrayView(T[] existingArray, int width)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[]</td>
+        <td><span class="parametername">existingArray</span></td>
+        <td><p>Existing 1D array to use as the underlying array.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">width</span></td>
+        <td><p>The width of the 2D grid represented by <code data-dev-comment-type="paramref" class="paramref">existingArray</code>.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1__ctor_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.%23ctor(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L25">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1__ctor_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.#ctor(System.Int32,System.Int32)">ArrayView(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes width and height of array to create.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ArrayView(int width, int height)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">width</span></td>
+        <td><p>Width of array.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">height</span></td>
+        <td><p>Height of array.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L69">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_Height_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_Height" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L75">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_Item_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView_1_Item_SadRogue_Primitives_Point__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L72">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_Width_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_Width" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_Clear.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.Clear%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L99">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_Clear_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Clear*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_Clear" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Clear">Clear()</h4>
+  <div class="markdown level1 summary"><p>Sets each element in the ArrayView to the default for type T.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void Clear()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_Clone.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.Clone%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L50">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_Clone_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Clone*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_Clone" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Clone">Clone()</h4>
+  <div class="markdown level1 summary"><p>Performs deep copy of array view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public object Clone()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
+        <td><p>The cloned ArrayView.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_Matches_SadRogue_Primitives_GridViews_ArrayView__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.Matches(SadRogue.Primitives.GridViews.ArrayView%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L66">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_Matches_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Matches*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_Matches_SadRogue_Primitives_GridViews_ArrayView__0__" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.Matches(SadRogue.Primitives.GridViews.ArrayView{`0})">Matches(ArrayView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Compares the current ArrayView to the one given.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(ArrayView&lt;T&gt; other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView</a>&lt;T&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the given ArrayView&lt;T&gt; with a reference to the same underlying array, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_ToArray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.ToArray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L94">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_ToArray_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToArray*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_ToArray" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToArray">ToArray()</h4>
+  <div class="markdown level1 summary"><p>Converts to 1D array, without copying the values.  Typically using this method is unnecessary
+and you can use the implicit conversion defined for this type instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T[] ToArray()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[]</td>
+        <td><p>The underlying ArrayView data as a 1D array.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L105">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_ToString" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.ToString(System.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L115">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToString(System.Func{`0,System.String})">ToString(Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using <code data-dev-comment-type="paramref" class="paramref">elementStringifier</code>
+to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each value.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Int32_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.ToString(System.Int32%2CSystem.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L135">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Int32_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.ToString(System.Int32,System.Func{`0,System.String})">ToString(Int32, Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values using the given parameters.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each value to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Int32_System_Func__0_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the value's string representation.</p>
+</div>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView__0____0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601.op_Implicit(SadRogue.Primitives.GridViews.ArrayView%7B%600%7D)~%600%5B%5D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L86">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView_1_op_Implicit_" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView__0____0__" data-uid="SadRogue.Primitives.GridViews.ArrayView`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView{`0})~`0[]">Implicit(ArrayView&lt;T&gt; to T[])</h4>
+  <div class="markdown level1 summary"><p>Allows implicit conversion to 1D array.  Does not copy the underlying values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator T[](ArrayView&lt;T&gt; arrayView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView</a>&lt;T&gt;</td>
+        <td><span class="parametername">arrayView</span></td>
+        <td><p>ArrayView to convert.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[]</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.icloneable">System.ICloneable</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView.cs/#L16" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.ArrayView2D-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.ArrayView2D-1.html
@@ -1,0 +1,866 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class ArrayView2D&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class ArrayView2D&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_ArrayView2D_1" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1" class="text-break">Class ArrayView2D&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Implementation of <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> that uses a 2D array to store data.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">ArrayView2D&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.icloneable">ICloneable</a></div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D</a>&lt;T&gt;&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count">SettableGridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView2D_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public sealed class ArrayView2D&lt;T&gt; : SettableGridViewBase&lt;T&gt;, ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;, ICloneable, IMatchable&lt;ArrayView2D&lt;T&gt;&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type of value being stored.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView2D_1_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>An <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D&lt;T&gt;</a> can be implicitly converted to its underlying 2D array,
+which allows exposing that array to code that works with 2D arrays.  Modifications in the array
+appear in the map view as well.</p>
+<p>If you need a 1D array instead of 2D, then you should use <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> instead.</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1__ctor__0_0__0___.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.%23ctor(%600%5B0%3A%2C0%3A%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L33">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1__ctor_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1__ctor__0_0__0___" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor(`0[0:,0:])">ArrayView2D(T[,])</h4>
+  <div class="markdown level1 summary"><p>Constructor.  Takes an existing 2D array to use as the underlying data structure.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ArrayView2D(T[, ] existingArray)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[,]</td>
+        <td><span class="parametername">existingArray</span></td>
+        <td><p>An existing 2D array to use as the data structure.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1__ctor_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.%23ctor(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L25">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1__ctor_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1__ctor_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor(System.Int32,System.Int32)">ArrayView2D(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes width and height of array to create.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ArrayView2D(int width, int height)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">width</span></td>
+        <td><p>Width of array.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">height</span></td>
+        <td><p>Height of array.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L58">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_Height_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Height" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L64">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_Item_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Item_SadRogue_Primitives_Point__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L61">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_Width_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Width" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_Clear.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.Clear%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L106">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_Clear_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Clear*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Clear" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Clear">Clear()</h4>
+  <div class="markdown level1 summary"><p>Sets each element in the ArrayView to the default for type T.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void Clear()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_Clone.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.Clone%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L39">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_Clone_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Clone*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Clone" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Clone">Clone()</h4>
+  <div class="markdown level1 summary"><p>Performs deep copy of array view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public object Clone()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
+        <td><p>The cloned ArrayView2D.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_FromMultidimensionalArray__0_0__0___.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.FromMultidimensionalArray(%600%5B0%3A%2C0%3A%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L101">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_FromMultidimensionalArray_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.FromMultidimensionalArray*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_FromMultidimensionalArray__0_0__0___" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.FromMultidimensionalArray(`0[0:,0:])">FromMultidimensionalArray(T[,])</h4>
+  <div class="markdown level1 summary"><p>Converts from 2D array, without copying the values.  Typically using this method is unnecessary and you
+can use the implicit conversion defined for this type instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static ArrayView2D&lt;T&gt; FromMultidimensionalArray(T[, ] array)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[,]</td>
+        <td><span class="parametername">array</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_Matches_SadRogue_Primitives_GridViews_ArrayView2D__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.Matches(SadRogue.Primitives.GridViews.ArrayView2D%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L55">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_Matches_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Matches*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_Matches_SadRogue_Primitives_GridViews_ArrayView2D__0__" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.Matches(SadRogue.Primitives.GridViews.ArrayView2D{`0})">Matches(ArrayView2D&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Compares the current ArrayView2D to the one given.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(ArrayView2D&lt;T&gt; other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D</a>&lt;T&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the given ArrayView2D&lt;T&gt; with a reference to the same underlying array, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_ToMultidimensionalArray.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.ToMultidimensionalArray%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L93">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToMultidimensionalArray_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToMultidimensionalArray*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToMultidimensionalArray" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToMultidimensionalArray">ToMultidimensionalArray()</h4>
+  <div class="markdown level1 summary"><p>Converts to 2D array, without copying the values.  Typically using this method is unnecessary
+and you can use the implicit conversion defined for this type instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T[, ] ToMultidimensionalArray()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[,]</td>
+        <td><p>The underlying ArrayView data as a 1D array.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L112">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.ToString(System.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L122">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToString(System.Func{`0,System.String})">ToString(Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using <code data-dev-comment-type="paramref" class="paramref">elementStringifier</code>
+to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each value.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the 2D array.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Int32_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.ToString(System.Int32%2CSystem.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L142">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Int32_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.ToString(System.Int32,System.Func{`0,System.String})">ToString(Int32, Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values using the given parameters.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each value to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Int32_System_Func__0_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the value's string representation.</p>
+</div>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit__0_0__0____SadRogue_Primitives_GridViews_ArrayView2D__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.op_Implicit(%600%5B0%3A%2C0%3A%5D)~SadRogue.Primitives.GridViews.ArrayView2D%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L85">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit__0_0__0____SadRogue_Primitives_GridViews_ArrayView2D__0_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit(`0[0:,0:])~SadRogue.Primitives.GridViews.ArrayView2D{`0}">Implicit(T[,] to ArrayView2D&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Allows implicit conversion from 2D array.  Does not copy the underlying values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator ArrayView2D&lt;T&gt;(T[, ] array)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[,]</td>
+        <td><span class="parametername">array</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView2D__0____0_0__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601.op_Implicit(SadRogue.Primitives.GridViews.ArrayView2D%7B%600%7D)~%600%5B0%3A%2C0%3A%5D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L76">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit_" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView2D__0____0_0__0__" data-uid="SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView2D{`0})~`0[0:,0:]">Implicit(ArrayView2D&lt;T&gt; to T[,])</h4>
+  <div class="markdown level1 summary"><p>Allows implicit conversion to 2D array.  Does not copy the underlying values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator T[, ](ArrayView2D&lt;T&gt; arrayView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D</a>&lt;T&gt;</td>
+        <td><span class="parametername">arrayView</span></td>
+        <td><p>The ArrayView2D to convert.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[,]</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.icloneable">System.ICloneable</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ArrayView2D_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ArrayView2D%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ArrayView2D.cs/#L16" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.Diff-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.Diff-1.html
@@ -1,0 +1,463 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class Diff&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class Diff&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.Diff`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_Diff_1" data-uid="SadRogue.Primitives.GridViews.Diff`1" class="text-break">Class Diff&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Represents a unique patch/diff of the state of a <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><span class="xref">Diff&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_Diff_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class Diff&lt;T&gt; : IEnumerable&lt;ValueChange&lt;T&gt;&gt;, IEnumerable where T : struct</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value stored in the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1__ctor.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L117">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1__ctor_" data-uid="SadRogue.Primitives.GridViews.Diff`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1__ctor" data-uid="SadRogue.Primitives.GridViews.Diff`1.#ctor">Diff()</h4>
+  <div class="markdown level1 summary"><p>Creates a new empty diff.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Diff()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_ValueChange__0___.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.%23ctor(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.GridViews.ValueChange%7B%600%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L128">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1__ctor_" data-uid="SadRogue.Primitives.GridViews.Diff`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_ValueChange__0___" data-uid="SadRogue.Primitives.GridViews.Diff`1.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.ValueChange{`0}})">Diff(IEnumerable&lt;ValueChange&lt;T&gt;&gt;)</h4>
+  <div class="markdown level1 summary"><p>Creates a diff composed of the specified changes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Diff(IEnumerable&lt;ValueChange&lt;T&gt;&gt; changes)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;&gt;</td>
+        <td><span class="parametername">changes</span></td>
+        <td><p>Changes to create a diff from.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_Changes.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.Changes%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L107">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_Changes_" data-uid="SadRogue.Primitives.GridViews.Diff`1.Changes*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_Changes" data-uid="SadRogue.Primitives.GridViews.Diff`1.Changes">Changes</h4>
+  <div class="markdown level1 summary"><p>Read-only list of changes made in this time step.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IReadOnlyList&lt;ValueChange&lt;T&gt;&gt; Changes { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1">IReadOnlyList</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_IsCompressed.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.IsCompressed%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L138">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_IsCompressed_" data-uid="SadRogue.Primitives.GridViews.Diff`1.IsCompressed*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_IsCompressed" data-uid="SadRogue.Primitives.GridViews.Diff`1.IsCompressed">IsCompressed</h4>
+  <div class="markdown level1 summary"><p>Whether or not the diff is currently known to be at the minimal possible size.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool IsCompressed { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_IsFinalized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.IsFinalized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L112">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_IsFinalized_" data-uid="SadRogue.Primitives.GridViews.Diff`1.IsFinalized*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_IsFinalized" data-uid="SadRogue.Primitives.GridViews.Diff`1.IsFinalized">IsFinalized</h4>
+  <div class="markdown level1 summary"><p>Whether or not the list of changes in this diff has been finalized, eg allows more changes to be added.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool IsFinalized { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_Add_SadRogue_Primitives_GridViews_ValueChange__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.Add(SadRogue.Primitives.GridViews.ValueChange%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L144">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_Add_" data-uid="SadRogue.Primitives.GridViews.Diff`1.Add*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_Add_SadRogue_Primitives_GridViews_ValueChange__0__" data-uid="SadRogue.Primitives.GridViews.Diff`1.Add(SadRogue.Primitives.GridViews.ValueChange{`0})">Add(ValueChange&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Adds a change to the diff.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void Add(ValueChange&lt;T&gt; change)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">change</span></td>
+        <td><p>Change to add.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_Compress.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.Compress%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L170">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_Compress_" data-uid="SadRogue.Primitives.GridViews.Diff`1.Compress*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_Compress" data-uid="SadRogue.Primitives.GridViews.Diff`1.Compress">Compress()</h4>
+  <div class="markdown level1 summary"><p>Reduces the diff to the minimum possible changes to achieve the resulting values by removing duplicate
+positions from the change list.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void Compress()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_FinalizeChanges.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.FinalizeChanges%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L161">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_FinalizeChanges_" data-uid="SadRogue.Primitives.GridViews.Diff`1.FinalizeChanges*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_FinalizeChanges" data-uid="SadRogue.Primitives.GridViews.Diff`1.FinalizeChanges">FinalizeChanges()</h4>
+  <div class="markdown level1 summary"><p>Finalizes the current diff, such that no changes are allowed to be added to it.  It can still be compressed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void FinalizeChanges()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L235">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_GetEnumerator_" data-uid="SadRogue.Primitives.GridViews.Diff`1.GetEnumerator*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_GetEnumerator" data-uid="SadRogue.Primitives.GridViews.Diff`1.GetEnumerator">GetEnumerator()</h4>
+  <div class="markdown level1 summary"><p>Returns an enumerator of the changes in the diff.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IEnumerator&lt;ValueChange&lt;T&gt;&gt; GetEnumerator()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="eii">Explicit Interface Implementations
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L241">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Diff_1_System_Collections_IEnumerable_GetEnumerator_" data-uid="SadRogue.Primitives.GridViews.Diff`1.System#Collections#IEnumerable#GetEnumerator*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Diff_1_System_Collections_IEnumerable_GetEnumerator" data-uid="SadRogue.Primitives.GridViews.Diff`1.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h4>
+  <div class="markdown level1 summary"><p>Returns an enumerator of the changes in the diff.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">IEnumerator IEnumerable.GetEnumerator()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">System.Collections.Generic.IEnumerable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">System.Collections.IEnumerable</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Diff_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Diff%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L100" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html
@@ -1,0 +1,796 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class DiffAwareGridView&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class DiffAwareGridView&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1" class="text-break">Class DiffAwareGridView&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>A grid view wrapper useful for recording diffs (change-sets) of changes to a grid view, and applying/removing
+those change-sets of values from the grid view.  Only works with grid views of value types.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">DiffAwareGridView&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count">SettableGridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class DiffAwareGridView&lt;T&gt; : SettableGridViewBase&lt;T&gt;, ISettableGridView&lt;T&gt;, IGridView&lt;T&gt; where T : struct</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value in the grid view.  Must be a value type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>Generally, this class is useful with values types/primitive types wherein values are completely replaced when
+they are modified.  It allows applying a series of change sets in forward or reverse order; and as such
+can be extremely useful for debugging or situations where you want to record intermediate states of an
+algorithm.</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Boolean_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L328">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Boolean_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Boolean)">DiffAwareGridView(ISettableGridView&lt;T&gt;, Boolean)</h4>
+  <div class="markdown level1 summary"><p>Constructs a diff-aware grid view that wraps around an existing grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public DiffAwareGridView(ISettableGridView&lt;T&gt; baseGrid, bool autoCompress = true)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>The grid view whose changes are to be recorded in diffs.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><span class="parametername">autoCompress</span></td>
+        <td><p>Whether or not to automatically compress diffs when the currently applied diff is changed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_System_Int32_System_Int32_System_Boolean_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L344">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_System_Int32_System_Int32_System_Boolean_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor(System.Int32,System.Int32,System.Boolean)">DiffAwareGridView(Int32, Int32, Boolean)</h4>
+  <div class="markdown level1 summary"><p>Constructs a diff-aware grid view, whose base grid will be a new <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public DiffAwareGridView(int width, int height, bool autoCompress = true)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">width</span></td>
+        <td><p>Width of the base grid view that will be created.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">height</span></td>
+        <td><p>Height of the base grid view that will be created.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><span class="parametername">autoCompress</span></td>
+        <td><p>Whether or not to automatically compress diffs when the currently applied diff is changed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_AutoCompress.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.AutoCompress%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L319">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_AutoCompress" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.AutoCompress">AutoCompress</h4>
+  <div class="markdown level1 summary"><p>Whether or not to automatically compress diffs when the currently applied diff is changed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool AutoCompress</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.BaseGrid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L263">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.BaseGrid*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.BaseGrid">BaseGrid</h4>
+  <div class="markdown level1 summary"><p>The grid view whose changes are being recorded in diffs.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IGridView&lt;T&gt; BaseGrid { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_CurrentDiffIndex.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.CurrentDiffIndex%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L308">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_CurrentDiffIndex_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.CurrentDiffIndex*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_CurrentDiffIndex" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.CurrentDiffIndex">CurrentDiffIndex</h4>
+  <div class="markdown level1 summary"><p>The index of the diff whose ending state is currently reflected in <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid">BaseGrid</a>. Returns -1
+if none of the diffs in the list have been applied (eg. the grid view is in the state it was in at the
+<a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>'s creation.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int CurrentDiffIndex { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_Diffs.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.Diffs%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L314">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Diffs_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Diffs*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Diffs" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Diffs">Diffs</h4>
+  <div class="markdown level1 summary"><p>All diffs recorded for the current grid view, and their changes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IReadOnlyList&lt;Diff&lt;T&gt;&gt; Diffs { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ireadonlylist-1">IReadOnlyList</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff</a>&lt;T&gt;&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L266">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Height_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Height" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L272">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <h5 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Item_SadRogue_Primitives_Point__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L269">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Width_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_Width" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiff.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.ApplyNextDiff%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L369">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiff_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiff*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiff" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiff">ApplyNextDiff()</h4>
+  <div class="markdown level1 summary"><p>Applies the next recorded diff, or throws exception if there is no future diffs recorded.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void ApplyNextDiff()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiffOrFinalize.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.ApplyNextDiffOrFinalize%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L463">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiffOrFinalize_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiffOrFinalize*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiffOrFinalize" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiffOrFinalize">ApplyNextDiffOrFinalize()</h4>
+  <div class="markdown level1 summary"><p>Convenience method that calls <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiff">ApplyNextDiff()</a> if there are existing diffs to apply, and
+<a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_FinalizeCurrentDiff">FinalizeCurrentDiff()</a> if there are no existing diffs to apply.  Returns whether or not an
+existing diff was applied.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool ApplyNextDiffOrFinalize()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if an existing diff is applied, false if a new one was created.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_ClearHistory.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.ClearHistory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L478">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_ClearHistory_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.ClearHistory*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_ClearHistory" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.ClearHistory">ClearHistory()</h4>
+  <div class="markdown level1 summary"><p>Erase recorded diffs without modifying state of grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void ClearHistory()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_FinalizeCurrentDiff.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.FinalizeCurrentDiff%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L430">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_FinalizeCurrentDiff_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.FinalizeCurrentDiff*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_FinalizeCurrentDiff" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.FinalizeCurrentDiff">FinalizeCurrentDiff()</h4>
+  <div class="markdown level1 summary"><p>Finalizes the current diff so that no more changes can be added to it; future changes will create a new
+diff.  Throws exceptions if there are diffs that are not currently applied.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void FinalizeCurrentDiff()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_RevertToPreviousDiff.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.RevertToPreviousDiff%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L396">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_RevertToPreviousDiff_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.RevertToPreviousDiff*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_RevertToPreviousDiff" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.RevertToPreviousDiff">RevertToPreviousDiff()</h4>
+  <div class="markdown level1 summary"><p>Reverts the current diff's changes, so that the grid view will be in the state it was in at the end
+of the previous diff.  Throws exception if no diffs are applied.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void RevertToPreviousDiff()</code></pre>
+  </div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetBaseline_SadRogue_Primitives_GridViews_IGridView__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.SetBaseline(SadRogue.Primitives.GridViews.IGridView%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L353">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetBaseline_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetBaseline*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetBaseline_SadRogue_Primitives_GridViews_IGridView__0__" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetBaseline(SadRogue.Primitives.GridViews.IGridView{`0})">SetBaseline(IGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Sets the baseline values (eg. values before any diffs are recorded) to the values from the given grid view.
+Only valid to do before any diffs are recorded.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void SetBaseline(IGridView&lt;T&gt; baseline)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">baseline</span></td>
+        <td><p>Baseline values to use.  Must have same width/height as <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid">BaseGrid</a>.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.SetHistory(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.GridViews.Diff%7B%600%7D%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L495">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.Diff{`0}})">SetHistory(IEnumerable&lt;Diff&lt;T&gt;&gt;)</h4>
+  <div class="markdown level1 summary"><p>Overwrite any history present and replace it with the history given.  This does not modify the underlying
+grid view; the history must be valid with respect to its current state.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void SetHistory(IEnumerable&lt;Diff&lt;T&gt;&gt; history)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff</a>&lt;T&gt;&gt;</td>
+        <td><span class="parametername">history</span></td>
+        <td><p>The history to apply.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0____remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Generally, you will not call this function, however it can be useful for serialization and copying
+histories between objects.  Assumes the grid view is in a state that reflects all of the diffs in the
+history being applied.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601.SetHistory(System.Collections.Generic.IEnumerable%7BSadRogue.Primitives.GridViews.Diff%7B%600%7D%7D%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L512">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___System_Int32_" data-uid="SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.Diff{`0}},System.Int32)">SetHistory(IEnumerable&lt;Diff&lt;T&gt;&gt;, Int32)</h4>
+  <div class="markdown level1 summary"><p>Overwrite any history present and replace it with the history given.  This does not modify the underlying
+grid view; the history must be valid with respect to its current state.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void SetHistory(IEnumerable&lt;Diff&lt;T&gt;&gt; history, int currentIndex)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff</a>&lt;T&gt;&gt;</td>
+        <td><span class="parametername">history</span></td>
+        <td><p>The history to apply.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">currentIndex</span></td>
+        <td><p>The index of the given history that is applied to the <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid">BaseGrid</a>.
+Set to the length of the list - 1 if all diffs have been applied, or -1 if none of them have.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Generally, you will not call this function, however it can be useful for serialization and copying
+histories between objects.</p>
+</div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_DiffAwareGridView_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.DiffAwareGridView%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L255" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.GridViewBase-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.GridViewBase-1.html
@@ -1,0 +1,463 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class GridViewBase&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class GridViewBase&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_GridViewBase_1" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1" class="text-break">Class GridViewBase&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>A convenient base class to inherit from when implementing <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> that minimizes
+the number of items you must implement by implementing indexers in terms of a single indexer taking a Point.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><span class="xref">GridViewBase&lt;T&gt;</span></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html">LambdaGridView&lt;T&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.UnboundedViewport-1.html">UnboundedViewport&lt;T&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_GridViewBase_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract class GridViewBase&lt;T&gt; : IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1_Count.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L18">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewBase_1_Count_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Count*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewBase_1_Count" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Count">Count</h4>
+  <div class="markdown level1 summary"><p>Number of tiles in the grid; equal to <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Width">Width</a> * <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Height">Height</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Count { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L10">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewBase_1_Height_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewBase_1_Height" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L15">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, returns the &quot;value&quot; associated with that location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract T this[Point pos] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to retrieve the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L24">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an 1-dimensional index, returns the value associated with the corresponding position
+in the map view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[int index1D] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">index1D</span></td>
+        <td><p>1D index of location to retrieve the &quot;value&quot; for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Typically, this may be implemented in terms of <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a> by using
+<a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_">FromIndex(Int32, Int32)</a> to calculate the 2D position represented by that
+1D index, and passing that position to the <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a> indexer to determine
+the value associated with the position.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601.Item(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L21">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Item(System.Int32,System.Int32)">Item[Int32, Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an X and Y value, returns the &quot;value&quot; associated with that location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[int x, int y] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">x</span></td>
+        <td><p>X-value of location.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">y</span></td>
+        <td><p>Y-value of location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with that location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Typically, this can be implemented via <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a>.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L12">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewBase_1_Width_" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewBase_1_Width" data-uid="SadRogue.Primitives.GridViews.GridViewBase`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewBase_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewBase%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/GridViewBase.cs/#L7" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.GridViewExtensions.html
+++ b/docs/api/SadRogue.Primitives.GridViews.GridViewExtensions.html
@@ -1,0 +1,824 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class GridViewExtensions
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class GridViewExtensions
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_GridViewExtensions" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions" class="text-break">Class GridViewExtensions
+  </h1>
+  <div class="markdown level0 summary"><p>Extensions for <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> implementations that provide basic utility functions
+for them.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><span class="xref">GridViewExtensions</span></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_GridViewExtensions_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static class GridViewExtensions</code></pre>
+  </div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay%60%601(SadRogue.Primitives.GridViews.ISettableGridView%7B%60%600%7D%2CSadRogue.Primitives.GridViews.IGridView%7B%60%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L22">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},SadRogue.Primitives.GridViews.IGridView{``0})">ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Sets all the values of the current grid view to be equal to the corresponding values from
+the grid view you pass in.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static void ApplyOverlay&lt;T&gt;(this ISettableGridView&lt;T&gt; self, IGridView&lt;T&gt; overlay)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">overlay</span></td>
+        <td><p>The data apply to the view. Must have identical dimensions to the current view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay%60%601(SadRogue.Primitives.GridViews.ISettableGridView%7B%60%600%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%60%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L41">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},System.Func{SadRogue.Primitives.Point,``0})">ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Sets the values for each location of the current grid view to be equal to the value returned from the given
+function when given that position.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static void ApplyOverlay&lt;T&gt;(this ISettableGridView&lt;T&gt; self, Func&lt;Point, T&gt; valueFunc)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueFunc</span></td>
+        <td><p>Function returning data for each location in the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.Bounds%60%601(SadRogue.Primitives.GridViews.IGridView%7B%60%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L50">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_Bounds_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Bounds*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Bounds``1(SadRogue.Primitives.GridViews.IGridView{``0})">Bounds&lt;T&gt;(IGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Gets a rectangle representing the bounds of the current grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static Rectangle Bounds&lt;T&gt;(this IGridView&lt;T&gt; gridView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><p>A rectangle representing the grid view's bounds.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.Contains%60%601(SadRogue.Primitives.GridViews.IGridView%7B%60%600%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L71">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_Contains_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Contains*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Contains``1(SadRogue.Primitives.GridViews.IGridView{``0},SadRogue.Primitives.Point)">Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</h4>
+  <div class="markdown level1 summary"><p>Returns whether or not the given position is contained within the current grid view or not.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool Contains&lt;T&gt;(this IGridView&lt;T&gt; gridView, Point position)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>The position to check.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the given position is contained within this grid view, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.Contains%60%601(SadRogue.Primitives.GridViews.IGridView%7B%60%600%7D%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L61">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_Contains_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Contains*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Contains``1(SadRogue.Primitives.GridViews.IGridView{``0},System.Int32,System.Int32)">Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns whether or not the given position is contained within the current grid view or not.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool Contains&lt;T&gt;(this IGridView&lt;T&gt; gridView, int x, int y)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">x</span></td>
+        <td><p>X-value of the position to check.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">y</span></td>
+        <td><p>Y-value of the position to check.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the given position is contained within this grid view, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString%60%601(SadRogue.Primitives.GridViews.IGridView%7B%60%600%7D%2CSystem.Int32%2CSystem.String%2CSystem.String%2CSystem.Func%7B%60%600%2CSystem.String%7D%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L143">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString``1(SadRogue.Primitives.GridViews.IGridView{``0},System.Int32,System.String,System.String,System.Func{``0,System.String},System.String,System.String,System.String,System.String)">ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</h4>
+  <div class="markdown level1 summary"><p>Allows stringifying the contents of a grid view. Takes characters to surround the grid view representation,
+and each row, the method used to get the string representation of each element (defaulting to the ToString
+function of type T), and separation characters for each element and row. Takes the size of the field to
+give each element, characters to surround the GridView printout, and each row, the method used to get the
+string representation of each element (defaulting to the ToString function of type T), and separation
+characters for each element and row.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static string ExtendToString&lt;T&gt;(this IGridView&lt;T&gt; gridView, int fieldSize, string begin = &quot;&quot;, string beginRow = &quot;&quot;, Func&lt;T, string&gt; elementStringifier = null, string rowSeparator = &quot;\n&quot;, string elementSeparator = &quot; &quot;, string endRow = &quot;&quot;, string end = &quot;&quot;)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The amount of space each element should take up in characters. A positive number aligns
+the text to the right of the space, while a negative number aligns the text to the left.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">begin</span></td>
+        <td><p>Character(s) that should precede the IGridView printout.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">beginRow</span></td>
+        <td><p>Character(s) that should precede each row.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to get the string representation of each value. Null uses the ToString
+function of type T.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">rowSeparator</span></td>
+        <td><p>Character(s) to separate each row from the next.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">elementSeparator</span></td>
+        <td><p>Character(s) to separate each element from the next.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">endRow</span></td>
+        <td><p>Character(s) that should follow each row.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">end</span></td>
+        <td><p>Character(s) that should follow the IGridView printout.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString%60%601(SadRogue.Primitives.GridViews.IGridView%7B%60%600%7D%2CSystem.String%2CSystem.String%2CSystem.Func%7B%60%600%2CSystem.String%7D%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L92">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString``1(SadRogue.Primitives.GridViews.IGridView{``0},System.String,System.String,System.Func{``0,System.String},System.String,System.String,System.String,System.String)">ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</h4>
+  <div class="markdown level1 summary"><p>Allows stringifying the contents of a grid view. Takes characters to surround the grid view printout, and
+each row, the method used to get the string representation of each element (defaulting to the ToString
+function of type T), and separation characters for each element and row.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static string ExtendToString&lt;T&gt;(this IGridView&lt;T&gt; gridView, string begin = &quot;&quot;, string beginRow = &quot;&quot;, Func&lt;T, string&gt; elementStringifier = null, string rowSeparator = &quot;\n&quot;, string elementSeparator = &quot; &quot;, string endRow = &quot;&quot;, string end = &quot;&quot;)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">begin</span></td>
+        <td><p>Character(s) that should precede the IGridView printout.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">beginRow</span></td>
+        <td><p>Character(s) that should precede each row.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to get the string representation of each value. null uses the ToString
+function of type T.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">rowSeparator</span></td>
+        <td><p>Character(s) to separate each row from the next.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">elementSeparator</span></td>
+        <td><p>Character(s) to separate each element from the next.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">endRow</span></td>
+        <td><p>Character(s) that should follow each row.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><span class="parametername">end</span></td>
+        <td><p>Character(s) that should follow the IGridView printout.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the values in the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.Fill%60%601(SadRogue.Primitives.GridViews.ISettableGridView%7B%60%600%7D%2C%60%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L175">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_Fill_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Fill*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Fill``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},``0)">Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</h4>
+  <div class="markdown level1 summary"><p>Sets each location in the grid view to the value specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static void Fill&lt;T&gt;(this ISettableGridView&lt;T&gt; self, T value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>Value to fill the grid view with.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions.Positions%60%601(SadRogue.Primitives.GridViews.IGridView%7B%60%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L184">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_GridViewExtensions_Positions_" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Positions*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__" data-uid="SadRogue.Primitives.GridViews.GridViewExtensions.Positions``1(SadRogue.Primitives.GridViews.IGridView{``0})">Positions&lt;T&gt;(IGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Iterates through each position in the grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static IEnumerable&lt;Point&gt; Positions&lt;T&gt;(this IGridView&lt;T&gt; gridView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>All positions in the IGridView.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_GridViewExtensions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.GridViewExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.IGridView-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.IGridView-1.html
@@ -1,0 +1,446 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Interface IGridView&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Interface IGridView&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.IGridView`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_IGridView_1" data-uid="SadRogue.Primitives.GridViews.IGridView`1" class="text-break">Interface IGridView&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate on a grid of some sort.  For a concrete implementation to subclass for custom
+implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_IGridView_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public interface IGridView&lt;out T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type of value being returned by the indexer functions.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_IGridView_1_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>Many algorithms that operate on a grid need only some very basic information about each location in the grid
+to function.  For example, a basic grid-based pathfinding algorithm might only need to know whether each
+location can be traversed or not, which can be represented by a single boolean value per location.  A renderer
+might want to know simple rendering information for each location, which might be wrapped in a class or
+structure.</p>
+<p>One option for creating these algorithms would be to take as input arrays of the type they need.  For example,
+the pathing algorithm might take an array of boolean values as input.  However, this can be quite inflexible.
+The values that algorithms need to function might be determined based on a much more complex structure than a
+simple array of the precise type it needs, depending on use case.  Taking an array as input in these cases
+forces a user to either adapt their data structure to the one that the algorithm uses, or maintain multiple
+&quot;copies&quot; of their data in the format that the algorithms need.</p>
+<p><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> is designed to act as a much more flexible input/output format for algorithms
+like this that operate on a grid.  The interface simply defines properties for width and height, and some
+basic abstract indexers that allow accessing the &quot;object&quot; at each location.  In the examples from above,
+the basic pathfinding algorithm might take as input an IGridView&lt;bool&gt;, whereas the renderer might take
+IGridView&lt;RenderingInfo&gt;.  This allows the algorithms to operate on the minimal data that they need
+to function, but allows a user to define where that data comes from.  For common cases, concrete implementations
+are provided that make the interface easier to use; for example, <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the
+interface such that the data comes from an array, and <a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html">LambdaGridView&lt;T&gt;</a> defines the interface
+such that an arbitrary callback is used to retrieve the data.</p>
+</div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1_Count.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L48">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_IGridView_1_Count_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Count*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_IGridView_1_Count" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Count">Count</h4>
+  <div class="markdown level1 summary"><p>Number of tiles in the grid; equal to <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Width">Width</a> * <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Height">Height</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">int Count { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L38">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_IGridView_1_Height_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_IGridView_1_Height" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L66">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_IGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, returns the &quot;value&quot; associated with that location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">T this[Point pos] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to retrieve the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L80">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_IGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an 1-dimensional index, returns the value associated with the corresponding position
+in the map view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">T this[int index1D] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">index1D</span></td>
+        <td><p>1D index of location to retrieve the &quot;value&quot; for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Typically, this may be implemented in terms of <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a> by using
+<a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_">FromIndex(Int32, Int32)</a> to calculate the 2D position represented by that
+1D index, and passing that position to the <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a> indexer to determine
+the value associated with the position.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601.Item(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L59">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_IGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Item(System.Int32,System.Int32)">Item[Int32, Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an X and Y value, returns the &quot;value&quot; associated with that location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">T this[int x, int y] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">x</span></td>
+        <td><p>X-value of location.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">y</span></td>
+        <td><p>Y-value of location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with that location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Typically, this can be implemented via <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a>.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L43">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_IGridView_1_Width_" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_IGridView_1_Width" data-uid="SadRogue.Primitives.GridViews.IGridView`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_IGridView_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.IGridView%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/IGridView.cs/#L33" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.ISettableGridView-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.ISettableGridView-1.html
@@ -1,0 +1,360 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Interface ISettableGridView&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Interface ISettableGridView&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_ISettableGridView_1" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1" class="text-break">Interface ISettableGridView&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Height">IGridView&lt;T&gt;.Height</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Width">IGridView&lt;T&gt;.Width</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Count">IGridView&lt;T&gt;.Count</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_ISettableGridView_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public interface ISettableGridView&lt;T&gt; : IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type of value being returned/set by the indexer functions.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ISettableGridView_1_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ISettableGridView_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ISettableGridView%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ISettableGridView.cs/#L36">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, returns/sets the &quot;value&quot; associated with that location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">T this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ISettableGridView%601.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ISettableGridView.cs/#L50">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an 1-dimensional index, returns/sets the value associated with the corresponding position
+in the map view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">T this[int index1D] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">index1D</span></td>
+        <td><p>1D index of location to get/set the &quot;value&quot; for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Typically, this may be implemented in terms of <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a> by using
+<a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_">FromIndex(Int32, Int32)</a> to calculate the 2D position represented by that
+1D index, and passing that position to the <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a> indexer to get/set
+the value associated with the position.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ISettableGridView%601.Item(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ISettableGridView.cs/#L29">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.ISettableGridView`1.Item(System.Int32,System.Int32)">Item[Int32, Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an X and Y value, returns/sets the &quot;value&quot; associated with that location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">T this[int x, int y] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">x</span></td>
+        <td><p>X-value of location.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">y</span></td>
+        <td><p>Y-value of location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with that location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Typically, this can be implemented via <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_SadRogue_Primitives_Point_">Item[Point]</a>.</p>
+</div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ISettableGridView_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ISettableGridView%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/ISettableGridView.cs/#L18" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.LambdaGridView-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.LambdaGridView-1.html
@@ -1,0 +1,588 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class LambdaGridView&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class LambdaGridView&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_LambdaGridView_1" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1" class="text-break">Class LambdaGridView&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>, by providing the &quot;get&quot; functionality via a function that is
+passed in at construction.  For a version that implements <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>, see
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">LambdaGridView&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count">GridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_">GridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_">GridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaGridView_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public sealed class LambdaGridView&lt;T&gt; : GridViewBase&lt;T&gt;, IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type of value being returned by the indexer functions.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.%23ctor(System.Func%7BSystem.Int32%7D%2CSystem.Func%7BSystem.Int32%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L55">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor(System.Func{System.Int32},System.Func{System.Int32},System.Func{SadRogue.Primitives.Point,`0})">LambdaGridView(Func&lt;Int32&gt;, Func&lt;Int32&gt;, Func&lt;Point, T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes functions that retrieve the width and height of the grid, and the
+function used to retrieve the value for a location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaGridView(Func&lt;int&gt; widthGetter, Func&lt;int&gt; heightGetter, Func&lt;Point, T&gt; valueGetter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-1">Func</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
+        <td><span class="parametername">widthGetter</span></td>
+        <td><p>A function/lambda that retrieves the width of the grid being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-1">Func</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
+        <td><span class="parametername">heightGetter</span></td>
+        <td><p>A function/lambda that retrieves the height of the grid being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueGetter</span></td>
+        <td><p>A function/lambda that returns the value of type T associated with the location it is given.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>This constructor is useful if the width and height of the grid being represented may
+change -- one can provide lambdas/functions that retrieve the width and height of the grid being
+represented, and these functions will be called any time the <a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Width">Width</a> and <a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Height">Height</a>
+properties are retrieved.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L32">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor(System.Int32,System.Int32,System.Func{SadRogue.Primitives.Point,`0})">LambdaGridView(Int32, Int32, Func&lt;Point, T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the width and height of the grid, and the function to use to retrieve
+the value for a location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaGridView(int width, int height, Func&lt;Point, T&gt; valueGetter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">width</span></td>
+        <td><p>The (constant) width of the map.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">height</span></td>
+        <td><p>The (constant) height of the map.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueGetter</span></td>
+        <td><p>A lambda/function that returns the value of type T associated with the location it is given.
+This function is called each time the grid view's indexers are called upon to retrieve a value
+from a location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>This constructor is useful if the width and height of the underlying representation do
+not change, so they can safely be passed in as constants.</p>
+</div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L63">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1_Height_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1_Height" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L77">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, returns the &quot;value&quot; associated with that position, by calling the
+valueGetter function provided at construction.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point pos] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to retrieve the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location, according to the valueGetter function
+provided at construction.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L66">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1_Width_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1_Width" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L83">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid view's values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the map view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.ToString(System.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L93">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.ToString(System.Func{`0,System.String})">ToString(Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid view's values, using <code data-dev-comment-type="paramref" class="paramref">elementStringifier</code>
+to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each element.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid view's values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Int32_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601.ToString(System.Int32%2CSystem.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L114">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Int32_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.LambdaGridView`1.ToString(System.Int32,System.Func{`0,System.String})">ToString(Int32, Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representing the grid view's values, using the function specified to turn elements into
+strings, and using the &quot;field length&quot; specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each element to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid view's values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Int32_System_Func__0_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element of type T will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the element's string representation.</p>
+</div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaGridView_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaGridView%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaGridView.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html
@@ -1,0 +1,613 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class LambdaSettableGridView&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class LambdaSettableGridView&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1" class="text-break">Class LambdaSettableGridView&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>, by providing the &quot;get&quot; and &quot;set&quot; functionality via
+functions that are passed in at construction.  For a version that implements <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>, see
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html">LambdaGridView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">LambdaSettableGridView&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count">SettableGridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_">SettableGridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public sealed class LambdaSettableGridView&lt;T&gt; : SettableGridViewBase&lt;T&gt;, ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type of value being returned by the indexer functions.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.%23ctor(System.Func%7BSystem.Int32%7D%2CSystem.Func%7BSystem.Int32%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%7D%2CSystem.Action%7BSadRogue.Primitives.Point%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L62">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor(System.Func{System.Int32},System.Func{System.Int32},System.Func{SadRogue.Primitives.Point,`0},System.Action{SadRogue.Primitives.Point,`0})">LambdaSettableGridView(Func&lt;Int32&gt;, Func&lt;Int32&gt;, Func&lt;Point, T&gt;, Action&lt;Point, T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes functions that retrieve the width and height of the grid, and the
+functions used to retrieve/set the value for a location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaSettableGridView(Func&lt;int&gt; widthGetter, Func&lt;int&gt; heightGetter, Func&lt;Point, T&gt; valueGetter, Action&lt;Point, T&gt; valueSetter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-1">Func</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
+        <td><span class="parametername">widthGetter</span></td>
+        <td><p>A function/lambda that retrieves the width of the grid being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-1">Func</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
+        <td><span class="parametername">heightGetter</span></td>
+        <td><p>A function/lambda that retrieves the height of the grid being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueGetter</span></td>
+        <td><p>A function/lambda that returns the value of type T associated with the location it is given.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.action-2">Action</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueSetter</span></td>
+        <td><p>A function/lambda that updates the grid being represented accordingly, given a type T and
+position to which it was set.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>This constructor is useful if the width and height of the underlying representation may
+change -- one can provide functions that retrieve the width and height of the map being
+represented, and these functions will be called any time the <a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Width">Width</a> and <a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Height">Height</a>
+properties are retrieved.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%7D%2CSystem.Action%7BSadRogue.Primitives.Point%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L35">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor(System.Int32,System.Int32,System.Func{SadRogue.Primitives.Point,`0},System.Action{SadRogue.Primitives.Point,`0})">LambdaSettableGridView(Int32, Int32, Func&lt;Point, T&gt;, Action&lt;Point, T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the width and height of the grid, and the functions to use to
+retrieve/set the value for a location.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaSettableGridView(int width, int height, Func&lt;Point, T&gt; valueGetter, Action&lt;Point, T&gt; valueSetter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">width</span></td>
+        <td><p>The (constant) width of the map.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">height</span></td>
+        <td><p>The (constant) height of the map.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueGetter</span></td>
+        <td><p>A function/lambda that returns the value of type T associated with the location it is given.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.action-2">Action</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T&gt;</td>
+        <td><span class="parametername">valueSetter</span></td>
+        <td><p>A function/lambda that updates the underlying representation of the grid being represented accordingly,
+given a type T and position to which it was set.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>This constructor is useful if the width and height of the underlying representation do
+not change, so they can safely be passed in as constants.</p>
+</div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L72">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Height_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Height" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L86">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Item_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, returns/sets the &quot;value&quot; associated with that location, by calling the
+valueGetter/valueSetter functions provided at construction.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to retrieve/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location, according to the valueGetter function
+provided at construction.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L75">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Width_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Width" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L96">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.ToString(System.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L106">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString(System.Func{`0,System.String})">ToString(Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using <code data-dev-comment-type="paramref" class="paramref">elementStringifier</code>
+to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each element.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Int32_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601.ToString(System.Int32%2CSystem.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L127">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Int32_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString(System.Int32,System.Func{`0,System.String})">ToString(Int32, Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using the function specified to turn elements into
+strings, and using the &quot;field length&quot; specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each element to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Int32_System_Func__0_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element of type T will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the element's string representation.</p>
+</div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableGridView_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableGridView%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableGridView.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html
+++ b/docs/api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html
@@ -1,0 +1,597 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class LambdaSettableTranslationGridView&lt;T1, T2&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class LambdaSettableTranslationGridView&lt;T1, T2&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2" class="text-break">Class LambdaSettableTranslationGridView&lt;T1, T2&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>A simple <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView&lt;T1, T2&gt;</a> implementation that allows you to provide
+functions/lambdas for the translation functions. For a version offering only &quot;get&quot; functionality,
+see <a class="xref" href="SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html">LambdaTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase</a>&lt;T2&gt;</div>
+    <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView</a>&lt;T1, T2&gt;</div>
+    <div class="level3"><span class="xref">LambdaSettableTranslationGridView&lt;T1, T2&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T2&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T2&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_BaseGrid">SettableTranslationGridView&lt;T1, T2&gt;.BaseGrid</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Height">SettableTranslationGridView&lt;T1, T2&gt;.Height</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Width">SettableTranslationGridView&lt;T1, T2&gt;.Width</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Item_SadRogue_Primitives_Point_">SettableTranslationGridView&lt;T1, T2&gt;.Item[Point]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString">SettableTranslationGridView&lt;T1, T2&gt;.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Func__1_System_String__">SettableTranslationGridView&lt;T1, T2&gt;.ToString(Func&lt;T2, String&gt;)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__">SettableTranslationGridView&lt;T1, T2&gt;.ToString(Int32, Func&lt;T2, String&gt;)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet__0_">SettableTranslationGridView&lt;T1, T2&gt;.TranslateGet(T1)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">SettableTranslationGridView&lt;T1, T2&gt;.TranslateGet(Point, T1)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet__1_">SettableTranslationGridView&lt;T1, T2&gt;.TranslateSet(T2)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_">SettableTranslationGridView&lt;T1, T2&gt;.TranslateSet(Point, T2)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Height">SettableGridViewBase&lt;T2&gt;.Height</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Width">SettableGridViewBase&lt;T2&gt;.Width</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_SadRogue_Primitives_Point_">SettableGridViewBase&lt;T2&gt;.Item[Point]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count">SettableGridViewBase&lt;T2&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_">SettableGridViewBase&lt;T2&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_">SettableGridViewBase&lt;T2&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public sealed class LambdaSettableTranslationGridView&lt;T1, T2&gt; : SettableTranslationGridView&lt;T1, T2&gt;, ISettableGridView&lt;T2&gt;, IGridView&lt;T2&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T1</span></td>
+        <td><p>The type of your underlying data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="parametername">T2</span></td>
+        <td><p>The type of the data being exposed by the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__System_Func__0__1__System_Func__1__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSadRogue.Primitives.GridViews.ISettableGridView%7B%601%7D%2CSystem.Func%7B%600%2C%601%7D%2CSystem.Func%7B%601%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L65">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__System_Func__0__1__System_Func__1__0__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1},System.Func{`0,`1},System.Func{`1,`0})">LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt;, ISettableGridView&lt;T2&gt;, Func&lt;T1, T2&gt;, Func&lt;T2, T1&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from and applies view data to it.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt; baseGrid, ISettableGridView&lt;T2&gt; overlay, Func&lt;T1, T2&gt; getter, Func&lt;T2, T1&gt; setter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying grid data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T2&gt;</td>
+        <td><span class="parametername">overlay</span></td>
+        <td><p>The view data to apply to the underlying representation. Must have identical dimensions to
+<code data-dev-comment-type="paramref" class="paramref">baseGrid</code>.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T1, T2&gt;</td>
+        <td><span class="parametername">getter</span></td>
+        <td><p>The TranslateGet implementation.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T2, T1&gt;</td>
+        <td><span class="parametername">setter</span></td>
+        <td><p>The TranslateSet implementation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__System_Func_SadRogue_Primitives_Point__0__1__System_Func_SadRogue_Primitives_Point__1__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSadRogue.Primitives.GridViews.ISettableGridView%7B%601%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%2C%601%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%601%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L79">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__System_Func_SadRogue_Primitives_Point__0__1__System_Func_SadRogue_Primitives_Point__1__0__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1},System.Func{SadRogue.Primitives.Point,`0,`1},System.Func{SadRogue.Primitives.Point,`1,`0})">LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt;, ISettableGridView&lt;T2&gt;, Func&lt;Point, T1, T2&gt;, Func&lt;Point, T2, T1&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from and applies view data to it.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt; baseGrid, ISettableGridView&lt;T2&gt; overlay, Func&lt;Point, T1, T2&gt; getter, Func&lt;Point, T2, T1&gt; setter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying grid data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T2&gt;</td>
+        <td><span class="parametername">overlay</span></td>
+        <td><p>The view data to apply to the underlying representation. Must have identical dimensions to
+<code data-dev-comment-type="paramref" class="paramref">baseGrid</code>.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-3">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T1, T2&gt;</td>
+        <td><span class="parametername">getter</span></td>
+        <td><p>The TranslateGet implementation.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-3">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T2, T1&gt;</td>
+        <td><span class="parametername">setter</span></td>
+        <td><p>The TranslateSet implementation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func__0__1__System_Func__1__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSystem.Func%7B%600%2C%601%7D%2CSystem.Func%7B%601%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L28">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func__0__1__System_Func__1__0__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Func{`0,`1},System.Func{`1,`0})">LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt;, Func&lt;T1, T2&gt;, Func&lt;T2, T1&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from, and getter/setter
+functions taking only a value from the underlying representation.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt; baseGrid, Func&lt;T1, T2&gt; getter, Func&lt;T2, T1&gt; setter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying grid data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T1, T2&gt;</td>
+        <td><span class="parametername">getter</span></td>
+        <td><p>The TranslateGet implementation.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T2, T1&gt;</td>
+        <td><span class="parametername">setter</span></td>
+        <td><p>The TranslateSet implementation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func__0__1__System_Func__1__0___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>If a position is also needed to perform the translation, an overload is provided taking
+corresponding functions.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func_SadRogue_Primitives_Point__0__1__System_Func_SadRogue_Primitives_Point__1__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%2C%601%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%601%2C%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L47">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func_SadRogue_Primitives_Point__0__1__System_Func_SadRogue_Primitives_Point__1__0__" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Func{SadRogue.Primitives.Point,`0,`1},System.Func{SadRogue.Primitives.Point,`1,`0})">LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt;, Func&lt;Point, T1, T2&gt;, Func&lt;Point, T2, T1&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from, and getter/setter
+functions taking a map value and its corresponding position.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaSettableTranslationGridView(ISettableGridView&lt;T1&gt; baseGrid, Func&lt;Point, T1, T2&gt; getter, Func&lt;Point, T2, T1&gt; setter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying grid data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-3">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T1, T2&gt;</td>
+        <td><span class="parametername">getter</span></td>
+        <td><p>The TranslateGet implementation.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-3">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T2, T1&gt;</td>
+        <td><span class="parametername">setter</span></td>
+        <td><p>The TranslateSet implementation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602.TranslateGet(SadRogue.Primitives.Point%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L90">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateGet_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateGet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)">TranslateGet(Point, T1)</h4>
+  <div class="markdown level1 summary"><p>Translates your grid data into the view type by calling the getter function specified in the
+class constructor.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected override T2 TranslateGet(Point position, T1 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>Position corresponding to given data value of your underlying representation.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>The data value from your grid.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>A value of the mapped data type (via the getter specified in the class constructor).</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableTranslationGridView&lt;T1, T2&gt;.TranslateGet(SadRogue.Primitives.Point, T1)</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602.TranslateSet(SadRogue.Primitives.Point%2C%601)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L101">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateSet_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateSet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_" data-uid="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateSet(SadRogue.Primitives.Point,`1)">TranslateSet(Point, T2)</h4>
+  <div class="markdown level1 summary"><p>Translates the view type into the appropriate form for your grid data, by calling the
+setter function specified in the class constructor.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected override T1 TranslateSet(Point position, T2 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>Position corresponding to the given mapped data type.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><p>The value to apply to the underlying representation via the setter specified in the class constructor.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableTranslationGridView&lt;T1, T2&gt;.TranslateSet(SadRogue.Primitives.Point, T2)</span></div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView%602%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaSettableTranslationGridView.cs/#L12" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html
+++ b/docs/api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html
@@ -1,0 +1,401 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class LambdaTranslationGridView&lt;T1, T2&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class LambdaTranslationGridView&lt;T1, T2&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2" class="text-break">Class LambdaTranslationGridView&lt;T1, T2&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>A simple <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a> implementation that allows you to provide a function/lambda
+at construction to use as the <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">TranslateGet(Point, T1)</a> implementation.
+For a version offering &quot;set&quot; functionality, see <a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html">LambdaSettableTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase</a>&lt;T2&gt;</div>
+    <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView</a>&lt;T1, T2&gt;</div>
+    <div class="level3"><span class="xref">LambdaTranslationGridView&lt;T1, T2&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T2&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_BaseGrid">TranslationGridView&lt;T1, T2&gt;.BaseGrid</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Height">TranslationGridView&lt;T1, T2&gt;.Height</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Width">TranslationGridView&lt;T1, T2&gt;.Width</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Item_SadRogue_Primitives_Point_">TranslationGridView&lt;T1, T2&gt;.Item[Point]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString">TranslationGridView&lt;T1, T2&gt;.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Func__1_System_String__">TranslationGridView&lt;T1, T2&gt;.ToString(Func&lt;T2, String&gt;)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__">TranslationGridView&lt;T1, T2&gt;.ToString(Int32, Func&lt;T2, String&gt;)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet__0_">TranslationGridView&lt;T1, T2&gt;.TranslateGet(T1)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">TranslationGridView&lt;T1, T2&gt;.TranslateGet(Point, T1)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Height">GridViewBase&lt;T2&gt;.Height</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Width">GridViewBase&lt;T2&gt;.Width</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_SadRogue_Primitives_Point_">GridViewBase&lt;T2&gt;.Item[Point]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count">GridViewBase&lt;T2&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_">GridViewBase&lt;T2&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_">GridViewBase&lt;T2&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public sealed class LambdaTranslationGridView&lt;T1, T2&gt; : TranslationGridView&lt;T1, T2&gt;, IGridView&lt;T2&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T1</span></td>
+        <td><p>The type of your underlying data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="parametername">T2</span></td>
+        <td><p>The type of the data being exposed by the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func__0__1__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D%2CSystem.Func%7B%600%2C%601%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaTranslationGridView.cs/#L26">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func__0__1__" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},System.Func{`0,`1})">LambdaTranslationGridView(IGridView&lt;T1&gt;, Func&lt;T1, T2&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from and a getter function
+taking only a value of type T1.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaTranslationGridView(IGridView&lt;T1&gt; baseGrid, Func&lt;T1, T2&gt; getter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying grid data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T1, T2&gt;</td>
+        <td><span class="parametername">getter</span></td>
+        <td><p>The TranslateGet implementation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func__0__1___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>If a position is also needed to perform the translation, an overload is provided taking a
+corresponding function.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func_SadRogue_Primitives_Point__0__1__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D%2CSystem.Func%7BSadRogue.Primitives.Point%2C%600%2C%601%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaTranslationGridView.cs/#L41">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func_SadRogue_Primitives_Point__0__1__" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},System.Func{SadRogue.Primitives.Point,`0,`1})">LambdaTranslationGridView(IGridView&lt;T1&gt;, Func&lt;Point, T1, T2&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from and a getter function
+taking a value of type T1 and its corresponding position.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public LambdaTranslationGridView(IGridView&lt;T1&gt; baseGrid, Func&lt;Point, T1, T2&gt; getter)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying grid data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-3">Func</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, T1, T2&gt;</td>
+        <td><span class="parametername">getter</span></td>
+        <td><p>The TranslateGet implementation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaTranslationGridView%602.TranslateGet(SadRogue.Primitives.Point%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaTranslationGridView.cs/#L51">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2_TranslateGet_" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.TranslateGet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_LambdaTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_" data-uid="SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)">TranslateGet(Point, T1)</h4>
+  <div class="markdown level1 summary"><p>Translates your underlying data into the view type by calling the getter function specified in the
+class constructor.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected override T2 TranslateGet(Point position, T1 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>Position corresponding to given value from your underlying data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>The value from your underlying data.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>A value of the mapped data type (via the getter specified in the class constructor).</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.TranslationGridView&lt;T1, T2&gt;.TranslateGet(SadRogue.Primitives.Point, T1)</span></div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_LambdaTranslationGridView_2.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.LambdaTranslationGridView%602%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/LambdaTranslationGridView.cs/#L12" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html
@@ -1,0 +1,497 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class SettableGridViewBase&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class SettableGridViewBase&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1" class="text-break">Class SettableGridViewBase&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>A convenient base class to inherit from when implementing <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> that minimizes
+the number of items you must implement by implementing indexers in terms of a single indexer taking a Point.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><span class="xref">SettableGridViewBase&lt;T&gt;</span></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D&lt;T&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a></div>
+      <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView&lt;T1, T2&gt;</a></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract class SettableGridViewBase&lt;T&gt; : ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L19">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Count*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Count">Count</h4>
+  <div class="markdown level1 summary"><p>Number of tiles in the grid; equal to <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Width">Width</a> * <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Height">Height</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Count { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L10">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Height_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Height" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L16">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract T this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_SadRogue_Primitives_Point__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L29">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[int index1D] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">index1D</span></td>
+        <td><p>1D index of location to get/set the &quot;value&quot; for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the given location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601.Item(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L22">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(System.Int32,System.Int32)">Item[Int32, Int32]</h4>
+  <div class="markdown level1 summary"><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[int x, int y] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">x</span></td>
+        <td><p>X-value of location.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">y</span></td>
+        <td><p>Y-value of location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with that location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>. This interface serves the same purpose, but for cases when it is also
+necessary for an algorithm to be able to change the value at each location.</p>
+<p>Like IGridView, a number of implementations of this interface to cover common needs are provided.  For example,
+<a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> defines the interface such that the data is retrieved from and set to an array, and
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a> defines the interface such that arbitrary callbacks are used to retrieve
+and set the data.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L13">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Width_" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableGridViewBase_1_Width" data-uid="SadRogue.Primitives.GridViews.SettableGridViewBase`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableGridViewBase_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableGridViewBase%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs/#L7" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html
+++ b/docs/api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html
@@ -1,0 +1,834 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class SettableTranslationGridView&lt;T1, T2&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class SettableTranslationGridView&lt;T1, T2&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2" class="text-break">Class SettableTranslationGridView&lt;T1, T2&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> by providing a functions that translate values from one
+grid view with complex data types, to a grid view with simple data types, and vice versa.  For a version that
+provides only &quot;get&quot; functionality, see <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase</a>&lt;T2&gt;</div>
+    <div class="level2"><span class="xref">SettableTranslationGridView&lt;T1, T2&gt;</span></div>
+      <div class="level3"><a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html">LambdaSettableTranslationGridView&lt;T1, T2&gt;</a></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T2&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T2&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count">SettableGridViewBase&lt;T2&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_">SettableGridViewBase&lt;T2&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_">SettableGridViewBase&lt;T2&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract class SettableTranslationGridView&lt;T1, T2&gt; : SettableGridViewBase&lt;T2&gt;, ISettableGridView&lt;T2&gt;, IGridView&lt;T2&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T1</span></td>
+        <td><p>The type of your underlying data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="parametername">T2</span></td>
+        <td><p>The type of the data being exposed by the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>See <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a>.  The use case is the same, except that this class
+implements <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> instead, and thus also allows you to specify
+set-translations via TranslateSet.</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L23">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0})">SettableTranslationGridView(ISettableGridView&lt;T1&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected SettableTranslationGridView(ISettableGridView&lt;T1&gt; baseGrid)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>A grid view exposing your underlying map data.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSadRogue.Primitives.GridViews.ISettableGridView%7B%601%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L37">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1})">SettableTranslationGridView(ISettableGridView&lt;T1&gt;, ISettableGridView&lt;T2&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from and applies view data to it.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected SettableTranslationGridView(ISettableGridView&lt;T1&gt; baseGrid, ISettableGridView&lt;T2&gt; overlay)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>Your underlying map data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T2&gt;</td>
+        <td><span class="parametername">overlay</span></td>
+        <td><p>The view data to apply to the grid. Must have identical dimensions to <code data-dev-comment-type="paramref" class="paramref">baseGrid</code>.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Since this constructor must call TranslateSet to perform its function, do NOT
+call this constructor if the TranslateSet implementation depends on the derived
+class's constructor being completed to function properly.</p>
+</div>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_BaseGrid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.BaseGrid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L43">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_BaseGrid_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.BaseGrid*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_BaseGrid" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.BaseGrid">BaseGrid</h4>
+  <div class="markdown level1 summary"><p>The grid view exposing your underlying data.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ISettableGridView&lt;T1&gt; BaseGrid { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T1&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L46">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Height_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Height" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T2&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L56">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Item_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, translates and returns/sets the &quot;value&quot; associated with that position.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T2 this[Point pos] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>The translated &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T2&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L49">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Width_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Width" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.SettableGridViewBase&lt;T2&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L66">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Func__1_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.ToString(System.Func%7B%601%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L76">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Func__1_System_String__" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString(System.Func{`1,System.String})">ToString(Func&lt;T2, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using <code data-dev-comment-type="paramref" class="paramref">elementStringifier</code>
+to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T2, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T2, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each element.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.ToString(System.Int32%2CSystem.Func%7B%601%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L97">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString(System.Int32,System.Func{`1,System.String})">ToString(Int32, Func&lt;T2, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using the function specified to turn elements into
+strings, and using the &quot;field length&quot; specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T2, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T2, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each element to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Int32_System_Func__1_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element of type T will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the element's string representation.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.TranslateGet(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L107">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet__0_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet(`0)">TranslateGet(T1)</h4>
+  <div class="markdown level1 summary"><p>Translates your underlying data into the view type. Takes only a value from the underlying data.
+If a position is also needed to perform the translation, use <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">TranslateGet(Point, T1)</a>
+instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected virtual T2 TranslateGet(T1 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>The data value from your underlying data.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.TranslateGet(SadRogue.Primitives.Point%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L119">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)">TranslateGet(Point, T1)</h4>
+  <div class="markdown level1 summary"><p>Translates your underlying data into the view type. Takes a value from the underlying data and
+the corresponding position for that value. If a position is not needed to perform the
+translation, use <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet__0_">TranslateGet(T1)</a> instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected virtual T2 TranslateGet(Point position, T1 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>The position of the given data value from your underlying data structure.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>The data value from your underlying structure.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet__1_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.TranslateSet(%601)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L128">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet__1_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet(`1)">TranslateSet(T2)</h4>
+  <div class="markdown level1 summary"><p>Translates the view type into the appropriate form for your underlying data. Takes only a value
+from the grid view itself. If a position is also needed to perform the translation, use
+<a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_">TranslateSet(Point, T2)</a> instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected virtual T1 TranslateSet(T2 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><p>The data value for your underlying representation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602.TranslateSet(SadRogue.Primitives.Point%2C%601)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L140">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_" data-uid="SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet(SadRogue.Primitives.Point,`1)">TranslateSet(Point, T2)</h4>
+  <div class="markdown level1 summary"><p>Translates the view type into the appropriate form for your underlying data. Takes a value from
+the underlying data, and it corresponding position. If a position is not needed to perform
+the translation, use <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet__1_">TranslateSet(T2)</a> instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected virtual T1 TranslateSet(Point position, T2 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>The position of the given mapped data type.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><p>The data value for your underlying representation.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableTranslationGridView_2.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableTranslationGridView%602%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableTranslationGridView.cs/#L17" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.SettableViewport-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.SettableViewport-1.html
@@ -1,0 +1,503 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class SettableViewport&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class SettableViewport&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_SettableViewport_1" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1" class="text-break">Class SettableViewport&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Similar to <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a>, but implements <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>and thus implements
+&quot;set&quot; functionality via relative coordinates.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport</a>&lt;T&gt;</div>
+    <div class="level3"><span class="xref">SettableViewport&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ViewArea">Viewport&lt;T&gt;.ViewArea</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Height">Viewport&lt;T&gt;.Height</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Width">Viewport&lt;T&gt;.Width</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_SadRogue_Primitives_Rectangle_">Viewport&lt;T&gt;.SetViewArea(Rectangle)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString">Viewport&lt;T&gt;.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Func__0_System_String__">Viewport&lt;T&gt;.ToString(Func&lt;T, String&gt;)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Int32_System_Func__0_System_String__">Viewport&lt;T&gt;.ToString(Int32, Func&lt;T, String&gt;)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count">GridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_SettableViewport_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class SettableViewport&lt;T&gt; : Viewport&lt;T&gt;, ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type being exposed by map view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L23">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableViewport_1__ctor_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableViewport_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0})">SettableViewport(ISettableGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the map view to represent. The viewport will represent the entire given map view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public SettableViewport(ISettableGridView&lt;T&gt; gridView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td><p>The map view to represent.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601.%23ctor(SadRogue.Primitives.GridViews.ISettableGridView%7B%600%7D%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L15">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableViewport_1__ctor_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableViewport_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.Rectangle)">SettableViewport(ISettableGridView&lt;T&gt;, Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the parent map view, and the initial subsection of that map view to represent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public SettableViewport(ISettableGridView&lt;T&gt; gridView, Rectangle viewArea)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td><p>The map view being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">viewArea</span></td>
+        <td><p>The initial subsection of that map to represent.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1_GridView.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601.GridView%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L30">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableViewport_1_GridView_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.GridView*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableViewport_1_GridView" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.GridView">GridView</h4>
+  <div class="markdown level1 summary"><p>The map view that this viewport is exposing values from.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ISettableGridView&lt;T&gt; GridView { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L58">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableViewport_1_Item_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableViewport_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position in relative coordinates, sets/returns the &quot;value&quot; associated with that
+location in absolute coordinates.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[Point relativePosition] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">relativePosition</span></td>
+        <td><p>Viewport-relative position of the location to retrieve/set the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the absolute location represented on the underlying map view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L42">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableViewport_1_Item_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableViewport_1_Item_System_Int32_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Given a position in relative 1d-array-index style, returns/sets the &quot;value&quot; associated with that
+location in absolute coordinates.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[int relativeIndex1D] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">relativeIndex1D</span></td>
+        <td><p>Viewport-relative position of the location to retrieve/set the value for, as a 1D array index.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the absolute location represented on the underlying map view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1_Item_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601.Item(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L73">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_SettableViewport_1_Item_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_SettableViewport_1_Item_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.GridViews.SettableViewport`1.Item(System.Int32,System.Int32)">Item[Int32, Int32]</h4>
+  <div class="markdown level1 summary"><p>Given an X and Y value in relative coordinates, sets/returns the &quot;value&quot; associated with
+that location in absolute coordinates.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T this[int relativeX, int relativeY] { get; set; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">relativeX</span></td>
+        <td><p>Viewport-relative X-value of location.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">relativeY</span></td>
+        <td><p>Viewport-relative Y-value of location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the absolute location represented on the underlying map view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__">GridViewExtensions.ApplyOverlay&lt;T&gt;(ISettableGridView&lt;T&gt;, Func&lt;Point, T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_">GridViewExtensions.Fill&lt;T&gt;(ISettableGridView&lt;T&gt;, T)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_SettableViewport_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.SettableViewport%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/SettableViewport.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.TranslationGridView-2.html
+++ b/docs/api/SadRogue.Primitives.GridViews.TranslationGridView-2.html
@@ -1,0 +1,668 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class TranslationGridView&lt;T1, T2&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class TranslationGridView&lt;T1, T2&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_TranslationGridView_2" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2" class="text-break">Class TranslationGridView&lt;T1, T2&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> by providing a function that translates values from one grid view
+with complex data types, to a grid view with simple data types.  For a version that provides &quot;set&quot;
+functionality, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase</a>&lt;T2&gt;</div>
+    <div class="level2"><span class="xref">TranslationGridView&lt;T1, T2&gt;</span></div>
+      <div class="level3"><a class="xref" href="SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html">LambdaTranslationGridView</a>&lt;T1, T2&gt;</div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T2&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count">GridViewBase&lt;T2&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_">GridViewBase&lt;T2&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_">GridViewBase&lt;T2&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_TranslationGridView_2_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract class TranslationGridView&lt;T1, T2&gt; : GridViewBase&lt;T2&gt;, IGridView&lt;T2&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T1</span></td>
+        <td><p>The type of your underlying data.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="parametername">T2</span></td>
+        <td><p>The type of the data being exposed by the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_TranslationGridView_2_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>This class is useful if the underlying representation of the data you are creating a grid view for is complex,
+and you simply need to map a complex data type to a simpler one.  For example, you might implement the
+<a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">TranslateGet(Point, T1)</a> function to extract a property from a more complex
+structure.  If your mapping is very simple, or you do not wish to create a subclass, see
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html">LambdaTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L25">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2__ctor_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0})">TranslationGridView(IGridView&lt;T1&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes an existing grid view to create a view from.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected TranslationGridView(IGridView&lt;T1&gt; baseGrid)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T1&gt;</td>
+        <td><span class="parametername">baseGrid</span></td>
+        <td><p>A grid view exposing your underlying data.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_BaseGrid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.BaseGrid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L30">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_BaseGrid_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.BaseGrid*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_BaseGrid" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.BaseGrid">BaseGrid</h4>
+  <div class="markdown level1 summary"><p>The underlying grid data, exposed as a grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IGridView&lt;T1&gt; BaseGrid { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T1&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L35">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_Height_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_Height" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the grid.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T2&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L47">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_Item_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position, translates and returns the &quot;value&quot; associated with that position.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T2 this[Point pos] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Location to get the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>The translated &quot;value&quot; associated with the provided location.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T2&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L40">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_Width_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_Width" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the grid.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T2&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L53">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the exposed grid values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the exposed grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Func__1_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.ToString(System.Func%7B%601%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L63">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Func__1_System_String__" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.ToString(System.Func{`1,System.String})">ToString(Func&lt;T2, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using <code data-dev-comment-type="paramref" class="paramref">elementStringifier</code>
+to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T2, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T2, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each element.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.ToString(System.Int32%2CSystem.Func%7B%601%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L84">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.ToString(System.Int32,System.Func{`1,System.String})">ToString(Int32, Func&lt;T2, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values, using the function specified to turn elements into
+strings, and using the &quot;field length&quot; specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T2, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T2, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each element to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Int32_System_Func__1_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element of type T will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the element's string representation.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.TranslateGet(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L94">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet__0_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet(`0)">TranslateGet(T1)</h4>
+  <div class="markdown level1 summary"><p>Translates your actual data into the view type using just the data value itself. If you need
+the location as well to perform the translation, implement <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">TranslateGet(Point, T1)</a>
+instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected virtual T2 TranslateGet(T1 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>The data value from the base grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602.TranslateGet(SadRogue.Primitives.Point%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L106">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_" data-uid="SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)">TranslateGet(Point, T1)</h4>
+  <div class="markdown level1 summary"><p>Translates your actual data into the view type using the position and the data value itself. If
+you need only the data value to perform the translation, implement <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet__0_">TranslateGet(T1)</a>
+instead.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">protected virtual T2 TranslateGet(Point position, T1 value)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>The position of the given data value.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T1</span></td>
+        <td><span class="parametername">value</span></td>
+        <td><p>The data value from your underlying grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T2</span></td>
+        <td><p>A value of the mapped data type.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_TranslationGridView_2.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.TranslationGridView%602%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/TranslationGridView.cs/#L19" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html
@@ -1,0 +1,665 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class UnboundedViewport&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class UnboundedViewport&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_UnboundedViewport_1" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1" class="text-break">Class UnboundedViewport&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Similar to <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a>, except that the view area is in no way bounded to the edges of the
+underlying grid view.  Instead, if you access a position that cannot map to any valid position in the underlying
+grid view, a (specified) default value is returned.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">UnboundedViewport&lt;T&gt;</span></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count">GridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_">GridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_">GridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class UnboundedViewport&lt;T&gt; : GridViewBase&lt;T&gt;, IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type being exposed by the UnboundedViewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0___0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L44">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0___0_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},`0)">UnboundedViewport(IGridView&lt;T&gt;, T)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the grid view to represent. The viewport will represent the entire given grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public UnboundedViewport(IGridView&lt;T&gt; gridView, T defaultValue)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td><p>The grid view to represent.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><span class="parametername">defaultValue</span></td>
+        <td><p>The value to return if a position is accessed that is outside the actual underlying grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__SadRogue_Primitives_Rectangle__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D%2CSadRogue.Primitives.Rectangle%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L30">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__SadRogue_Primitives_Rectangle__0_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},SadRogue.Primitives.Rectangle,`0)">UnboundedViewport(IGridView&lt;T&gt;, Rectangle, T)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the parent grid view, and the initial subsection of that grid view to represent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public UnboundedViewport(IGridView&lt;T&gt; gridView, Rectangle viewArea, T defaultValue)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td><p>The grid view being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">viewArea</span></td>
+        <td><p>The initial subsection of that grid to represent.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><span class="parametername">defaultValue</span></td>
+        <td><p>The value to return if a position is accessed that is outside the actual underlying grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_DefaultValue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.DefaultValue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L16">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_DefaultValue" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.DefaultValue">DefaultValue</h4>
+  <div class="markdown level1 summary"><p>The value to return if a position is accessed that is outside the actual underlying grid view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public readonly T DefaultValue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_GridView.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.GridView%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L51">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_GridView_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.GridView*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_GridView" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.GridView">GridView</h4>
+  <div class="markdown level1 summary"><p>The grid view that this UnboundedViewport is exposing values from.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IGridView&lt;T&gt; GridView { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L64">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_Height_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_Height" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the area being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L82">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_Item_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position in relative coordinates, returns the &quot;value&quot; associated with that
+location in absolute coordinates.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point relativePosition] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">relativePosition</span></td>
+        <td><p>Viewport-relative position of the location to retrieve the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the absolute location represented on the underlying grid view,
+or <a class="xref" href="SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_DefaultValue">DefaultValue</a> if the absolute position does not exist in the underlying grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_ViewArea.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.ViewArea%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L59">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ViewArea_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ViewArea*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ViewArea" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ViewArea">ViewArea</h4>
+  <div class="markdown level1 summary"><p>The area of the base GridView that this Viewport is exposing. Although this property does
+not explicitly expose a set accessor, it is returning a reference and as such may be
+assigned to. This viewport is NOT bounded to base map edges -- for this functionality, see the
+<a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a> class.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Rectangle ViewArea { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L69">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_Width_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_Width" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the area being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L95">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values inside the viewport.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values inside the viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.ToString(System.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L105">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString(System.Func{`0,System.String})">ToString(Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values inside the viewport, using
+<code data-dev-comment-type="paramref" class="paramref">elementStringifier</code> to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each element.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values inside the viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Int32_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601.ToString(System.Int32%2CSystem.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L126">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Int32_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString(System.Int32,System.Func{`0,System.String})">ToString(Int32, Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values inside the viewport, using the function specified to turn
+elements into strings, and using the &quot;field length&quot; specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each element to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values inside the viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Int32_System_Func__0_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element of type T will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the element's string representation.</p>
+</div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_UnboundedViewport_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.UnboundedViewport%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/UnboundedViewport.cs/#L11" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.ValueChange-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.ValueChange-1.html
@@ -1,0 +1,637 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct ValueChange&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct ValueChange&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.ValueChange`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_ValueChange_1" data-uid="SadRogue.Primitives.GridViews.ValueChange`1" class="text-break">Struct ValueChange&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Records a value change in a diff as recorded by a <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_ValueChange_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct ValueChange&lt;T&gt; : IEquatable&lt;ValueChange&lt;T&gt;&gt;, IMatchable&lt;ValueChange&lt;T&gt;&gt; where T : struct</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value being changed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1__ctor_SadRogue_Primitives_Point__0__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.%23ctor(SadRogue.Primitives.Point%2C%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L38">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1__ctor_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1__ctor_SadRogue_Primitives_Point__0__0_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.#ctor(SadRogue.Primitives.Point,`0,`0)">ValueChange(Point, T, T)</h4>
+  <div class="markdown level1 summary"><p>Creates a new value change record.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ValueChange(Point position, T oldValue, T newValue)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">position</span></td>
+        <td><p>Position whose value was changed.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><span class="parametername">oldValue</span></td>
+        <td><p>Original value that was changed.</p>
+</td>
+      </tr>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><span class="parametername">newValue</span></td>
+        <td><p>New value that was set.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_NewValue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.NewValue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L30">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_NewValue" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.NewValue">NewValue</h4>
+  <div class="markdown level1 summary"><p>New value that was set.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly T NewValue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_OldValue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.OldValue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L25">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_OldValue" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.OldValue">OldValue</h4>
+  <div class="markdown level1 summary"><p>Original value that was changed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly T OldValue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_Position.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L20">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_Position" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Position">Position</h4>
+  <div class="markdown level1 summary"><p>Position whose value was changed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly Point Position</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_Equals_SadRogue_Primitives_GridViews_ValueChange__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.Equals(SadRogue.Primitives.GridViews.ValueChange%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L50">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_Equals_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Equals*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_Equals_SadRogue_Primitives_GridViews_ValueChange__0__" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Equals(SadRogue.Primitives.GridViews.ValueChange{`0})">Equals(ValueChange&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Compares the two changes according to their positions and values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Equals(ValueChange&lt;T&gt; other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two value changes represent the same change, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L65">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_Equals_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Equals*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_Equals_System_Object_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Equals(System.Object)">Equals(Object)</h4>
+  <div class="markdown level1 summary"><p>Compares the two changes according to their types, positions and values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
+        <td><span class="parametername">obj</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two value changes represent the same object and change, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L71">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_GetHashCode_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.GetHashCode*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_GetHashCode" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.GetHashCode">GetHashCode()</h4>
+  <div class="markdown level1 summary"><p>Returns a hash value computed using the item's position, old value, and new value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_Matches_SadRogue_Primitives_GridViews_ValueChange__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.Matches(SadRogue.Primitives.GridViews.ValueChange%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L58">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_Matches_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Matches*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_Matches_SadRogue_Primitives_GridViews_ValueChange__0__" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.Matches(SadRogue.Primitives.GridViews.ValueChange{`0})">Matches(ValueChange&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Compares the two changes according to their positions and values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(ValueChange&lt;T&gt; other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two value changes represent the same change, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L93">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_ToString_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_ToString" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representing the object, including its position, old value, and new value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_op_Equality_SadRogue_Primitives_GridViews_ValueChange__0__SadRogue_Primitives_GridViews_ValueChange__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.op_Equality(SadRogue.Primitives.GridViews.ValueChange%7B%600%7D%2CSadRogue.Primitives.GridViews.ValueChange%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L79">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_op_Equality_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.op_Equality*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_op_Equality_SadRogue_Primitives_GridViews_ValueChange__0__SadRogue_Primitives_GridViews_ValueChange__0__" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.op_Equality(SadRogue.Primitives.GridViews.ValueChange{`0},SadRogue.Primitives.GridViews.ValueChange{`0})">Equality(ValueChange&lt;T&gt;, ValueChange&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Tests the two changes by their fields for equality.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool operator ==(ValueChange&lt;T&gt; left, ValueChange&lt;T&gt; right)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">left</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">right</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if all the changes are equivalent; false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1_op_Inequality_SadRogue_Primitives_GridViews_ValueChange__0__SadRogue_Primitives_GridViews_ValueChange__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601.op_Inequality(SadRogue.Primitives.GridViews.ValueChange%7B%600%7D%2CSadRogue.Primitives.GridViews.ValueChange%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L87">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_ValueChange_1_op_Inequality_" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.op_Inequality*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_ValueChange_1_op_Inequality_SadRogue_Primitives_GridViews_ValueChange__0__SadRogue_Primitives_GridViews_ValueChange__0__" data-uid="SadRogue.Primitives.GridViews.ValueChange`1.op_Inequality(SadRogue.Primitives.GridViews.ValueChange{`0},SadRogue.Primitives.GridViews.ValueChange{`0})">Inequality(ValueChange&lt;T&gt;, ValueChange&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Tests the two changes by their fields for inequality.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool operator !=(ValueChange&lt;T&gt; left, ValueChange&lt;T&gt; right)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">left</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">right</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if all the changes are equivalent; false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_ValueChange_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.ValueChange%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/DiffAwareGridView.cs/#L13" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.Viewport-1.html
+++ b/docs/api/SadRogue.Primitives.GridViews.Viewport-1.html
@@ -1,0 +1,661 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class Viewport&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class Viewport&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews.Viewport`1">
+  
+  
+  <h1 id="SadRogue_Primitives_GridViews_Viewport_1" data-uid="SadRogue.Primitives.GridViews.Viewport`1" class="text-break">Class Viewport&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Implements <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> to expose a &quot;viewport&quot;, or sub-area, of another grid view.
+Its indexers perform relative to absolute coordinate translations based on the viewport size/location, and
+return the proper value of type T from the underlying view.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase</a>&lt;T&gt;</div>
+    <div class="level2"><span class="xref">Viewport&lt;T&gt;</span></div>
+      <div class="level3"><a class="xref" href="SadRogue.Primitives.GridViews.SettableViewport-1.html">SettableViewport&lt;T&gt;</a></div>
+  </div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count">GridViewBase&lt;T&gt;.Count</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_">GridViewBase&lt;T&gt;.Item[Int32, Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_">GridViewBase&lt;T&gt;.Item[Int32]</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.GridViews.html">SadRogue.Primitives.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_GridViews_Viewport_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public class Viewport&lt;T&gt; : GridViewBase&lt;T&gt;, IGridView&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>The type being exposed by the Viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_Viewport_1_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>This implementation restricts the subsection of the view that is presented in such a way that no part
+of the viewport can be outside the boundary of its parent grid view.  The viewport cannot be bigger than
+the underlying grid view, and the viewport's position is &quot;locked&quot; to the edge so that it cannot be set in such a
+way that a portion of the viewport lies outside the bounds of the parent view.  If you would rather allow this
+and return a default value for locations outside the parent grid view, see <a class="xref" href="SadRogue.Primitives.GridViews.UnboundedViewport-1.html">UnboundedViewport&lt;T&gt;</a>.</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L37">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1__ctor_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__" data-uid="SadRogue.Primitives.GridViews.Viewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0})">Viewport(IGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the map view to represent. The viewport will represent the entire given map view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Viewport(IGridView&lt;T&gt; gridView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td><p>The map view to represent.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.%23ctor(SadRogue.Primitives.GridViews.IGridView%7B%600%7D%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L27">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1__ctor_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},SadRogue.Primitives.Rectangle)">Viewport(IGridView&lt;T&gt;, Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Constructor. Takes the parent grid view, and the initial subsection of that grid view to represent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Viewport(IGridView&lt;T&gt; gridView, Rectangle viewArea)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">gridView</span></td>
+        <td><p>The grid view being represented.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">viewArea</span></td>
+        <td><p>The initial subsection of that grid view to represent.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_GridView.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.GridView%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L44">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_GridView_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.GridView*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_GridView" data-uid="SadRogue.Primitives.GridViews.Viewport`1.GridView">GridView</h4>
+  <div class="markdown level1 summary"><p>The grid view that this Viewport is exposing values from.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IGridView&lt;T&gt; GridView { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L55">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_Height_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.Height*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_Height" data-uid="SadRogue.Primitives.GridViews.Viewport`1.Height">Height</h4>
+  <div class="markdown level1 summary"><p>The height of the area being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Height { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Height</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_Item_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.Item(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L72">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_Item_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.Item*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_Item_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.Item(SadRogue.Primitives.Point)">Item[Point]</h4>
+  <div class="markdown level1 summary"><p>Given a position in relative coordinates, returns the &quot;value&quot; associated with that
+location in absolute coordinates.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override T this[Point relativePosition] { get; }</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">relativePosition</span></td>
+        <td><p>Viewport-relative position of the location to retrieve the value for.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><p>The &quot;value&quot; associated with the absolute location represented on the underlying grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Item[SadRogue.Primitives.Point]</span></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_ViewArea.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.ViewArea%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L50">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_ViewArea_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ViewArea*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_ViewArea" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ViewArea">ViewArea</h4>
+  <div class="markdown level1 summary"><p>The area of <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_GridView">GridView</a> that this Viewport is exposing.  Use <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_SadRogue_Primitives_Rectangle_">SetViewArea(Rectangle)</a>
+to set the viewing area.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public Rectangle ViewArea { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L60">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_Width_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.Width*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_Width" data-uid="SadRogue.Primitives.GridViews.Viewport`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>The width of the area being represented.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int Width { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadRogue.Primitives.GridViews.GridViewBase&lt;T&gt;.Width</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.SetViewArea(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L79">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.SetViewArea*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.SetViewArea(SadRogue.Primitives.Rectangle)">SetViewArea(Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Sets the viewing area for the viewport to the value given.  The viewport will automatically be bounded as
+needed to ensure that it remains within the bounds of the underlying IGridView.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public void SetViewArea(Rectangle viewArea)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">viewArea</span></td>
+        <td><p>The new view area.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L85">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_ToString_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_ToString" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values inside the viewport.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the values inside the viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.ToString(System.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L95">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_ToString_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ToString(System.Func{`0,System.String})">ToString(Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values inside the viewport, using
+<code data-dev-comment-type="paramref" class="paramref">elementStringifier</code> to determine what string represents each value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(Func&lt;T, string&gt; elementStringifier)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function determining the string representation of each element.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values inside the viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Int32_System_Func__0_System_String__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601.ToString(System.Int32%2CSystem.Func%7B%600%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L116">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_GridViews_Viewport_1_ToString_" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ToString*"></a>
+  <h4 id="SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Int32_System_Func__0_System_String__" data-uid="SadRogue.Primitives.GridViews.Viewport`1.ToString(System.Int32,System.Func{`0,System.String})">ToString(Int32, Func&lt;T, String&gt;)</h4>
+  <div class="markdown level1 summary"><p>Returns a string representation of the grid values inside the viewport, using the function specified to
+turn elements into strings, and using the &quot;field length&quot; specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public string ToString(int fieldSize, Func&lt;T, string&gt; elementStringifier = null)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">fieldSize</span></td>
+        <td><p>The size of the field to give each value.  A positive-number
+right-aligns the text within the field, while a negative number left-aligns the text.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;T, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>&gt;</td>
+        <td><span class="parametername">elementStringifier</span></td>
+        <td><p>Function to use to convert each element to a string. null defaults to the ToString
+function of type T.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A string representation of the grid values inside the viewport.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Int32_System_Func__0_System_String___remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Each element of type T will have spaces added to cause it to take up exactly
+<code data-dev-comment-type="paramref" class="paramref">fieldSize</code> characters, provided <code data-dev-comment-type="paramref" class="paramref">fieldSize</code>
+is less than the length of the element's string representation.</p>
+</div>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Bounds&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Int32, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_">GridViewExtensions.Contains&lt;T&gt;(IGridView&lt;T&gt;, Point)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_">GridViewExtensions.ExtendToString&lt;T&gt;(IGridView&lt;T&gt;, Int32, String, String, Func&lt;T, String&gt;, String, String, String, String)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__">GridViewExtensions.Positions&lt;T&gt;(IGridView&lt;T&gt;)</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_GridViews_Viewport_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.GridViews.Viewport%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/GridViews/Viewport.cs/#L18" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.GridViews.html
+++ b/docs/api/SadRogue.Primitives.GridViews.html
@@ -1,0 +1,201 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace SadRogue.Primitives.GridViews
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace SadRogue.Primitives.GridViews
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.GridViews">
+  
+  <h1 id="SadRogue_Primitives_GridViews" data-uid="SadRogue.Primitives.GridViews" class="text-break">Namespace SadRogue.Primitives.GridViews
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="classes">Classes
+  </h3>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a></h4>
+      <section><p>Implementation of <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> that uses a 1D array to store data.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView2D-1.html">ArrayView2D&lt;T&gt;</a></h4>
+      <section><p>Implementation of <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> that uses a 2D array to store data.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff&lt;T&gt;</a></h4>
+      <section><p>Represents a unique patch/diff of the state of a <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a></h4>
+      <section><p>A grid view wrapper useful for recording diffs (change-sets) of changes to a grid view, and applying/removing
+those change-sets of values from the grid view.  Only works with grid views of value types.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase&lt;T&gt;</a></h4>
+      <section><p>A convenient base class to inherit from when implementing <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> that minimizes
+the number of items you must implement by implementing indexers in terms of a single indexer taking a Point.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.GridViewExtensions.html">GridViewExtensions</a></h4>
+      <section><p>Extensions for <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> implementations that provide basic utility functions
+for them.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html">LambdaGridView&lt;T&gt;</a></h4>
+      <section><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>, by providing the &quot;get&quot; functionality via a function that is
+passed in at construction.  For a version that implements <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>, see
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html">LambdaSettableGridView&lt;T&gt;</a></h4>
+      <section><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>, by providing the &quot;get&quot; and &quot;set&quot; functionality via
+functions that are passed in at construction.  For a version that implements <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a>, see
+<a class="xref" href="SadRogue.Primitives.GridViews.LambdaGridView-1.html">LambdaGridView&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html">LambdaSettableTranslationGridView&lt;T1, T2&gt;</a></h4>
+      <section><p>A simple <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView&lt;T1, T2&gt;</a> implementation that allows you to provide
+functions/lambdas for the translation functions. For a version offering only &quot;get&quot; functionality,
+see <a class="xref" href="SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html">LambdaTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html">LambdaTranslationGridView&lt;T1, T2&gt;</a></h4>
+      <section><p>A simple <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a> implementation that allows you to provide a function/lambda
+at construction to use as the <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_">TranslateGet(Point, T1)</a> implementation.
+For a version offering &quot;set&quot; functionality, see <a class="xref" href="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html">LambdaSettableTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a></h4>
+      <section><p>A convenient base class to inherit from when implementing <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> that minimizes
+the number of items you must implement by implementing indexers in terms of a single indexer taking a Point.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView&lt;T1, T2&gt;</a></h4>
+      <section><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a> by providing a functions that translate values from one
+grid view with complex data types, to a grid view with simple data types, and vice versa.  For a version that
+provides only &quot;get&quot; functionality, see <a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.SettableViewport-1.html">SettableViewport&lt;T&gt;</a></h4>
+      <section><p>Similar to <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a>, but implements <a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a>and thus implements
+&quot;set&quot; functionality via relative coordinates.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.TranslationGridView-2.html">TranslationGridView&lt;T1, T2&gt;</a></h4>
+      <section><p>Class implementing <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> by providing a function that translates values from one grid view
+with complex data types, to a grid view with simple data types.  For a version that provides &quot;set&quot;
+functionality, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html">SettableTranslationGridView&lt;T1, T2&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.UnboundedViewport-1.html">UnboundedViewport&lt;T&gt;</a></h4>
+      <section><p>Similar to <a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a>, except that the view area is in no way bounded to the edges of the
+underlying grid view.  Instead, if you access a position that cannot map to any valid position in the underlying
+grid view, a (specified) default value is returned.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.Viewport-1.html">Viewport&lt;T&gt;</a></h4>
+      <section><p>Implements <a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a> to expose a &quot;viewport&quot;, or sub-area, of another grid view.
+Its indexers perform relative to absolute coordinate translations based on the viewport size/location, and
+return the proper value of type T from the underlying view.</p>
+</section>
+    <h3 id="structs">Structs
+  </h3>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange&lt;T&gt;</a></h4>
+      <section><p>Records a value change in a diff as recorded by a <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</section>
+    <h3 id="interfaces">Interfaces
+  </h3>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.IGridView-1.html">IGridView&lt;T&gt;</a></h4>
+      <section><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate on a grid of some sort.  For a concrete implementation to subclass for custom
+implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.GridViewBase-1.html">GridViewBase&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView&lt;T&gt;</a></h4>
+      <section><p>Interface designed to act as a standardized input/output format that defines minimal required data
+for algorithms that operate and make changes to a grid of some sort.  For a concrete implementation to subclass
+for custom implementations, see <a class="xref" href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html">SettableGridViewBase&lt;T&gt;</a>.</p>
+</section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.IMatchable-1.html
+++ b/docs/api/SadRogue.Primitives.IMatchable-1.html
@@ -1,0 +1,196 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Interface IMatchable&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Interface IMatchable&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.IMatchable`1">
+  
+  
+  <h1 id="SadRogue_Primitives_IMatchable_1" data-uid="SadRogue.Primitives.IMatchable`1" class="text-break">Interface IMatchable&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Interface implemented to define a form of checking value equality, without guarantees that it corresponds
+to GetHashCode.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_IMatchable_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public interface IMatchable&lt;in T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of object being compared.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IMatchable_1_Matches__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IMatchable%601.Matches(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IMatchable.cs/#L18">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_IMatchable_1_Matches_" data-uid="SadRogue.Primitives.IMatchable`1.Matches*"></a>
+  <h4 id="SadRogue_Primitives_IMatchable_1_Matches__0_" data-uid="SadRogue.Primitives.IMatchable`1.Matches(`0)">Matches(T)</h4>
+  <div class="markdown level1 summary"><p>Returns true if the given object is considered &quot;equal&quot; to the current one, based on the definition
+of equality for the object.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">bool Matches(T other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Object to compare to.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the objects are considered equal, false, otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IMatchable_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IMatchable%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IMatchable.cs/#L10" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.IReadOnlyArea.html
+++ b/docs/api/SadRogue.Primitives.IReadOnlyArea.html
@@ -73,14 +73,23 @@
   
   <h1 id="SadRogue_Primitives_IReadOnlyArea" data-uid="SadRogue.Primitives.IReadOnlyArea" class="text-break">Interface IReadOnlyArea
   </h1>
-  <div class="markdown level0 summary"><p>Read-only interface for an arbitry 2D area.</p>
+  <div class="markdown level0 summary"><p>Read-only interface for an arbitrary 2D area.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html#SadRogue_Primitives_IMatchable_1_Matches__0_">IMatchable&lt;IReadOnlyArea&gt;.Matches(IReadOnlyArea)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1.getenumerator#System_Collections_Generic_IEnumerable_1_GetEnumerator">IEnumerable&lt;Point&gt;.GetEnumerator()</a>
+    </div>
+  </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_IReadOnlyArea_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public interface IReadOnlyArea</code></pre>
+    <pre><code class="lang-csharp hljs">public interface IReadOnlyArea : IMatchable&lt;IReadOnlyArea&gt;, IEnumerable&lt;Point&gt;, IEnumerable</code></pre>
   </div>
   <h3 id="properties">Properties
   </h3>
@@ -141,27 +150,45 @@
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IReadOnlyArea_Positions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IReadOnlyArea.Positions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IReadOnlyArea_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IReadOnlyArea.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L23">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L24">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_IReadOnlyArea_Positions_" data-uid="SadRogue.Primitives.IReadOnlyArea.Positions*"></a>
-  <h4 id="SadRogue_Primitives_IReadOnlyArea_Positions" data-uid="SadRogue.Primitives.IReadOnlyArea.Positions">Positions</h4>
-  <div class="markdown level1 summary"><p>List of all (unique) positions in the current area.</p>
+  <a id="SadRogue_Primitives_IReadOnlyArea_Item_" data-uid="SadRogue.Primitives.IReadOnlyArea.Item*"></a>
+  <h4 id="SadRogue_Primitives_IReadOnlyArea_Item_System_Int32_" data-uid="SadRogue.Primitives.IReadOnlyArea.Item(System.Int32)">Item[Int32]</h4>
+  <div class="markdown level1 summary"><p>Returns positions from the area in the same fashion you would via a list.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">IReadOnlyList&lt;Point&gt; Positions { get; }</code></pre>
+    <pre><code class="lang-csharp hljs">Point this[int index] { get; }</code></pre>
   </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">index</span></td>
+        <td><p>Index of list to retrieve.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,7 +199,7 @@
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IReadOnlyList</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -184,7 +211,7 @@
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IReadOnlyArea_Contains_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IReadOnlyArea.Contains(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L32">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L33">View Source</a>
   </span>
   <a id="SadRogue_Primitives_IReadOnlyArea_Contains_" data-uid="SadRogue.Primitives.IReadOnlyArea.Contains*"></a>
   <h4 id="SadRogue_Primitives_IReadOnlyArea_Contains_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.IReadOnlyArea.Contains(SadRogue.Primitives.IReadOnlyArea)">Contains(IReadOnlyArea)</h4>
@@ -223,7 +250,7 @@
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the given area is completely contained within the current one, false otherwise.</p>
 </td>
       </tr>
@@ -234,7 +261,7 @@
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IReadOnlyArea_Contains_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IReadOnlyArea.Contains(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L39">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L40">View Source</a>
   </span>
   <a id="SadRogue_Primitives_IReadOnlyArea_Contains_" data-uid="SadRogue.Primitives.IReadOnlyArea.Contains*"></a>
   <h4 id="SadRogue_Primitives_IReadOnlyArea_Contains_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.IReadOnlyArea.Contains(SadRogue.Primitives.Point)">Contains(Point)</h4>
@@ -273,7 +300,63 @@
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the specified position is within the area, false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IReadOnlyArea_Contains_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IReadOnlyArea.Contains(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L48">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_IReadOnlyArea_Contains_" data-uid="SadRogue.Primitives.IReadOnlyArea.Contains*"></a>
+  <h4 id="SadRogue_Primitives_IReadOnlyArea_Contains_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.IReadOnlyArea.Contains(System.Int32,System.Int32)">Contains(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Determines whether or not the given position is considered within the area or not.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">bool Contains(int positionX, int positionY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionX</span></td>
+        <td><p>X-value of the position to check.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">positionY</span></td>
+        <td><p>X-value of the position to check.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the specified position is within the area, false otherwise.</p>
 </td>
       </tr>
@@ -284,7 +367,7 @@
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_IReadOnlyArea_Intersects_SadRogue_Primitives_IReadOnlyArea_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.IReadOnlyArea.Intersects(SadRogue.Primitives.IReadOnlyArea)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L49">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/IReadOnlyArea.cs/#L58">View Source</a>
   </span>
   <a id="SadRogue_Primitives_IReadOnlyArea_Intersects_" data-uid="SadRogue.Primitives.IReadOnlyArea.Intersects*"></a>
   <h4 id="SadRogue_Primitives_IReadOnlyArea_Intersects_SadRogue_Primitives_IReadOnlyArea_" data-uid="SadRogue.Primitives.IReadOnlyArea.Intersects(SadRogue.Primitives.IReadOnlyArea)">Intersects(IReadOnlyArea)</h4>
@@ -326,7 +409,7 @@ of positions in the result (0 if no intersection).</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the given area intersects the current one, false otherwise.</p>
 </td>
       </tr>

--- a/docs/api/SadRogue.Primitives.MathHelpers.html
+++ b/docs/api/SadRogue.Primitives.MathHelpers.html
@@ -79,31 +79,31 @@ for performing operations on a 2D grid.</p>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">MathHelpers</span></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetHashCode()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
@@ -139,7 +139,67 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_DegreesToRadiansConstant.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.DegreesToRadiansConstant%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L20">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_MathHelpers_DegreesToRadiansConstant" data-uid="SadRogue.Primitives.MathHelpers.DegreesToRadiansConstant">DegreesToRadiansConstant</h4>
+  <div class="markdown level1 summary"><p>Pi / 180. Used to speed up calculations related to circles.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public const double DegreesToRadiansConstant = 0.017453292519943295</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_RadiansToDegreesConstant.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.RadiansToDegreesConstant%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L25">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_MathHelpers_RadiansToDegreesConstant" data-uid="SadRogue.Primitives.MathHelpers.RadiansToDegreesConstant">RadiansToDegreesConstant</h4>
+  <div class="markdown level1 summary"><p>180 / Pi. Used to speed up calculations related to circles.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public const double RadiansToDegreesConstant = 57.295779513082323</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -151,7 +211,7 @@ for performing operations on a 2D grid.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_Clamp_System_Double_System_Double_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.Clamp(System.Double%2CSystem.Double%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L84">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L88">View Source</a>
   </span>
   <a id="SadRogue_Primitives_MathHelpers_Clamp_" data-uid="SadRogue.Primitives.MathHelpers.Clamp*"></a>
   <h4 id="SadRogue_Primitives_MathHelpers_Clamp_System_Double_System_Double_System_Double_" data-uid="SadRogue.Primitives.MathHelpers.Clamp(System.Double,System.Double,System.Double)">Clamp(Double, Double, Double)</h4>
@@ -173,19 +233,19 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">value</span></td>
         <td><p>The value to restrict.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">min</span></td>
         <td><p>The minimum to clamp the value to.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">max</span></td>
         <td><p>The maximum to clamp the value to.</p>
 </td>
@@ -202,7 +262,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The clamped value.</p>
 </td>
       </tr>
@@ -213,7 +273,7 @@ for performing operations on a 2D grid.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_Clamp_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.Clamp(System.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L38">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L50">View Source</a>
   </span>
   <a id="SadRogue_Primitives_MathHelpers_Clamp_" data-uid="SadRogue.Primitives.MathHelpers.Clamp*"></a>
   <h4 id="SadRogue_Primitives_MathHelpers_Clamp_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.MathHelpers.Clamp(System.Int32,System.Int32,System.Int32)">Clamp(Int32, Int32, Int32)</h4>
@@ -235,19 +295,19 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">value</span></td>
         <td><p>The value to restrict.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">min</span></td>
         <td><p>The minimum to clamp the value to.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">max</span></td>
         <td><p>The maximum to clamp the value to.</p>
 </td>
@@ -264,7 +324,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The clamped value.</p>
 </td>
       </tr>
@@ -275,7 +335,7 @@ for performing operations on a 2D grid.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_Clamp_System_Single_System_Single_System_Single_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.Clamp(System.Single%2CSystem.Single%2CSystem.Single)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L61">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L69">View Source</a>
   </span>
   <a id="SadRogue_Primitives_MathHelpers_Clamp_" data-uid="SadRogue.Primitives.MathHelpers.Clamp*"></a>
   <h4 id="SadRogue_Primitives_MathHelpers_Clamp_System_Single_System_Single_System_Single_" data-uid="SadRogue.Primitives.MathHelpers.Clamp(System.Single,System.Single,System.Single)">Clamp(Single, Single, Single)</h4>
@@ -297,19 +357,19 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">value</span></td>
         <td><p>The value to restrict.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">min</span></td>
         <td><p>The minimum to clamp the value to.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">max</span></td>
         <td><p>The maximum to clamp the value to.</p>
 </td>
@@ -326,7 +386,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><p>The clamped value.</p>
 </td>
       </tr>
@@ -359,19 +419,19 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">value1</span></td>
         <td><p>Starting value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">value2</span></td>
         <td><p>Ending value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">amount</span></td>
         <td><p>The weight to apply to <code data-dev-comment-type="paramref" class="paramref">value2</code>.</p>
 </td>
@@ -388,7 +448,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -420,19 +480,19 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">value1</span></td>
         <td><p>Starting value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">value2</span></td>
         <td><p>Ending value.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">amount</span></td>
         <td><p>The weight to apply to <code data-dev-comment-type="paramref" class="paramref">value2</code>.</p>
 </td>
@@ -449,7 +509,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -459,7 +519,7 @@ for performing operations on a 2D grid.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_ToDegree_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.ToDegree(System.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L22">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L32">View Source</a>
   </span>
   <a id="SadRogue_Primitives_MathHelpers_ToDegree_" data-uid="SadRogue.Primitives.MathHelpers.ToDegree*"></a>
   <h4 id="SadRogue_Primitives_MathHelpers_ToDegree_System_Double_" data-uid="SadRogue.Primitives.MathHelpers.ToDegree(System.Double)">ToDegree(Double)</h4>
@@ -481,7 +541,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">radAngle</span></td>
         <td><p>Angle in radians.</p>
 </td>
@@ -498,7 +558,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The given angle in degrees.</p>
 </td>
       </tr>
@@ -509,7 +569,7 @@ for performing operations on a 2D grid.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_MathHelpers_ToRadian_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.MathHelpers.ToRadian(System.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L29">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/MathHelpers.cs/#L40">View Source</a>
   </span>
   <a id="SadRogue_Primitives_MathHelpers_ToRadian_" data-uid="SadRogue.Primitives.MathHelpers.ToRadian*"></a>
   <h4 id="SadRogue_Primitives_MathHelpers_ToRadian_System_Double_" data-uid="SadRogue.Primitives.MathHelpers.ToRadian(System.Double)">ToRadian(Double)</h4>
@@ -531,7 +591,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">degAngle</span></td>
         <td><p>Angle in degrees.</p>
 </td>
@@ -548,7 +608,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The given angle in radians.</p>
 </td>
       </tr>
@@ -581,19 +641,19 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">value</span></td>
         <td><p>The value to wrap.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">min</span></td>
         <td><p>The minimum value before it transforms into the maximum.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><span class="parametername">max</span></td>
         <td><p>The maximum value before it transforms into the minimum.</p>
 </td>
@@ -610,7 +670,7 @@ for performing operations on a 2D grid.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Single</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
         <td><p>A new value if it falls outside the min/max range otherwise, the same value.</p>
 </td>
       </tr>

--- a/docs/api/SadRogue.Primitives.Palette.html
+++ b/docs/api/SadRogue.Primitives.Palette.html
@@ -78,44 +78,45 @@
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">Palette</span></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</div>
-    <div><span class="xref">System.Collections.IEnumerable</span></div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">IEnumerable</a></div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetHashCode()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Palette_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public class Palette : IEnumerable&lt;Color&gt;, IEnumerable, IMatchable&lt;Palette&gt;</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -146,7 +147,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</td>
         <td><span class="parametername">colors</span></td>
         <td><p>The list of colors this palette is made from.</p>
 </td>
@@ -158,7 +159,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette__ctor_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.%23ctor(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L35">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L37">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Palette__ctor_" data-uid="SadRogue.Primitives.Palette.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Palette__ctor_System_Int32_" data-uid="SadRogue.Primitives.Palette.#ctor(System.Int32)">Palette(Int32)</h4>
@@ -180,7 +181,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">colors</span></td>
         <td><p>The number of colors.</p>
 </td>
@@ -194,7 +195,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette_Item_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L25">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L27">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Palette_Item_" data-uid="SadRogue.Primitives.Palette.Item*"></a>
   <h4 id="SadRogue_Primitives_Palette_Item_System_Int32_" data-uid="SadRogue.Primitives.Palette.Item(System.Int32)">Item[Int32]</h4>
@@ -216,7 +217,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">index</span></td>
         <td><p>Index of the color.</p>
 </td>
@@ -244,7 +245,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette_Length.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.Length%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L18">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L20">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Palette_Length_" data-uid="SadRogue.Primitives.Palette.Length*"></a>
   <h4 id="SadRogue_Primitives_Palette_Length" data-uid="SadRogue.Primitives.Palette.Length">Length</h4>
@@ -265,7 +266,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -277,7 +278,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L129">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L132">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Palette_GetEnumerator_" data-uid="SadRogue.Primitives.Palette.GetEnumerator*"></a>
   <h4 id="SadRogue_Primitives_Palette_GetEnumerator" data-uid="SadRogue.Primitives.Palette.GetEnumerator">GetEnumerator()</h4>
@@ -298,7 +299,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerator</span>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1">IEnumerator</a>&lt;<a class="xref" href="SadRogue.Primitives.Color.html">Color</a>&gt;</td>
         <td><p>The colors in the palette.</p>
 </td>
       </tr>
@@ -359,7 +360,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette_GetNearestIndex_SadRogue_Primitives_Color_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.GetNearestIndex(SadRogue.Primitives.Color)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L107">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L108">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Palette_GetNearestIndex_" data-uid="SadRogue.Primitives.Palette.GetNearestIndex*"></a>
   <h4 id="SadRogue_Primitives_Palette_GetNearestIndex_SadRogue_Primitives_Color_" data-uid="SadRogue.Primitives.Palette.GetNearestIndex(SadRogue.Primitives.Color)">GetNearestIndex(Color)</h4>
@@ -398,8 +399,57 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The palette index of the closest color.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette_Matches_SadRogue_Primitives_Palette_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.Matches(SadRogue.Primitives.Palette)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L145">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Palette_Matches_" data-uid="SadRogue.Primitives.Palette.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Palette_Matches_SadRogue_Primitives_Palette_" data-uid="SadRogue.Primitives.Palette.Matches(SadRogue.Primitives.Palette)">Matches(Palette)</h4>
+  <div class="markdown level1 summary"><p>Returns true if the two palettes hold identical colors in the same order.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(Palette other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two palettes hold identical colors in the same order; false otherwise.</p>
 </td>
       </tr>
     </tbody>
@@ -447,13 +497,13 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">startingIndex</span></td>
         <td><p>The starting index in the palette.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">count</span></td>
         <td><p>The amount of colors to shift from the starting index.</p>
 </td>
@@ -503,13 +553,13 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">startingIndex</span></td>
         <td><p>The starting index in the palette.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">count</span></td>
         <td><p>The amount of colors to shift from the starting index.</p>
 </td>
@@ -523,7 +573,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L135">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L138">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Palette_System_Collections_IEnumerable_GetEnumerator_" data-uid="SadRogue.Primitives.Palette.System#Collections#IEnumerable#GetEnumerator*"></a>
   <h4 id="SadRogue_Primitives_Palette_System_Collections_IEnumerable_GetEnumerator" data-uid="SadRogue.Primitives.Palette.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h4>
@@ -544,7 +594,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.IEnumerator</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerator">IEnumerator</a></td>
         <td><p>The colors in the palette.</p>
 </td>
       </tr>
@@ -552,10 +602,13 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.Collections.Generic.IEnumerable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">System.Collections.Generic.IEnumerable&lt;T&gt;</a>
   </div>
   <div>
-      <span class="xref">System.Collections.IEnumerable</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.ienumerable">System.Collections.IEnumerable</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -568,7 +621,7 @@ public class Palette : IEnumerable&lt;Color&gt;, IEnumerable</code></pre>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Palette.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Palette%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L10" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Palette.cs/#L12" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Point.html
+++ b/docs/api/SadRogue.Primitives.Point.html
@@ -79,32 +79,34 @@ common grid/position-related math and operations.</p>
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</div>
-    <div><span class="xref">System.IEquatable</span>&lt;<span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Point_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct Point : IEquatable&lt;Point&gt;, IEquatable&lt;(int x, int y)&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct Point : IEquatable&lt;Point&gt;, IEquatable&lt;(int x, int y)&gt;, IMatchable&lt;Point&gt;, IMatchable&lt;(int x, int y)&gt;</code></pre>
   </div>
   <h5 id="SadRogue_Primitives_Point_remarks"><strong>Remarks</strong></h5>
   <div class="markdown level0 remarks"><p>Point instances can be created using the standard Point c = new Point(x, y) syntax.  In addition,
 you may create a coord from a c# 7 tuple, like Point c = (x, y);.  As well, Point supports C#
-Deconstrution syntax.</p>
+Deconstruction syntax.</p>
 <p>Point also provides operators and static helper functions that perform common grid math/operations,
 as well as interoperability with other grid-based classes like <a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a>.</p>
 </div>
@@ -115,7 +117,7 @@ as well as interoperability with other grid-based classes like <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point__ctor_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.%23ctor(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L46">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L49">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point__ctor_" data-uid="SadRogue.Primitives.Point.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Point__ctor_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.#ctor(System.Int32,System.Int32)">Point(Int32, Int32)</h4>
@@ -137,13 +139,13 @@ as well as interoperability with other grid-based classes like <a class="xref" h
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>X-value for the coordinate.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>Y-value for the coordinate.</p>
 </td>
@@ -157,7 +159,7 @@ as well as interoperability with other grid-based classes like <a class="xref" h
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_None.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.None%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L29">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L32">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Point_None" data-uid="SadRogue.Primitives.Point.None">None</h4>
   <div class="markdown level1 summary"><p>Point value that represents None or no position (since Point is not a nullable type).
@@ -166,8 +168,7 @@ Typically you would use this constant instead of null.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Point None</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Point None</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -193,7 +194,7 @@ x/y values is not considered a valid coordinate by many functions.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_X.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L34">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L37">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Point_X" data-uid="SadRogue.Primitives.Point.X">X</h4>
   <div class="markdown level1 summary"><p>X-value of the position.</p>
@@ -201,7 +202,8 @@ x/y values is not considered a valid coordinate by many functions.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly int X</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly int X</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -213,7 +215,7 @@ x/y values is not considered a valid coordinate by many functions.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -223,7 +225,7 @@ x/y values is not considered a valid coordinate by many functions.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Y.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L39">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L42">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Point_Y" data-uid="SadRogue.Primitives.Point.Y">Y</h4>
   <div class="markdown level1 summary"><p>Y-value of the position.</p>
@@ -231,7 +233,8 @@ x/y values is not considered a valid coordinate by many functions.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly int Y</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly int Y</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -243,7 +246,7 @@ x/y values is not considered a valid coordinate by many functions.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -255,17 +258,18 @@ x/y values is not considered a valid coordinate by many functions.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_BearingOfLine_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.BearingOfLine(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L70">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L88">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_BearingOfLine_" data-uid="SadRogue.Primitives.Point.BearingOfLine*"></a>
   <h4 id="SadRogue_Primitives_Point_BearingOfLine_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.BearingOfLine(SadRogue.Primitives.Point)">BearingOfLine(Point)</h4>
   <div class="markdown level1 summary"><p>Calculates the degree bearing of a line with the given delta-x and delta-y values, where
-0 degreees points in the direction <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a>.</p>
+0 degrees points in the direction <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static double BearingOfLine(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double BearingOfLine(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -296,7 +300,7 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The degree bearing of the line with the given dx and dy values.</p>
 </td>
       </tr>
@@ -307,7 +311,7 @@ is the change in y-values across the line.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_BearingOfLine_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.BearingOfLine(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L58">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L61">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_BearingOfLine_" data-uid="SadRogue.Primitives.Point.BearingOfLine*"></a>
   <h4 id="SadRogue_Primitives_Point_BearingOfLine_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.BearingOfLine(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">BearingOfLine(Point, Point)</h4>
@@ -316,7 +320,8 @@ is the change in y-values across the line.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static double BearingOfLine(Point start, Point end)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double BearingOfLine(Point start, Point end)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -352,7 +357,7 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The degree bearing of the line specified by the two given points.</p>
 </td>
       </tr>
@@ -360,19 +365,21 @@ is the change in y-values across the line.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Deconstruct_System_Int32__System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Deconstruct(System.Int32%40%2CSystem.Int32%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_BearingOfLine_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.BearingOfLine(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L353">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L109">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Point_Deconstruct_" data-uid="SadRogue.Primitives.Point.Deconstruct*"></a>
-  <h4 id="SadRogue_Primitives_Point_Deconstruct_System_Int32__System_Int32__" data-uid="SadRogue.Primitives.Point.Deconstruct(System.Int32@,System.Int32@)">Deconstruct(out Int32, out Int32)</h4>
-  <div class="markdown level1 summary"><p>Adds support for C# Deconstruction syntax.</p>
+  <a id="SadRogue_Primitives_Point_BearingOfLine_" data-uid="SadRogue.Primitives.Point.BearingOfLine*"></a>
+  <h4 id="SadRogue_Primitives_Point_BearingOfLine_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.BearingOfLine(System.Int32,System.Int32)">BearingOfLine(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Calculates the degree bearing of a line with the given delta-x and delta-y values, where
+0 degrees points in the direction <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out int x, out int y)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double BearingOfLine(int dx, int dy)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,12 +392,138 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dx</span></td>
+        <td><p>Change in x-value across the line.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dy</span></td>
+        <td><p>Change in y-value across the line.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><p>The degree bearing of the line with the given dx and dy values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_BearingOfLine_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.BearingOfLine(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L73">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_BearingOfLine_" data-uid="SadRogue.Primitives.Point.BearingOfLine*"></a>
+  <h4 id="SadRogue_Primitives_Point_BearingOfLine_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.BearingOfLine(System.Int32,System.Int32,System.Int32,System.Int32)">BearingOfLine(Int32, Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Calculates degree bearing of the line (start =&gt; end), where 0 points in the direction <a class="xref" href="SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Up">Up</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double BearingOfLine(int startX, int startY, int endX, int endY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startX</span></td>
+        <td><p>X-value of the position of line starting point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">startY</span></td>
+        <td><p>Y-value of the position of line starting point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">endX</span></td>
+        <td><p>X-value of the position of line ending point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">endY</span></td>
+        <td><p>X-value of the position of line ending point.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><p>The degree bearing of the line specified by the two given points.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Deconstruct_System_Int32__System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Deconstruct(System.Int32%40%2CSystem.Int32%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L497">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_Deconstruct_" data-uid="SadRogue.Primitives.Point.Deconstruct*"></a>
+  <h4 id="SadRogue_Primitives_Point_Deconstruct_System_Int32__System_Int32__" data-uid="SadRogue.Primitives.Point.Deconstruct(System.Int32@,System.Int32@)">Deconstruct(out Int32, out Int32)</h4>
+  <div class="markdown level1 summary"><p>Adds support for C# Deconstruction syntax.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out int x, out int y)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td></td>
       </tr>
@@ -401,7 +534,7 @@ is the change in y-values across the line.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Equals_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Equals(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L345">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L487">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_Equals_" data-uid="SadRogue.Primitives.Point.Equals*"></a>
   <h4 id="SadRogue_Primitives_Point_Equals_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.Equals(SadRogue.Primitives.Point)">Equals(Point)</h4>
@@ -410,7 +543,8 @@ is the change in y-values across the line.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(Point other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(Point other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -440,7 +574,7 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
@@ -451,7 +585,7 @@ is the change in y-values across the line.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L280">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L400">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_Equals_" data-uid="SadRogue.Primitives.Point.Equals*"></a>
   <h4 id="SadRogue_Primitives_Point_Equals_System_Object_" data-uid="SadRogue.Primitives.Point.Equals(System.Object)">Equals(Object)</h4>
@@ -460,7 +594,8 @@ is the change in y-values across the line.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -473,7 +608,7 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td><p>The object to compare the current Point to.</p>
 </td>
@@ -490,20 +625,20 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a Coord instance, and the two positions are equal, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Equals_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Equals(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L477">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L641">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_Equals_" data-uid="SadRogue.Primitives.Point.Equals*"></a>
   <h4 id="SadRogue_Primitives_Point_Equals_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.Equals(System.ValueTuple{System.Int32,System.Int32})">Equals((Int32 x, Int32 y))</h4>
@@ -512,7 +647,8 @@ is the change in y-values across the line.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals((int x, int y) other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals((int x, int y) other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -525,9 +661,9 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">other</span></td>
-        <td><p>Point to compare.</p>
+        <td><p>Tuple to compare.</p>
 </td>
       </tr>
     </tbody>
@@ -542,7 +678,7 @@ is the change in y-values across the line.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
@@ -553,7 +689,7 @@ is the change in y-values across the line.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_EuclideanDistanceMagnitude_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.EuclideanDistanceMagnitude(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L111">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L163">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude*"></a>
   <h4 id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude(SadRogue.Primitives.Point)">EuclideanDistanceMagnitude(Point)</h4>
@@ -567,7 +703,8 @@ you're trying to compare two distances. Omitting the square root provides a spee
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static double EuclideanDistanceMagnitude(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double EuclideanDistanceMagnitude(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -598,7 +735,7 @@ deltaChange.Y is the change in y-values between the two points.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The &quot;magnitude&quot; of the euclidean distance of two locations with the given dx and dy
 values -- basically the distance formula without the square root.</p>
 </td>
@@ -610,7 +747,7 @@ values -- basically the distance formula without the square root.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_EuclideanDistanceMagnitude_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.EuclideanDistanceMagnitude(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L95">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L126">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude*"></a>
   <h4 id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">EuclideanDistanceMagnitude(Point, Point)</h4>
@@ -622,7 +759,8 @@ Omitting the square root provides a speed increase.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static double EuclideanDistanceMagnitude(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double EuclideanDistanceMagnitude(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -658,7 +796,7 @@ Omitting the square root provides a speed increase.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><p>The &quot;magnitude&quot; of the euclidean distance between the two points -- basically the
 distance formula without the square root.</p>
 </td>
@@ -667,19 +805,25 @@ distance formula without the square root.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.FromIndex(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_EuclideanDistanceMagnitude_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L246">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L180">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Point_FromIndex_" data-uid="SadRogue.Primitives.Point.FromIndex*"></a>
-  <h4 id="SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.FromIndex(System.Int32,System.Int32)">FromIndex(Int32, Int32)</h4>
-  <div class="markdown level1 summary"><p>Reverses the ToIndex functions, returning the position represented by a given index.</p>
+  <a id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude*"></a>
+  <h4 id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32,System.Int32)">EuclideanDistanceMagnitude(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the result of the euclidean distance formula, without the square root, given the
+dx and dy values between two points -- eg., (deltaChange.X * deltaChange.X) + (deltaChange.Y</p>
+<ul>
+<li>deltaChange.Y). Use this if you only care about the magnitude of the distance -- eg., if
+you're trying to compare two distances. Omitting the square root provides a speed increase.</li>
+</ul>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point FromIndex(int index, int width)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double EuclideanDistanceMagnitude(int dx, int dy)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -692,13 +836,144 @@ distance formula without the square root.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dx</span></td>
+        <td><p>Change in x-values between the two points.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dy</span></td>
+        <td><p>Change in y-values between the two points.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><p>The &quot;magnitude&quot; of the euclidean distance of two locations with the given dx and dy
+values -- basically the distance formula without the square root.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_EuclideanDistanceMagnitude_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L144">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude*"></a>
+  <h4 id="SadRogue_Primitives_Point_EuclideanDistanceMagnitude_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32,System.Int32,System.Int32,System.Int32)">EuclideanDistanceMagnitude(Int32, Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the result of the euclidean distance formula, without the square root -- eg.,
+(c2.X - c1.X) * (c2.X - c1.X) + (c2.Y - c1.Y) * (c2.Y - c1.Y). Use this if you only care
+about the magnitude of the distance -- eg., if you're trying to compare two distances.
+Omitting the square root provides a speed increase.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static double EuclideanDistanceMagnitude(int firstX, int firstY, int secondX, int secondY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">firstX</span></td>
+        <td><p>X-value for the first point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">firstY</span></td>
+        <td><p>Y-value for the first point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">secondX</span></td>
+        <td><p>X-value for the second point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">secondY</span></td>
+        <td><p>Y-value for the second point.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><p>The &quot;magnitude&quot; of the euclidean distance between the two points -- basically the
+distance formula without the square root.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.FromIndex(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L358">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_FromIndex_" data-uid="SadRogue.Primitives.Point.FromIndex*"></a>
+  <h4 id="SadRogue_Primitives_Point_FromIndex_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.FromIndex(System.Int32,System.Int32)">FromIndex(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Reverses the ToIndex functions, returning the position represented by a given index.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point FromIndex(int index, int width)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">index</span></td>
         <td><p>The index in 1D form.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width of the 2D array.</p>
 </td>
@@ -726,7 +1001,7 @@ distance formula without the square root.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L294">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L415">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_GetHashCode_" data-uid="SadRogue.Primitives.Point.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_Point_GetHashCode" data-uid="SadRogue.Primitives.Point.GetHashCode">GetHashCode()</h4>
@@ -736,7 +1011,8 @@ does not collide often.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -748,27 +1024,129 @@ does not collide often.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The hash-code for the Point.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
   <h5 id="SadRogue_Primitives_Point_GetHashCode_remarks">Remarks</h5>
-  <div class="markdown level1 remarks"><p>This hashing algorithm uses a seperate bit-mixing algorithm for <a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_X">X</a> and
-<a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Y">Y</a>, with X and Y each multiplied by a differet large integer, then xors
+  <div class="markdown level1 remarks"><p>This hashing algorithm uses a separate bit-mixing algorithm for <a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_X">X</a> and
+<a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Y">Y</a>, with X and Y each multiplied by a different large integer, then xors
 the mixed values, does a right shift, and finally multiplies by an overflowing prime
 number.  This hashing algorithm should produce an exceptionally low collision rate for
 coordinates between (0, 0) and (255, 255), and remain relatively reasonable beyond that.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Matches_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Matches(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L190">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_Matches_" data-uid="SadRogue.Primitives.Point.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Point_Matches_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.Matches(SadRogue.Primitives.Point)">Matches(Point)</h4>
+  <div class="markdown level1 summary"><p>True if the given coordinate has equal x and y values to the current one.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(Point other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Position to compare.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two positions are equal, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Matches_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Matches(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L649">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_Matches_" data-uid="SadRogue.Primitives.Point.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Point_Matches_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.Matches(System.ValueTuple{System.Int32,System.Int32})">Matches((Int32 x, Int32 y))</h4>
+  <div class="markdown level1 summary"><p>True if the given position has equal x and y values to the current one.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches((int x, int y) other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Point to compare.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two positions are equal, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Midpoint_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Midpoint(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L120">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L199">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_Midpoint_" data-uid="SadRogue.Primitives.Point.Midpoint*"></a>
   <h4 id="SadRogue_Primitives_Point_Midpoint_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.Midpoint(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Midpoint(Point, Point)</h4>
@@ -777,7 +1155,8 @@ coordinates between (0, 0) and (255, 255), and remain relatively reasonable beyo
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Midpoint(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Midpoint(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -821,19 +1200,20 @@ coordinates between (0, 0) and (255, 255), and remain relatively reasonable beyo
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToIndex_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToIndex(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Midpoint_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Midpoint(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L307">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L213">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Point_ToIndex_" data-uid="SadRogue.Primitives.Point.ToIndex*"></a>
-  <h4 id="SadRogue_Primitives_Point_ToIndex_System_Int32_" data-uid="SadRogue.Primitives.Point.ToIndex(System.Int32)">ToIndex(Int32)</h4>
-  <div class="markdown level1 summary"><p>Returns a value that can be used to uniquely index this location 1D array.</p>
+  <a id="SadRogue_Primitives_Point_Midpoint_" data-uid="SadRogue.Primitives.Point.Midpoint*"></a>
+  <h4 id="SadRogue_Primitives_Point_Midpoint_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.Midpoint(System.Int32,System.Int32,System.Int32,System.Int32)">Midpoint(Int32, Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the midpoint between the two points.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public int ToIndex(int width)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Midpoint(int firstX, int firstY, int secondX, int secondY)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -846,7 +1226,247 @@ coordinates between (0, 0) and (255, 255), and remain relatively reasonable beyo
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">firstX</span></td>
+        <td><p>X-value for the first point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">firstY</span></td>
+        <td><p>Y-value for the first point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">secondX</span></td>
+        <td><p>X-value for the second point.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">secondY</span></td>
+        <td><p>Y-value for the second point.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>The midpoint between the two points.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Rotate_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Rotate(System.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L675">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_Rotate_" data-uid="SadRogue.Primitives.Point.Rotate*"></a>
+  <h4 id="SadRogue_Primitives_Point_Rotate_System_Double_" data-uid="SadRogue.Primitives.Point.Rotate(System.Double)">Rotate(Double)</h4>
+  <div class="markdown level1 summary"><p>Rotates a single point around the origin (0, 0).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point Rotate(double degrees)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">degrees</span></td>
+        <td><p>The amount of Degrees to rotate this point clockwise</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>The equivalent point after a rotation</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Rotate_System_Double_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Rotate(System.Double%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L690">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_Rotate_" data-uid="SadRogue.Primitives.Point.Rotate*"></a>
+  <h4 id="SadRogue_Primitives_Point_Rotate_System_Double_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.Rotate(System.Double,SadRogue.Primitives.Point)">Rotate(Double, Point)</h4>
+  <div class="markdown level1 summary"><p>Rotates a single point around the origin point.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point Rotate(double degrees, Point origin)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">degrees</span></td>
+        <td><p>The amount of Degrees to rotate this point</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">origin</span></td>
+        <td><p>The Point around which to rotate</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>The equivalent point after a rotation</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Rotate_System_Double_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Rotate(System.Double%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L707">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_Rotate_" data-uid="SadRogue.Primitives.Point.Rotate*"></a>
+  <h4 id="SadRogue_Primitives_Point_Rotate_System_Double_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.Rotate(System.Double,System.Int32,System.Int32)">Rotate(Double, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Rotates a single point around the origin point.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point Rotate(double degrees, int originX, int originY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">degrees</span></td>
+        <td><p>The amount of Degrees to rotate this point</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">originX</span></td>
+        <td><p>X-value of the location around which to rotate</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">originY</span></td>
+        <td><p>Y-value of the location around which to rotate</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>The equivalent point after a rotation</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToIndex_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToIndex(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L429">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_ToIndex_" data-uid="SadRogue.Primitives.Point.ToIndex*"></a>
+  <h4 id="SadRogue_Primitives_Point_ToIndex_System_Int32_" data-uid="SadRogue.Primitives.Point.ToIndex(System.Int32)">ToIndex(Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns a value that can be used to uniquely index this location 1D array.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public int ToIndex(int width)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width of the 2D map/array this location is referring to --
 used to do the math to calculate index.</p>
@@ -864,7 +1484,7 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The 1D index of this Point.</p>
 </td>
       </tr>
@@ -875,7 +1495,7 @@ used to do the math to calculate index.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToIndex_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToIndex(System.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L255">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L369">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_ToIndex_" data-uid="SadRogue.Primitives.Point.ToIndex*"></a>
   <h4 id="SadRogue_Primitives_Point_ToIndex_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.ToIndex(System.Int32,System.Int32,System.Int32)">ToIndex(Int32, Int32, Int32)</h4>
@@ -884,7 +1504,8 @@ used to do the math to calculate index.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static int ToIndex(int x, int y, int width)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static int ToIndex(int x, int y, int width)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -897,19 +1518,19 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>X-value of the coordinate.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>Y-value of the coordinate.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width of the 2D array, used to do the math to calculate index.</p>
 </td>
@@ -926,7 +1547,7 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The 1D index of the position specified.</p>
 </td>
       </tr>
@@ -934,19 +1555,20 @@ used to do the math to calculate index.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToPolarCoordinate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToPolarCoordinate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L313">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L666">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Point_ToString_" data-uid="SadRogue.Primitives.Point.ToString*"></a>
-  <h4 id="SadRogue_Primitives_Point_ToString" data-uid="SadRogue.Primitives.Point.ToString">ToString()</h4>
-  <div class="markdown level1 summary"><p>Returns representation (X, Y).</p>
+  <a id="SadRogue_Primitives_Point_ToPolarCoordinate_" data-uid="SadRogue.Primitives.Point.ToPolarCoordinate*"></a>
+  <h4 id="SadRogue_Primitives_Point_ToPolarCoordinate" data-uid="SadRogue.Primitives.Point.ToPolarCoordinate">ToPolarCoordinate()</h4>
+  <div class="markdown level1 summary"><p>Returns a Polar Coordinate that is equivalent to this (Cartesian) Coordinate</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public PolarCoordinate ToPolarCoordinate()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -958,20 +1580,53 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><p>The Equivalent Polar Coordinate</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L437">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_ToString_" data-uid="SadRogue.Primitives.Point.ToString*"></a>
+  <h4 id="SadRogue_Primitives_Point_ToString" data-uid="SadRogue.Primitives.Point.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Returns representation (X, Y).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
         <td><p>String (X, Y)</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToXValue_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToXValue(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L263">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L379">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_ToXValue_" data-uid="SadRogue.Primitives.Point.ToXValue*"></a>
   <h4 id="SadRogue_Primitives_Point_ToXValue_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.ToXValue(System.Int32,System.Int32)">ToXValue(Int32, Int32)</h4>
@@ -980,7 +1635,8 @@ used to do the math to calculate index.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static int ToXValue(int index, int width)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static int ToXValue(int index, int width)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -993,13 +1649,13 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">index</span></td>
         <td><p>The index in 1D form.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width of the 2D array.</p>
 </td>
@@ -1016,7 +1672,7 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The X-value for the location represented by the given index.</p>
 </td>
       </tr>
@@ -1027,7 +1683,7 @@ used to do the math to calculate index.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_ToYValue_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.ToYValue(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L271">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L389">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_ToYValue_" data-uid="SadRogue.Primitives.Point.ToYValue*"></a>
   <h4 id="SadRogue_Primitives_Point_ToYValue_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.ToYValue(System.Int32,System.Int32)">ToYValue(Int32, Int32)</h4>
@@ -1036,7 +1692,8 @@ used to do the math to calculate index.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static int ToYValue(int index, int width)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static int ToYValue(int index, int width)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1049,13 +1706,13 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">index</span></td>
         <td><p>The index in 1D form.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width of the 2D array.</p>
 </td>
@@ -1072,7 +1729,7 @@ used to do the math to calculate index.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>The Y-value for the location represented by the given index.</p>
 </td>
       </tr>
@@ -1083,7 +1740,7 @@ used to do the math to calculate index.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Translate_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Translate(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L324">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L449">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_Translate_" data-uid="SadRogue.Primitives.Point.Translate*"></a>
   <h4 id="SadRogue_Primitives_Point_Translate_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.Translate(SadRogue.Primitives.Point)">Translate(Point)</h4>
@@ -1093,7 +1750,8 @@ to the Y-value of the position.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Point Translate(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point Translate(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1132,19 +1790,21 @@ delta-y value.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_WithX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.WithX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_Translate_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.Translate(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L331">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L460">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Point_WithX_" data-uid="SadRogue.Primitives.Point.WithX*"></a>
-  <h4 id="SadRogue_Primitives_Point_WithX_System_Int32_" data-uid="SadRogue.Primitives.Point.WithX(System.Int32)">WithX(Int32)</h4>
-  <div class="markdown level1 summary"><p>Creates a new Point with its X value moved to the given one.</p>
+  <a id="SadRogue_Primitives_Point_Translate_" data-uid="SadRogue.Primitives.Point.Translate*"></a>
+  <h4 id="SadRogue_Primitives_Point_Translate_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.Translate(System.Int32,System.Int32)">Translate(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns the position resulting from adding dx to the X-value of the position, and dy
+to the Y-value of the position.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Point WithX(int x)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point Translate(int dx, int dy)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1157,7 +1817,64 @@ delta-y value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dx</span></td>
+        <td><p>Change in x-value to apply.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dy</span></td>
+        <td><p>Change in y-value to apply.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>The position (<a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_X">X</a> + dx, <a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Y">Y</a> + dy)</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_WithX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.WithX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L469">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_WithX_" data-uid="SadRogue.Primitives.Point.WithX*"></a>
+  <h4 id="SadRogue_Primitives_Point_WithX_System_Int32_" data-uid="SadRogue.Primitives.Point.WithX(System.Int32)">WithX(Int32)</h4>
+  <div class="markdown level1 summary"><p>Creates a new Point with its X value moved to the given one.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point WithX(int x)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>X-value for the new Point.</p>
 </td>
@@ -1185,7 +1902,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_WithY_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.WithY(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L338">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L478">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_WithY_" data-uid="SadRogue.Primitives.Point.WithY*"></a>
   <h4 id="SadRogue_Primitives_Point_WithY_System_Int32_" data-uid="SadRogue.Primitives.Point.WithY(System.Int32)">WithY(Int32)</h4>
@@ -1194,7 +1911,8 @@ delta-y value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Point WithY(int y)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point WithY(int y)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1207,7 +1925,7 @@ delta-y value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>Y-value for the new Point.</p>
 </td>
@@ -1237,7 +1955,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L230">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L340">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Addition_" data-uid="SadRogue.Primitives.Point.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">Addition(Point, Direction)</h4>
@@ -1246,7 +1964,8 @@ delta-y value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator +(Point c, Direction d)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator +(Point c, Direction d)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1291,7 +2010,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L212">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L320">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Addition_" data-uid="SadRogue.Primitives.Point.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Addition(Point, Point)</h4>
@@ -1300,7 +2019,8 @@ delta-y value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator +(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator +(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1345,7 +2065,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L220">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L329">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Addition_" data-uid="SadRogue.Primitives.Point.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point,System.Int32)">Addition(Point, Int32)</h4>
@@ -1354,7 +2074,8 @@ delta-y value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator +(Point c, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator +(Point c, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1372,7 +2093,7 @@ delta-y value.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -1399,7 +2120,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L385">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L535">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Addition_" data-uid="SadRogue.Primitives.Point.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Addition_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.op_Addition(SadRogue.Primitives.Point,System.ValueTuple{System.Int32,System.Int32})">Addition(Point, (Int32 x, Int32 y))</h4>
@@ -1408,7 +2129,8 @@ delta-y value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator +(Point c, (int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator +(Point c, (int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1426,7 +2148,7 @@ delta-y value.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1453,7 +2175,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Addition_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Addition(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L378">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L526">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Addition_" data-uid="SadRogue.Primitives.Point.op_Addition*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Addition_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Addition(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Point)">Addition((Int32 x, Int32 y), Point)</h4>
@@ -1462,7 +2184,8 @@ delta-y value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static (int x, int y) operator +((int x, int y) tuple, Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static (int x, int y) operator +((int x, int y) tuple, Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1475,7 +2198,7 @@ delta-y value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1496,7 +2219,7 @@ delta-y value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><p>A tuple (tuple.x + c.X, tuple.y + c.Y).</p>
 </td>
       </tr>
@@ -1507,7 +2230,7 @@ delta-y value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Division_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Division(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L193">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L297">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Division_" data-uid="SadRogue.Primitives.Point.op_Division*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Division_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Division(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Division(Point, Point)</h4>
@@ -1517,7 +2240,8 @@ value to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator /(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator /(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1562,7 +2286,7 @@ value to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Division_SadRogue_Primitives_Point_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Division(SadRogue.Primitives.Point%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L203">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L309">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Division_" data-uid="SadRogue.Primitives.Point.op_Division*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Division_SadRogue_Primitives_Point_System_Double_" data-uid="SadRogue.Primitives.Point.op_Division(SadRogue.Primitives.Point,System.Double)">Division(Point, Double)</h4>
@@ -1572,7 +2296,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator /(Point c, double i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator /(Point c, double i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1590,7 +2315,7 @@ to the nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -1617,7 +2342,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Division_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Division(SadRogue.Primitives.Point%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L433">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L591">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Division_" data-uid="SadRogue.Primitives.Point.op_Division*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Division_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.op_Division(SadRogue.Primitives.Point,System.ValueTuple{System.Int32,System.Int32})">Division(Point, (Int32 x, Int32 y))</h4>
@@ -1626,7 +2351,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static (int x, int y) operator /(Point c, (int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static (int x, int y) operator /(Point c, (int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1644,7 +2370,7 @@ to the nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1660,7 +2386,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><p>Position (c.X / tuple.x, c.Y / tuple.y), with each value rounded to the nearest integer.</p>
 </td>
       </tr>
@@ -1671,7 +2397,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Division_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Division(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L424">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L580">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Division_" data-uid="SadRogue.Primitives.Point.op_Division*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Division_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Division(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Point)">Division((Int32 x, Int32 y), Point)</h4>
@@ -1680,7 +2406,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static (int x, int y) operator /((int x, int y) tuple, Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static (int x, int y) operator /((int x, int y) tuple, Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1693,7 +2420,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1714,7 +2441,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><p>Position (tuple.x / c.X, tuple.y / c.Y), with each value rounded to the nearest integer.</p>
 </td>
       </tr>
@@ -1725,7 +2452,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Equality_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Equality(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L238">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L349">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Equality_" data-uid="SadRogue.Primitives.Point.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Equality_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Equality(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Equality(Point, Point)</h4>
@@ -1734,7 +2461,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1768,7 +2496,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
@@ -1779,7 +2507,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Equality_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Equality(SadRogue.Primitives.Point%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L442">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L602">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Equality_" data-uid="SadRogue.Primitives.Point.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Equality_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.op_Equality(SadRogue.Primitives.Point,System.ValueTuple{System.Int32,System.Int32})">Equality(Point, (Int32 x, Int32 y))</h4>
@@ -1788,7 +2516,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Point c, (int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Point c, (int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1806,7 +2535,7 @@ to the nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1822,7 +2551,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
@@ -1833,7 +2562,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Equality_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Equality(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L460">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L622">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Equality_" data-uid="SadRogue.Primitives.Point.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Equality_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Equality(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Point)">Equality((Int32 x, Int32 y), Point)</h4>
@@ -1842,7 +2571,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==((int x, int y) tuple, Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==((int x, int y) tuple, Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1855,7 +2585,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1876,8 +2606,58 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Implicit_SadRogue_Primitives_Point__SadRogue_Primitives_PolarCoordinate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.PolarCoordinate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L660">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Point_op_Implicit_" data-uid="SadRogue.Primitives.Point.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Point_op_Implicit_SadRogue_Primitives_Point__SadRogue_Primitives_PolarCoordinate" data-uid="SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.PolarCoordinate">Implicit(Point to PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts a Point to its equivalent polar coordinate.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator PolarCoordinate(Point pos)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Point to convert.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><p>A <a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a> equivalent to this cartesian point.</p>
 </td>
       </tr>
     </tbody>
@@ -1887,7 +2667,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Implicit_SadRogue_Primitives_Point__System_ValueTuple_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L364">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L509">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Implicit_" data-uid="SadRogue.Primitives.Point.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Implicit_SadRogue_Primitives_Point__System_ValueTuple_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~System.ValueTuple{System.Int32,System.Int32}">Implicit(Point to (Int32 x, Int32 y))</h4>
@@ -1896,7 +2676,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator (int x, int y)(Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator (int x, int y)(Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1925,7 +2706,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td></td>
       </tr>
     </tbody>
@@ -1935,7 +2716,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Implicit_System_ValueTuple_System_Int32_System_Int32___SadRogue_Primitives_Point.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Implicit(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)~SadRogue.Primitives.Point%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L370">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L517">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Implicit_" data-uid="SadRogue.Primitives.Point.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Implicit_System_ValueTuple_System_Int32_System_Int32___SadRogue_Primitives_Point" data-uid="SadRogue.Primitives.Point.op_Implicit(System.ValueTuple{System.Int32,System.Int32})~SadRogue.Primitives.Point">Implicit((Int32 x, Int32 y) to Point)</h4>
@@ -1944,7 +2725,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator Point((int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Point((int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1957,7 +2739,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -1983,7 +2765,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Inequality_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Inequality(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L155">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L254">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Inequality_" data-uid="SadRogue.Primitives.Point.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Inequality_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Inequality(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Inequality(Point, Point)</h4>
@@ -1992,7 +2774,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2026,7 +2809,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if either the x-values or y-values are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -2037,7 +2820,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Inequality_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Inequality(SadRogue.Primitives.Point%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L452">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L613">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Inequality_" data-uid="SadRogue.Primitives.Point.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Inequality_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.op_Inequality(SadRogue.Primitives.Point,System.ValueTuple{System.Int32,System.Int32})">Inequality(Point, (Int32 x, Int32 y))</h4>
@@ -2046,7 +2829,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Point c, (int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Point c, (int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2064,7 +2848,7 @@ to the nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -2080,7 +2864,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if either the x-values or y-values are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -2091,7 +2875,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Inequality_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Inequality(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L470">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L633">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Inequality_" data-uid="SadRogue.Primitives.Point.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Inequality_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Inequality(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Point)">Inequality((Int32 x, Int32 y), Point)</h4>
@@ -2100,7 +2884,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=((int x, int y) tuple, Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=((int x, int y) tuple, Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2113,7 +2898,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -2134,7 +2919,7 @@ to the nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if either the x-values or y-values are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -2145,7 +2930,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L163">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L263">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Multiply_" data-uid="SadRogue.Primitives.Point.op_Multiply*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Multiply(Point, Point)</h4>
@@ -2154,7 +2939,8 @@ to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator *(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator *(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2199,7 +2985,7 @@ to the nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L183">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L285">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Multiply_" data-uid="SadRogue.Primitives.Point.op_Multiply*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_System_Double_" data-uid="SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point,System.Double)">Multiply(Point, Double)</h4>
@@ -2209,7 +2995,8 @@ the result to the nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator *(Point c, double i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator *(Point c, double i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2227,7 +3014,7 @@ the result to the nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -2255,7 +3042,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L171">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L272">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Multiply_" data-uid="SadRogue.Primitives.Point.op_Multiply*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point,System.Int32)">Multiply(Point, Int32)</h4>
@@ -2264,7 +3051,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator *(Point c, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator *(Point c, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2282,7 +3070,7 @@ rounded to nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -2309,7 +3097,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L416">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L571">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Multiply_" data-uid="SadRogue.Primitives.Point.op_Multiply*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Multiply_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.op_Multiply(SadRogue.Primitives.Point,System.ValueTuple{System.Int32,System.Int32})">Multiply(Point, (Int32 x, Int32 y))</h4>
@@ -2318,7 +3106,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator *(Point c, (int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator *(Point c, (int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2336,7 +3125,7 @@ rounded to nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -2363,7 +3152,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Multiply_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Multiply(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L408">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L562">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Multiply_" data-uid="SadRogue.Primitives.Point.op_Multiply*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Multiply_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Multiply(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Point)">Multiply((Int32 x, Int32 y), Point)</h4>
@@ -2372,7 +3161,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static (int x, int y) operator *((int x, int y) tuple, Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static (int x, int y) operator *((int x, int y) tuple, Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2385,7 +3175,7 @@ rounded to nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -2406,7 +3196,7 @@ rounded to nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><p>Position (tuple.x * c.X, tuple.y * c.Y).</p>
 </td>
       </tr>
@@ -2417,7 +3207,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L137">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L233">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Subtraction_" data-uid="SadRogue.Primitives.Point.op_Subtraction*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">Subtraction(Point, Direction)</h4>
@@ -2426,7 +3216,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator -(Point point, Direction direction)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator -(Point point, Direction direction)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2471,7 +3262,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L129">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L224">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Subtraction_" data-uid="SadRogue.Primitives.Point.op_Subtraction*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Subtraction(Point, Point)</h4>
@@ -2480,7 +3271,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator -(Point c1, Point c2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator -(Point c1, Point c2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2525,7 +3317,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L145">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L243">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Subtraction_" data-uid="SadRogue.Primitives.Point.op_Subtraction*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point,System.Int32)">Subtraction(Point, Int32)</h4>
@@ -2534,7 +3326,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator -(Point c, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator -(Point c, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2552,7 +3345,7 @@ rounded to nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -2579,7 +3372,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L400">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L553">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Subtraction_" data-uid="SadRogue.Primitives.Point.op_Subtraction*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Subtraction_SadRogue_Primitives_Point_System_ValueTuple_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Point.op_Subtraction(SadRogue.Primitives.Point,System.ValueTuple{System.Int32,System.Int32})">Subtraction(Point, (Int32 x, Int32 y))</h4>
@@ -2588,7 +3381,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point operator -(Point c, (int x, int y) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point operator -(Point c, (int x, int y) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2606,7 +3400,7 @@ rounded to nearest integer.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -2633,7 +3427,7 @@ rounded to nearest integer.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point_op_Subtraction_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point.op_Subtraction(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L393">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L544">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Point_op_Subtraction_" data-uid="SadRogue.Primitives.Point.op_Subtraction*"></a>
   <h4 id="SadRogue_Primitives_Point_op_Subtraction_System_ValueTuple_System_Int32_System_Int32__SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Point.op_Subtraction(System.ValueTuple{System.Int32,System.Int32},SadRogue.Primitives.Point)">Subtraction((Int32 x, Int32 y), Point)</h4>
@@ -2642,7 +3436,8 @@ rounded to nearest integer.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static (int x, int y) operator -((int x, int y) tuple, Point c)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static (int x, int y) operator -((int x, int y) tuple, Point c)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2655,7 +3450,7 @@ rounded to nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -2676,7 +3471,7 @@ rounded to nearest integer.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><p>A tuple (tuple.x - c.X, tuple.y - c.Y).</p>
 </td>
       </tr>
@@ -2684,10 +3479,16 @@ rounded to nearest integer.</p>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
   </div>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
   <h3 id="extensionmethods">Extension Methods</h3>
   <div>
@@ -2704,6 +3505,9 @@ rounded to nearest integer.</p>
   </div>
   <div>
       <a class="xref" href="SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_System_Int32_">PointExtensions.Subtract(Point, Int32)</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_">PointExtensions.Subtract(Point, Direction)</a>
   </div>
   <div>
       <a class="xref" href="SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_SadRogue_Primitives_Point_">PointExtensions.Multiply(Point, Point)</a>
@@ -2723,6 +3527,9 @@ rounded to nearest integer.</p>
   <div>
       <a class="xref" href="SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_System_Double_">PointExtensions.Divide(Point, Double)</a>
   </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Matches_SadRogue_Primitives_Point_SadRogue_Primitives_Point_">PointExtensions.Matches(Point, Point)</a>
+  </div>
 </article>
           </div>
           
@@ -2734,7 +3541,7 @@ rounded to nearest integer.</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Point.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Point%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L17" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Point.cs/#L20" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.PointExtensions.html
+++ b/docs/api/SadRogue.Primitives.PointExtensions.html
@@ -79,31 +79,31 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">PointExtensions</span></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetHashCode()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
@@ -119,7 +119,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Add_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Add(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L31">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L38">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Add_" data-uid="SadRogue.Primitives.PointExtensions.Add*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Add_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.PointExtensions.Add(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">Add(Point, Direction)</h4>
@@ -128,7 +128,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Add(this Point self, Direction dir)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Add(this Point self, Direction dir)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -163,7 +164,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <tbody>
       <tr>
         <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
-        <td><p>Position (c.X + d.DeltaX, c.Y + d.DeltaY)</p>
+        <td><p>Position (self.X + dir.DeltaX, self.Y + dir.DeltaY)</p>
 </td>
       </tr>
     </tbody>
@@ -173,7 +174,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Add_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Add(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L15">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L18">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Add_" data-uid="SadRogue.Primitives.PointExtensions.Add*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Add_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.PointExtensions.Add(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Add(Point, Point)</h4>
@@ -182,7 +183,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Add(this Point self, Point other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Add(this Point self, Point other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -227,7 +229,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Add_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Add(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L23">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L28">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Add_" data-uid="SadRogue.Primitives.PointExtensions.Add*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Add_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.PointExtensions.Add(SadRogue.Primitives.Point,System.Int32)">Add(Point, Int32)</h4>
@@ -236,7 +238,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Add(this Point self, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Add(this Point self, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -254,7 +257,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -281,7 +284,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Divide(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L79">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L108">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Divide_" data-uid="SadRogue.Primitives.PointExtensions.Divide*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.PointExtensions.Divide(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Divide(Point, Point)</h4>
@@ -290,7 +293,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Divide(this Point self, Point other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Divide(this Point self, Point other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -335,7 +339,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Divide(SadRogue.Primitives.Point%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L95">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L128">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Divide_" data-uid="SadRogue.Primitives.PointExtensions.Divide*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_System_Double_" data-uid="SadRogue.Primitives.PointExtensions.Divide(SadRogue.Primitives.Point,System.Double)">Divide(Point, Double)</h4>
@@ -344,7 +348,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Divide(this Point self, double d)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Divide(this Point self, double d)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -362,7 +367,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">d</span></td>
         <td></td>
       </tr>
@@ -389,7 +394,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Divide(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L87">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L118">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Divide_" data-uid="SadRogue.Primitives.PointExtensions.Divide*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Divide_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.PointExtensions.Divide(SadRogue.Primitives.Point,System.Int32)">Divide(Point, Int32)</h4>
@@ -398,7 +403,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Divide(this Point self, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Divide(this Point self, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -416,7 +422,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -440,10 +446,65 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Matches_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Matches(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L138">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PointExtensions_Matches_" data-uid="SadRogue.Primitives.PointExtensions.Matches*"></a>
+  <h4 id="SadRogue_Primitives_PointExtensions_Matches_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.PointExtensions.Matches(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Matches(Point, Point)</h4>
+  <div class="markdown level1 summary"><p>Compares the two points for equality; equivalent to <a class="xref" href="SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Equals_SadRogue_Primitives_Point_">Equals(Point)</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool Matches(this Point self, Point other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two points are equal; false otherwise.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L55">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L78">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Multiply_" data-uid="SadRogue.Primitives.PointExtensions.Multiply*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Multiply(Point, Point)</h4>
@@ -452,7 +513,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Multiply(this Point self, Point other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Multiply(this Point self, Point other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -497,7 +559,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L71">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L98">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Multiply_" data-uid="SadRogue.Primitives.PointExtensions.Multiply*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_System_Double_" data-uid="SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point,System.Double)">Multiply(Point, Double)</h4>
@@ -506,7 +568,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Multiply(this Point self, double d)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Multiply(this Point self, double d)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -524,7 +587,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Double</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
         <td><span class="parametername">d</span></td>
         <td></td>
       </tr>
@@ -551,7 +614,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L63">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L88">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Multiply_" data-uid="SadRogue.Primitives.PointExtensions.Multiply*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point,System.Int32)">Multiply(Point, Int32)</h4>
@@ -560,7 +623,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Multiply(this Point self, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Multiply(this Point self, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -578,7 +642,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -602,10 +666,65 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L68">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PointExtensions_Subtract_" data-uid="SadRogue.Primitives.PointExtensions.Subtract*"></a>
+  <h4 id="SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">Subtract(Point, Direction)</h4>
+  <div class="markdown level1 summary"><p>Translates the current position by one unit in the opposite of the given direction.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Subtract(this Point self, Direction dir)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">dir</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>Position (self.X - dir.DeltaX, self.Y - dir.DeltaY)</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L39">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L48">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Subtract_" data-uid="SadRogue.Primitives.PointExtensions.Subtract*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Subtract(Point, Point)</h4>
@@ -614,7 +733,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Subtract(this Point self, Point other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Subtract(this Point self, Point other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -659,7 +779,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L47">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L58">View Source</a>
   </span>
   <a id="SadRogue_Primitives_PointExtensions_Subtract_" data-uid="SadRogue.Primitives.PointExtensions.Subtract*"></a>
   <h4 id="SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point,System.Int32)">Subtract(Point, Int32)</h4>
@@ -668,7 +788,8 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Point Subtract(this Point self, int i)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Point Subtract(this Point self, int i)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -686,7 +807,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">i</span></td>
         <td></td>
       </tr>
@@ -719,7 +840,7 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PointExtensions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PointExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L7" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PointExtensions.cs/#L10" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.PolarCoordinate.html
+++ b/docs/api/SadRogue.Primitives.PolarCoordinate.html
@@ -1,0 +1,1296 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct PolarCoordinate
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct PolarCoordinate
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.PolarCoordinate">
+  
+  
+  <h1 id="SadRogue_Primitives_PolarCoordinate" data-uid="SadRogue.Primitives.PolarCoordinate" class="text-break">Struct PolarCoordinate
+  </h1>
+  <div class="markdown level0 summary"><p>A Polar Coordinate.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div classs="implements">
+    <h5>Implements</h5>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;&gt;</div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_PolarCoordinate_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct PolarCoordinate : IEquatable&lt;PolarCoordinate&gt;, IMatchable&lt;PolarCoordinate&gt;, IEquatable&lt;(double radius, double theta)&gt;, IMatchable&lt;(double radius, double theta)&gt;</code></pre>
+  </div>
+  <h5 id="SadRogue_Primitives_PolarCoordinate_remarks"><strong>Remarks</strong></h5>
+  <div class="markdown level0 remarks"><p>See wikipedia: <a href="https://en.wikipedia.org/wiki/Polar_coordinate_system">https://en.wikipedia.org/wiki/Polar_coordinate_system</a>
+Polar Coordinates are very, very slow and should not be used often</p>
+</div>
+  <h3 id="constructors">Constructors
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate__ctor_System_Double_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.%23ctor(System.Double%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L35">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate__ctor_" data-uid="SadRogue.Primitives.PolarCoordinate.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate__ctor_System_Double_System_Double_" data-uid="SadRogue.Primitives.PolarCoordinate.#ctor(System.Double,System.Double)">PolarCoordinate(Double, Double)</h4>
+  <div class="markdown level1 summary"><p>Creates a new Polar Coordinate with the given Radius and Theta</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public PolarCoordinate(double radius, double theta)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td><p>Radius of the Polar Coord</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">theta</span></td>
+        <td><p>Degree of rotation (clockwise) of the Polar Coord</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Radius.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Radius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L23">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Radius" data-uid="SadRogue.Primitives.PolarCoordinate.Radius">Radius</h4>
+  <div class="markdown level1 summary"><p>The distance away from the Origin (0,0) of this Polar Coord</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly double Radius</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Theta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Theta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L28">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Theta" data-uid="SadRogue.Primitives.PolarCoordinate.Theta">Theta</h4>
+  <div class="markdown level1 summary"><p>The angle of rotation, clockwise, in radians</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly double Theta</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="properties">Properties
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Functions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Functions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L248">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Functions_" data-uid="SadRogue.Primitives.PolarCoordinate.Functions*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Functions" data-uid="SadRogue.Primitives.PolarCoordinate.Functions">Functions</h4>
+  <div class="markdown level1 summary"><p>A handy list of example polar functions for you.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Dictionary&lt;string, Func&lt;double, Point&gt;&gt; Functions { get; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.dictionary-2">Dictionary</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.func-2">Func</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_PolarCoordinate_Functions_remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>This list contains several examples of Polar Coordinates you can use.
+Add more by calling <code>PolarFunctions.Add((theta) =&gt; { Return new PolarCoordinate(radius, theta);});</code></p>
+<p>Each function accepts a parameter of Theta, which is the angle of rotation around the center.
+They return a Point that can be used on the map.
+Polar functions are very slow. Use them seldom, for things like spirographs
+As the radius gets larger, there will be increased likelihood of functions producing gaps in output.
+You've been warned.</p>
+</div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Deconstruct_System_Double__System_Double__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Deconstruct(System.Double%40%2CSystem.Double%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L151">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Deconstruct_" data-uid="SadRogue.Primitives.PolarCoordinate.Deconstruct*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Deconstruct_System_Double__System_Double__" data-uid="SadRogue.Primitives.PolarCoordinate.Deconstruct(System.Double@,System.Double@)">Deconstruct(out Double, out Double)</h4>
+  <div class="markdown level1 summary"><p>Adds support for C# Deconstruction syntax.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out double radius, out double theta)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td><span class="parametername">theta</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Equals_SadRogue_Primitives_PolarCoordinate_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Equals(SadRogue.Primitives.PolarCoordinate)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L79">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Equals_" data-uid="SadRogue.Primitives.PolarCoordinate.Equals*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Equals_SadRogue_Primitives_PolarCoordinate_" data-uid="SadRogue.Primitives.PolarCoordinate.Equals(SadRogue.Primitives.PolarCoordinate)">Equals(PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Performs comparison between this PolarCoordinate and an other</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(PolarCoordinate other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>The other Polar Coordinate to analyze</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>Whether these two PolarCoordinates are equal</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L87">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Equals_" data-uid="SadRogue.Primitives.PolarCoordinate.Equals*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Equals_System_Object_" data-uid="SadRogue.Primitives.PolarCoordinate.Equals(System.Object)">Equals(Object)</h4>
+  <div class="markdown level1 summary"><p>Compares the equality of this Polar Coordinate to another object</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
+        <td><span class="parametername">obj</span></td>
+        <td><p>The object against which to compare</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>Whether or not these objects are equal</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Equals_System_ValueTuple_System_Double_System_Double__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Equals(System.ValueTuple%7BSystem.Double%2CSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L180">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Equals_" data-uid="SadRogue.Primitives.PolarCoordinate.Equals*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Equals_System_ValueTuple_System_Double_System_Double__" data-uid="SadRogue.Primitives.PolarCoordinate.Equals(System.ValueTuple{System.Double,System.Double})">Equals((Double radius, Double theta))</h4>
+  <div class="markdown level1 summary"><p>Compares the values in this polar coordinate to the specified values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Equals((double radius, double theta) other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_FromCartesian_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.FromCartesian(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L125">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_FromCartesian_" data-uid="SadRogue.Primitives.PolarCoordinate.FromCartesian*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_FromCartesian_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.PolarCoordinate.FromCartesian(SadRogue.Primitives.Point)">FromCartesian(Point)</h4>
+  <div class="markdown level1 summary"><p>Returns a new PolarCoordinate that is equivalent to the Cartesian point provided.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static PolarCoordinate FromCartesian(Point cartesian)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">cartesian</span></td>
+        <td><p>The cartesian point to analyze</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><p>An Equivalent Polar Coordinate</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_FromCartesian_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.FromCartesian(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L139">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_FromCartesian_" data-uid="SadRogue.Primitives.PolarCoordinate.FromCartesian*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_FromCartesian_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.PolarCoordinate.FromCartesian(System.Int32,System.Int32)">FromCartesian(Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns a new PolarCoordinate that is equivalent to the Cartesian point provided.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static PolarCoordinate FromCartesian(int cartesianX, int cartesianY)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">cartesianX</span></td>
+        <td><p>X-value of the cartesian point to analyze.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">cartesianY</span></td>
+        <td><p>Y-value of the cartesian point to analyze.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><p>An Equivalent Polar Coordinate</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L72">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_GetHashCode_" data-uid="SadRogue.Primitives.PolarCoordinate.GetHashCode*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_GetHashCode" data-uid="SadRogue.Primitives.PolarCoordinate.GetHashCode">GetHashCode()</h4>
+  <div class="markdown level1 summary"><p>Gets the Object's Hash Code</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><p>A Hash code.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Matches_SadRogue_Primitives_PolarCoordinate_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Matches(SadRogue.Primitives.PolarCoordinate)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L100">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Matches_" data-uid="SadRogue.Primitives.PolarCoordinate.Matches*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Matches_SadRogue_Primitives_PolarCoordinate_" data-uid="SadRogue.Primitives.PolarCoordinate.Matches(SadRogue.Primitives.PolarCoordinate)">Matches(PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Performs comparison between this PolarCoordinate and an other</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(PolarCoordinate other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>The other Polar Coordinate to analyze</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>Whether these two PolarCoordinates are equal</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_Matches_System_ValueTuple_System_Double_System_Double__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.Matches(System.ValueTuple%7BSystem.Double%2CSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L188">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_Matches_" data-uid="SadRogue.Primitives.PolarCoordinate.Matches*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_Matches_System_ValueTuple_System_Double_System_Double__" data-uid="SadRogue.Primitives.PolarCoordinate.Matches(System.ValueTuple{System.Double,System.Double})">Matches((Double radius, Double theta))</h4>
+  <div class="markdown level1 summary"><p>Compares the values in this polar coordinate to the specified values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches((double radius, double theta) other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_ToCartesian.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.ToCartesian%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L115">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_ToCartesian_" data-uid="SadRogue.Primitives.PolarCoordinate.ToCartesian*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_ToCartesian" data-uid="SadRogue.Primitives.PolarCoordinate.ToCartesian">ToCartesian()</h4>
+  <div class="markdown level1 summary"><p>Returns the Cartesian Equivalent of this Polar Coordinate</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Point ToCartesian()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>A Cartesian Coordinate that points at the same spot on the map as the Polar Coord</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L45">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_ToString_" data-uid="SadRogue.Primitives.PolarCoordinate.ToString*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_ToString" data-uid="SadRogue.Primitives.PolarCoordinate.ToString">ToString()</h4>
+  <div class="markdown level1 summary"><p>Ovverride ToString to help you debug</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
+        <td><p>A short representation of the Polar Coordinate</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Equality_SadRogue_Primitives_PolarCoordinate_SadRogue_Primitives_PolarCoordinate_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate%2CSadRogue.Primitives.PolarCoordinate)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L56">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Equality_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Equality*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Equality_SadRogue_Primitives_PolarCoordinate_SadRogue_Primitives_PolarCoordinate_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate,SadRogue.Primitives.PolarCoordinate)">Equality(PolarCoordinate, PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Compares two polar Coordinates</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(PolarCoordinate left, PolarCoordinate right)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">left</span></td>
+        <td><p>The first polar coordinate to analyze</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">right</span></td>
+        <td><p>The Second polar coordinate to analyze</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>Whether or not these two Polar Coordinates are similar enough to be considered &quot;Equal&quot;</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Equality_SadRogue_Primitives_PolarCoordinate_System_ValueTuple_System_Double_System_Double__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate%2CSystem.ValueTuple%7BSystem.Double%2CSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L196">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Equality_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Equality*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Equality_SadRogue_Primitives_PolarCoordinate_System_ValueTuple_System_Double_System_Double__" data-uid="SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate,System.ValueTuple{System.Double,System.Double})">Equality(PolarCoordinate, (Double radius, Double theta))</h4>
+  <div class="markdown level1 summary"><p>True if the two polar coordinates' radius and theta values are close enough to equal.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(PolarCoordinate c, (double radius, double theta) tuple)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">c</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">tuple</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two polar coordinates are equivalent, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Equality_System_ValueTuple_System_Double_System_Double__SadRogue_Primitives_PolarCoordinate_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Equality(System.ValueTuple%7BSystem.Double%2CSystem.Double%7D%2CSadRogue.Primitives.PolarCoordinate)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L217">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Equality_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Equality*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Equality_System_ValueTuple_System_Double_System_Double__SadRogue_Primitives_PolarCoordinate_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Equality(System.ValueTuple{System.Double,System.Double},SadRogue.Primitives.PolarCoordinate)">Equality((Double radius, Double theta), PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>True if the two polar coordinate's values are equivalent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==((double radius, double theta) tuple, PolarCoordinate c)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">tuple</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">c</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two polar coordinates are equal, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Implicit_SadRogue_Primitives_PolarCoordinate__SadRogue_Primitives_Point.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.Point%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L108">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Implicit_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Implicit_SadRogue_Primitives_PolarCoordinate__SadRogue_Primitives_Point" data-uid="SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.Point">Implicit(PolarCoordinate to Point)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts the polar coordinate to its cartesian plane equivalent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Point(PolarCoordinate pos)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">pos</span></td>
+        <td><p>Polar coordinate to convert.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><p>The equivalent cartesian coordinate.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Implicit_SadRogue_Primitives_PolarCoordinate__System_ValueTuple_System_Double_System_Double_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~System.ValueTuple%7BSystem.Double%2CSystem.Double%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L163">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Implicit_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Implicit_SadRogue_Primitives_PolarCoordinate__System_ValueTuple_System_Double_System_Double_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~System.ValueTuple{System.Double,System.Double}">Implicit(PolarCoordinate to (Double radius, Double theta))</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts a PolarCoordinate to an equivalent tuple of two doubles.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator (double radius, double theta)(PolarCoordinate c)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">c</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Implicit_System_ValueTuple_System_Double_System_Double___SadRogue_Primitives_PolarCoordinate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Implicit(System.ValueTuple%7BSystem.Double%2CSystem.Double%7D)~SadRogue.Primitives.PolarCoordinate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L171">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Implicit_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Implicit_System_ValueTuple_System_Double_System_Double___SadRogue_Primitives_PolarCoordinate" data-uid="SadRogue.Primitives.PolarCoordinate.op_Implicit(System.ValueTuple{System.Double,System.Double})~SadRogue.Primitives.PolarCoordinate">Implicit((Double radius, Double theta) to PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts a tuple of two doubles to an equivalent PolarCoordinate.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator PolarCoordinate((double radius, double theta) tuple)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">tuple</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Inequality_SadRogue_Primitives_PolarCoordinate_SadRogue_Primitives_PolarCoordinate_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate%2CSadRogue.Primitives.PolarCoordinate)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L66">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Inequality_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Inequality*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Inequality_SadRogue_Primitives_PolarCoordinate_SadRogue_Primitives_PolarCoordinate_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate,SadRogue.Primitives.PolarCoordinate)">Inequality(PolarCoordinate, PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Compares two PolarCoordinates</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool operator !=(PolarCoordinate left, PolarCoordinate right)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">left</span></td>
+        <td><p>The first polar coordinate to analyze</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">right</span></td>
+        <td><p>The second PolarCoordinate to analyze</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>Whether these polar coordinates are dissimilar enough to not be equal</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Inequality_SadRogue_Primitives_PolarCoordinate_System_ValueTuple_System_Double_System_Double__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate%2CSystem.ValueTuple%7BSystem.Double%2CSystem.Double%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L207">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Inequality_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Inequality*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Inequality_SadRogue_Primitives_PolarCoordinate_System_ValueTuple_System_Double_System_Double__" data-uid="SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate,System.ValueTuple{System.Double,System.Double})">Inequality(PolarCoordinate, (Double radius, Double theta))</h4>
+  <div class="markdown level1 summary"><p>True if either the radius or theta values aren't equivalent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(PolarCoordinate c, (double radius, double theta) tuple)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">c</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">tuple</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if either the radius or theta values are not equal, false if they are both equal.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate_op_Inequality_System_ValueTuple_System_Double_System_Double__SadRogue_Primitives_PolarCoordinate_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate.op_Inequality(System.ValueTuple%7BSystem.Double%2CSystem.Double%7D%2CSadRogue.Primitives.PolarCoordinate)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L229">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_PolarCoordinate_op_Inequality_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Inequality*"></a>
+  <h4 id="SadRogue_Primitives_PolarCoordinate_op_Inequality_System_ValueTuple_System_Double_System_Double__SadRogue_Primitives_PolarCoordinate_" data-uid="SadRogue.Primitives.PolarCoordinate.op_Inequality(System.ValueTuple{System.Double,System.Double},SadRogue.Primitives.PolarCoordinate)">Inequality((Double radius, Double theta), PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>True if either the radius or theta values are not equal.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=((double radius, double theta) tuple, PolarCoordinate c)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a>&gt;</td>
+        <td><span class="parametername">tuple</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">c</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if either the radius or theta values are not equal, false if they are both equal.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="implements">Implements</h3>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_PolarCoordinate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.PolarCoordinate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/PolarCoordinate.cs/#L16" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.Radius.Types.html
+++ b/docs/api/SadRogue.Primitives.Radius.Types.html
@@ -122,7 +122,7 @@ types to a primitive type (for cases like a switch statement).</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L58" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L57" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Radius.html
+++ b/docs/api/SadRogue.Primitives.Radius.html
@@ -80,26 +80,27 @@ representing the various radius shapes.</p>
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a>&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Radius_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct Radius : IEquatable&lt;Radius&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct Radius : IEquatable&lt;Radius&gt;, IMatchable&lt;Radius&gt;</code></pre>
   </div>
   <h5 id="SadRogue_Primitives_Radius_remarks"><strong>Remarks</strong></h5>
   <div class="markdown level0 remarks"><p>Contains utility functions to work with radius shapes.  Instances of Radius are also implicitly
@@ -114,7 +115,7 @@ shape).</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_Circle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.Circle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L25">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L27">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Radius_Circle" data-uid="SadRogue.Primitives.Radius.Circle">Circle</h4>
   <div class="markdown level1 summary"><p>Radius is a circle around the center point. CIRCLE would represent movement radius in
@@ -123,8 +124,7 @@ an 8-way movement scheme with a ~1.41 cost multiplier for diagonal movement.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Radius Circle</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Radius Circle</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -146,7 +146,7 @@ public static readonly Radius Circle</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_Diamond.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.Diamond%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L32">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L33">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Radius_Diamond" data-uid="SadRogue.Primitives.Radius.Diamond">Diamond</h4>
   <div class="markdown level1 summary"><p>Radius is a diamond around the center point. DIAMOND would represent movement radius
@@ -155,8 +155,7 @@ in a 4-way movement scheme.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Radius Diamond</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Radius Diamond</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -188,8 +187,7 @@ away.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Radius Square</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Radius Square</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -220,7 +218,8 @@ statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly Radius.Types Type</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly Radius.Types Type</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -244,7 +243,7 @@ statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_Equals_SadRogue_Primitives_Radius_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.Equals(SadRogue.Primitives.Radius)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L180">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L222">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_Equals_" data-uid="SadRogue.Primitives.Radius.Equals*"></a>
   <h4 id="SadRogue_Primitives_Radius_Equals_SadRogue_Primitives_Radius_" data-uid="SadRogue.Primitives.Radius.Equals(SadRogue.Primitives.Radius)">Equals(Radius)</h4>
@@ -253,7 +252,8 @@ statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(Radius other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(Radius other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -283,7 +283,7 @@ statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two radius shapes are the same, false if not.</p>
 </td>
       </tr>
@@ -294,7 +294,7 @@ statements.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L189">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L232">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_Equals_" data-uid="SadRogue.Primitives.Radius.Equals*"></a>
   <h4 id="SadRogue_Primitives_Radius_Equals_System_Object_" data-uid="SadRogue.Primitives.Radius.Equals(System.Object)">Equals(Object)</h4>
@@ -303,7 +303,8 @@ statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -316,7 +317,7 @@ statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td><p>The object to compare the current Radius to.</p>
 </td>
@@ -333,20 +334,20 @@ statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if <code data-dev-comment-type="paramref" class="paramref">obj</code> is a Radius, and the two radius shapes are equal, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L195">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L239">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_GetHashCode_" data-uid="SadRogue.Primitives.Radius.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_Radius_GetHashCode" data-uid="SadRogue.Primitives.Radius.GetHashCode">GetHashCode()</h4>
@@ -355,7 +356,8 @@ statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -367,19 +369,69 @@ statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_Matches_SadRogue_Primitives_Radius_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.Matches(SadRogue.Primitives.Radius)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L247">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Radius_Matches_" data-uid="SadRogue.Primitives.Radius.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Radius_Matches_SadRogue_Primitives_Radius_" data-uid="SadRogue.Primitives.Radius.Matches(SadRogue.Primitives.Radius)">Matches(Radius)</h4>
+  <div class="markdown level1 summary"><p>True if the given Radius has the same Type the current one.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool Matches(Radius other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a></td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Radius to compare.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two radius shapes are the same, false if not.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L111">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L135">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_PositionsInRadius_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius*"></a>
   <h4 id="SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.Point,System.Int32)">PositionsInRadius(Point, Int32)</h4>
@@ -388,7 +440,8 @@ statements.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; PositionsInRadius(Point center, int radius)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PositionsInRadius(Point center, int radius)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -407,7 +460,7 @@ statements.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">radius</span></td>
         <td><p>Length of the radius.</p>
 </td>
@@ -424,7 +477,7 @@ statements.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All points in the radius shape defined by the given parameters, in order from least distance to greatest
 if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
 </td>
@@ -432,7 +485,7 @@ if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Rad
     </tbody>
   </table>
   <h5 id="SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_Point_System_Int32__remarks">Remarks</h5>
-  <div class="markdown level1 remarks"><p>If you are getting postions for a radius of the same size frequently, it may be more performant to instead
+  <div class="markdown level1 remarks"><p>If you are getting positions for a radius of the same size frequently, it may be more performant to instead
 construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html">RadiusLocationContext</a> to represent it, and pass that to
 <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_RadiusLocationContext_">PositionsInRadius(RadiusLocationContext)</a>.</p>
 <p>The positions returned are guaranteed to be in order from least distance from center to most distance if either
@@ -443,7 +496,7 @@ construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_Point_System_Int32_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.Point%2CSystem.Int32%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L93">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L92">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_PositionsInRadius_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius*"></a>
   <h4 id="SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_Point_System_Int32_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.Point,System.Int32,SadRogue.Primitives.Rectangle)">PositionsInRadius(Point, Int32, Rectangle)</h4>
@@ -452,7 +505,8 @@ construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; PositionsInRadius(Point center, int radius, Rectangle bounds)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PositionsInRadius(Point center, int radius, Rectangle bounds)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -471,7 +525,7 @@ construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">radius</span></td>
         <td><p>Length of the radius.</p>
 </td>
@@ -494,7 +548,7 @@ construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All points in the radius shape defined by the given parameters, in order from least distance to greatest
 if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
 </td>
@@ -502,7 +556,7 @@ if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Rad
     </tbody>
   </table>
   <h5 id="SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_Point_System_Int32_SadRogue_Primitives_Rectangle__remarks">Remarks</h5>
-  <div class="markdown level1 remarks"><p>If you are getting postions for a radius of the same size frequently, it may be more performant to instead
+  <div class="markdown level1 remarks"><p>If you are getting positions for a radius of the same size frequently, it may be more performant to instead
 construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html">RadiusLocationContext</a> to represent it, and pass that to
 <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_RadiusLocationContext_">PositionsInRadius(RadiusLocationContext)</a>.</p>
 <p>The positions returned are all guaranteed to be within the <code data-dev-comment-type="paramref" class="paramref">bounds</code> specified.  As well,
@@ -514,7 +568,7 @@ they are guaranteed to be in order from least distance from center to most dista
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_RadiusLocationContext_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.RadiusLocationContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L129">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L176">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_PositionsInRadius_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius*"></a>
   <h4 id="SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_RadiusLocationContext_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.RadiusLocationContext)">PositionsInRadius(RadiusLocationContext)</h4>
@@ -525,7 +579,8 @@ the positions for a radius of the same size multiple times, even if the shape/po
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; PositionsInRadius(RadiusLocationContext context)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PositionsInRadius(RadiusLocationContext context)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -555,7 +610,7 @@ the positions for a radius of the same size multiple times, even if the shape/po
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All points in the radius shape defined by the given context, in order from least distance to greatest
 if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
 </td>
@@ -570,19 +625,20 @@ the bounds are unspecified, in which case no bound restriction results.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_ToRadius_SadRogue_Primitives_Radius_Types_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.ToRadius(SadRogue.Primitives.Radius.Types)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.PositionsInRadius(System.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L270">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L156">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Radius_ToRadius_" data-uid="SadRogue.Primitives.Radius.ToRadius*"></a>
-  <h4 id="SadRogue_Primitives_Radius_ToRadius_SadRogue_Primitives_Radius_Types_" data-uid="SadRogue.Primitives.Radius.ToRadius(SadRogue.Primitives.Radius.Types)">ToRadius(Radius.Types)</h4>
-  <div class="markdown level1 summary"><p>Gets the Radius class instance representing the radius type specified.</p>
+  <a id="SadRogue_Primitives_Radius_PositionsInRadius_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius*"></a>
+  <h4 id="SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius(System.Int32,System.Int32,System.Int32)">PositionsInRadius(Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Returns an IEnumerable of all positions in a radius of the current shape defined by the given parameters.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Radius ToRadius(Radius.Types radiusType)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PositionsInRadius(int centerX, int centerY, int radius)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -595,9 +651,21 @@ the bounds are unspecified, in which case no bound restriction results.</p>
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Radius.Types.html">Radius.Types</a></td>
-        <td><span class="parametername">radiusType</span></td>
-        <td><p>The enum value for the radius shape.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerX</span></td>
+        <td><p>X-value of the center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerY</span></td>
+        <td><p>Y-value of the center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td><p>Length of the radius.</p>
 </td>
       </tr>
     </tbody>
@@ -612,18 +680,104 @@ the bounds are unspecified, in which case no bound restriction results.</p>
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a></td>
-        <td><p>The radius class representing the given radius shape.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>All points in the radius shape defined by the given parameters, in order from least distance to greatest
+if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
 </td>
       </tr>
     </tbody>
   </table>
+  <h5 id="SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>If you are getting positions for a radius of the same size frequently, it may be more performant to instead
+construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html">RadiusLocationContext</a> to represent it, and pass that to
+<a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_RadiusLocationContext_">PositionsInRadius(RadiusLocationContext)</a>.</p>
+<p>The positions returned are guaranteed to be in order from least distance from center to most distance if either
+<a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.PositionsInRadius(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L115">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Radius_PositionsInRadius_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius*"></a>
+  <h4 id="SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Radius.PositionsInRadius(System.Int32,System.Int32,System.Int32,SadRogue.Primitives.Rectangle)">PositionsInRadius(Int32, Int32, Int32, Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Returns an IEnumerable of all positions in a radius of the current shape defined by the given parameters.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PositionsInRadius(int centerX, int centerY, int radius, Rectangle bounds)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerX</span></td>
+        <td><p>X-value of the center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerY</span></td>
+        <td><p>Y-value of the center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td><p>Length of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">bounds</span></td>
+        <td><p>Bounds to restrict the returned values by.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>All points in the radius shape defined by the given parameters, in order from least distance to greatest
+if <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle__remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>If you are getting positions for a radius of the same size frequently, it may be more performant to instead
+construct a <a class="xref" href="SadRogue.Primitives.RadiusLocationContext.html">RadiusLocationContext</a> to represent it, and pass that to
+<a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_SadRogue_Primitives_RadiusLocationContext_">PositionsInRadius(RadiusLocationContext)</a>.</p>
+<p>The positions returned are all guaranteed to be within the <code data-dev-comment-type="paramref" class="paramref">bounds</code> specified.  As well,
+they are guaranteed to be in order from least distance from center to most distance if either
+<a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Diamond">Diamond</a> or <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Square">Square</a> is being used.</p>
+</div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L292">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L327">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_ToString_" data-uid="SadRogue.Primitives.Radius.ToString*"></a>
   <h4 id="SadRogue_Primitives_Radius_ToString" data-uid="SadRogue.Primitives.Radius.ToString">ToString()</h4>
@@ -644,14 +798,14 @@ the bounds are unspecified, in which case no bound restriction results.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
         <td><p>A string representation of the Radius.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <h3 id="operators">Operators
   </h3>
   <span class="small pull-right mobile-hide">
@@ -659,7 +813,7 @@ the bounds are unspecified, in which case no bound restriction results.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_op_Equality_SadRogue_Primitives_Radius_SadRogue_Primitives_Radius_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.op_Equality(SadRogue.Primitives.Radius%2CSadRogue.Primitives.Radius)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L203">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L255">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_op_Equality_" data-uid="SadRogue.Primitives.Radius.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Radius_op_Equality_SadRogue_Primitives_Radius_SadRogue_Primitives_Radius_" data-uid="SadRogue.Primitives.Radius.op_Equality(SadRogue.Primitives.Radius,SadRogue.Primitives.Radius)">Equality(Radius, Radius)</h4>
@@ -668,7 +822,8 @@ the bounds are unspecified, in which case no bound restriction results.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Radius lhs, Radius rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Radius lhs, Radius rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -702,7 +857,7 @@ the bounds are unspecified, in which case no bound restriction results.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two radius shapes are equal, false if not.</p>
 </td>
       </tr>
@@ -713,7 +868,7 @@ the bounds are unspecified, in which case no bound restriction results.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_AdjacencyRule.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.AdjacencyRule%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L223">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L277">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_op_Implicit_" data-uid="SadRogue.Primitives.Radius.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_AdjacencyRule" data-uid="SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.AdjacencyRule">Implicit(Radius to AdjacencyRule)</h4>
@@ -722,7 +877,8 @@ the bounds are unspecified, in which case no bound restriction results.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator AdjacencyRule(Radius radius)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator AdjacencyRule(Radius radius)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -766,7 +922,7 @@ radius shape casted will be returned.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_Distance.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.Distance%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L247">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L294">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_op_Implicit_" data-uid="SadRogue.Primitives.Radius.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_Distance" data-uid="SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.Distance">Implicit(Radius to Distance)</h4>
@@ -775,7 +931,8 @@ radius shape casted will be returned.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator Distance(Radius radius)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Distance(Radius radius)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -816,10 +973,108 @@ distance that creates the radius shape casted will be returned.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_Radius_Types.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.Radius.Types%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L307">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Radius_op_Implicit_" data-uid="SadRogue.Primitives.Radius.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_Radius_Types" data-uid="SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.Radius.Types">Implicit(Radius to Radius.Types)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts a Radius to its corresponding <a class="xref" href="SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Type">Type</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Radius.Types(Radius radius)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Radius.Types.html">Radius.Types</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius_Types__SadRogue_Primitives_Radius.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius.Types)~SadRogue.Primitives.Radius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L314">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Radius_op_Implicit_" data-uid="SadRogue.Primitives.Radius.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius_Types__SadRogue_Primitives_Radius" data-uid="SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius.Types)~SadRogue.Primitives.Radius">Implicit(Radius.Types to Radius)</h4>
+  <div class="markdown level1 summary"><p>Implicitly converts an <a class="xref" href="SadRogue.Primitives.Radius.Types.html">Radius.Types</a> enum value to its corresponding Radius.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Radius(Radius.Types type)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Radius.Types.html">Radius.Types</a></td>
+        <td><span class="parametername">type</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius_op_Inequality_SadRogue_Primitives_Radius_SadRogue_Primitives_Radius_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius.op_Inequality(SadRogue.Primitives.Radius%2CSadRogue.Primitives.Radius)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L213">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L266">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Radius_op_Inequality_" data-uid="SadRogue.Primitives.Radius.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Radius_op_Inequality_SadRogue_Primitives_Radius_SadRogue_Primitives_Radius_" data-uid="SadRogue.Primitives.Radius.op_Inequality(SadRogue.Primitives.Radius,SadRogue.Primitives.Radius)">Inequality(Radius, Radius)</h4>
@@ -828,7 +1083,8 @@ distance that creates the radius shape casted will be returned.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Radius lhs, Radius rhs)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Radius lhs, Radius rhs)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -862,7 +1118,7 @@ distance that creates the radius shape casted will be returned.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the types are not equal, false if they are both equal.</p>
 </td>
       </tr>
@@ -870,7 +1126,10 @@ distance that creates the radius shape casted will be returned.</p>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
   </div>
 </article>
           </div>
@@ -883,7 +1142,7 @@ distance that creates the radius shape casted will be returned.</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Radius.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Radius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L17" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L20" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.RadiusLocationContext.html
+++ b/docs/api/SadRogue.Primitives.RadiusLocationContext.html
@@ -81,31 +81,31 @@ even if the location center point or shape of the radius is changing.</p>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
     <div class="level1"><span class="xref">RadiusLocationContext</span></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetHashCode()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.MemberwiseClone()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.ToString()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
@@ -121,7 +121,7 @@ even if the location center point or shape of the radius is changing.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext__ctor_SadRogue_Primitives_Point_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.%23ctor(SadRogue.Primitives.Point%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L361">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L408">View Source</a>
   </span>
   <a id="SadRogue_Primitives_RadiusLocationContext__ctor_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor*"></a>
   <h4 id="SadRogue_Primitives_RadiusLocationContext__ctor_SadRogue_Primitives_Point_System_Int32_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor(SadRogue.Primitives.Point,System.Int32)">RadiusLocationContext(Point, Int32)</h4>
@@ -149,7 +149,7 @@ even if the location center point or shape of the radius is changing.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">radius</span></td>
         <td><p>The starting length of the radius.</p>
 </td>
@@ -161,7 +161,7 @@ even if the location center point or shape of the radius is changing.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext__ctor_SadRogue_Primitives_Point_System_Int32_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.%23ctor(SadRogue.Primitives.Point%2CSystem.Int32%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L345">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L380">View Source</a>
   </span>
   <a id="SadRogue_Primitives_RadiusLocationContext__ctor_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor*"></a>
   <h4 id="SadRogue_Primitives_RadiusLocationContext__ctor_SadRogue_Primitives_Point_System_Int32_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor(SadRogue.Primitives.Point,System.Int32,SadRogue.Primitives.Rectangle)">RadiusLocationContext(Point, Int32, Rectangle)</h4>
@@ -189,7 +189,106 @@ even if the location center point or shape of the radius is changing.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td><p>The starting length of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">bounds</span></td>
+        <td><p>The bounds to restrict the radius to.  Any positions inside the radius but outside
+the bounds will be ignored and considered outside the radius.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext__ctor_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L418">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_RadiusLocationContext__ctor_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_RadiusLocationContext__ctor_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor(System.Int32,System.Int32,System.Int32)">RadiusLocationContext(Int32, Int32, Int32)</h4>
+  <div class="markdown level1 summary"><p>Constructor.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public RadiusLocationContext(int centerX, int centerY, int radius)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerX</span></td>
+        <td><p>X-value of the starting center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerY</span></td>
+        <td><p>Y-value of the starting center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">radius</span></td>
+        <td><p>The starting length of the radius.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext__ctor_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L399">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_RadiusLocationContext__ctor_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor*"></a>
+  <h4 id="SadRogue_Primitives_RadiusLocationContext__ctor_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.RadiusLocationContext.#ctor(System.Int32,System.Int32,System.Int32,SadRogue.Primitives.Rectangle)">RadiusLocationContext(Int32, Int32, Int32, Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Constructor.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public RadiusLocationContext(int centerX, int centerY, int radius, Rectangle bounds)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerX</span></td>
+        <td><p>X-value of the starting center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">centerY</span></td>
+        <td><p>Y-value of the starting center-point of the radius.</p>
+</td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">radius</span></td>
         <td><p>The starting length of the radius.</p>
 </td>
@@ -210,7 +309,7 @@ the bounds will be ignored and considered outside the radius.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext_Bounds.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.Bounds%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L336">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L371">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_RadiusLocationContext_Bounds" data-uid="SadRogue.Primitives.RadiusLocationContext.Bounds">Bounds</h4>
   <div class="markdown level1 summary"><p>Represents the bounds that restrict the valid positions that are considered
@@ -245,11 +344,11 @@ to indicate no bounds.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext_Center.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.Center%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L328">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L363">View Source</a>
   </span>
   <a id="SadRogue_Primitives_RadiusLocationContext_Center_" data-uid="SadRogue.Primitives.RadiusLocationContext.Center*"></a>
   <h4 id="SadRogue_Primitives_RadiusLocationContext_Center" data-uid="SadRogue.Primitives.RadiusLocationContext.Center">Center</h4>
-  <div class="markdown level1 summary"><p>The centr-point of the radius represented.</p>
+  <div class="markdown level1 summary"><p>The center-point of the radius represented.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
@@ -276,7 +375,7 @@ to indicate no bounds.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext_Radius.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext.Radius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L311">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L346">View Source</a>
   </span>
   <a id="SadRogue_Primitives_RadiusLocationContext_Radius_" data-uid="SadRogue.Primitives.RadiusLocationContext.Radius*"></a>
   <h4 id="SadRogue_Primitives_RadiusLocationContext_Radius" data-uid="SadRogue.Primitives.RadiusLocationContext.Radius">Radius</h4>
@@ -297,7 +396,7 @@ to indicate no bounds.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -313,7 +412,7 @@ to indicate no bounds.</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RadiusLocationContext.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RadiusLocationContext%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L301" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Radius.cs/#L336" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.Rectangle.html
+++ b/docs/api/SadRogue.Primitives.Rectangle.html
@@ -79,27 +79,31 @@ involving rectangles.</p>
   <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</div>
-    <div><span class="xref">System.IEquatable</span>&lt;<span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;&gt;</div>
+    <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">IEquatable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;&gt;</div>
+    <div><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;&gt;</div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <span class="xref">System.Object.Equals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
     </div>
     <div>
-      <span class="xref">System.Object.GetType()</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
     </div>
     <div>
-      <span class="xref">System.Object.ReferenceEquals(System.Object, System.Object)</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
     </div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
   <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
   <h5 id="SadRogue_Primitives_Rectangle_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[Serializable]
-public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int y, int width, int height)&gt;</code></pre>
+    <pre><code class="lang-csharp hljs">[DataContract]
+public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int y, int width, int height)&gt;, IMatchable&lt;Rectangle&gt;, IMatchable&lt;(int x, int y, int width, int height)&gt;, IEquatable&lt;(Point minExtent, Point maxExtent)&gt;, IMatchable&lt;(Point minExtent, Point maxExtent)&gt;</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -108,7 +112,7 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle__ctor_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.%23ctor(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L39">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L43">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle__ctor_" data-uid="SadRogue.Primitives.Rectangle.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Rectangle__ctor_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.#ctor(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">Rectangle(Point, Point)</h4>
@@ -148,7 +152,7 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle__ctor_SadRogue_Primitives_Point_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.%23ctor(SadRogue.Primitives.Point%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L57">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L61">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle__ctor_" data-uid="SadRogue.Primitives.Rectangle.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Rectangle__ctor_SadRogue_Primitives_Point_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.#ctor(SadRogue.Primitives.Point,System.Int32,System.Int32)">Rectangle(Point, Int32, Int32)</h4>
@@ -176,13 +180,13 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">horizontalRadius</span></td>
         <td><p>Number of units to the left and right of the center point that are included within the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">verticalRadius</span></td>
         <td><p>Number of units to the top and bottom of the center point that are included within the rectangle.</p>
 </td>
@@ -194,7 +198,7 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle__ctor_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.%23ctor(System.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L26">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L30">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle__ctor_" data-uid="SadRogue.Primitives.Rectangle.#ctor*"></a>
   <h4 id="SadRogue_Primitives_Rectangle__ctor_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.#ctor(System.Int32,System.Int32,System.Int32,System.Int32)">Rectangle(Int32, Int32, Int32, Int32)</h4>
@@ -216,25 +220,25 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>Minimum x coordinate that is inside the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>Minimum y coordinate that is inside the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>Width of the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">height</span></td>
         <td><p>Height of the rectangle.</p>
 </td>
@@ -248,7 +252,7 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Empty.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Empty%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L17">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L21">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Rectangle_Empty" data-uid="SadRogue.Primitives.Rectangle.Empty">Empty</h4>
   <div class="markdown level1 summary"><p>The empty rectangle. Has origin of (0, 0) with 0 width and height.</p>
@@ -256,8 +260,7 @@ public struct Rectangle : IEquatable&lt;Rectangle&gt;, IEquatable&lt;(int x, int
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">[NonSerialized]
-public static readonly Rectangle Empty</code></pre>
+    <pre><code class="lang-csharp hljs">public static readonly Rectangle Empty</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -279,7 +282,7 @@ public static readonly Rectangle Empty</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L79">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L83">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Rectangle_Height" data-uid="SadRogue.Primitives.Rectangle.Height">Height</h4>
   <div class="markdown level1 summary"><p>The height of the rectangle.</p>
@@ -287,7 +290,8 @@ public static readonly Rectangle Empty</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly int Height</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly int Height</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -299,7 +303,7 @@ public static readonly Rectangle Empty</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -309,7 +313,7 @@ public static readonly Rectangle Empty</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L135">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L139">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Rectangle_Width" data-uid="SadRogue.Primitives.Rectangle.Width">Width</h4>
   <div class="markdown level1 summary"><p>The width of the rectangle.</p>
@@ -317,7 +321,8 @@ public static readonly Rectangle Empty</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly int Width</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly int Width</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -329,7 +334,7 @@ public static readonly Rectangle Empty</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -339,7 +344,7 @@ public static readonly Rectangle Empty</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_X.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L140">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L144">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Rectangle_X" data-uid="SadRogue.Primitives.Rectangle.X">X</h4>
   <div class="markdown level1 summary"><p>X-coordinate of position of the rectangle.</p>
@@ -347,7 +352,8 @@ public static readonly Rectangle Empty</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly int X</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly int X</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,7 +365,7 @@ public static readonly Rectangle Empty</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -369,7 +375,7 @@ public static readonly Rectangle Empty</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Y.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L145">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L149">View Source</a>
   </span>
   <h4 id="SadRogue_Primitives_Rectangle_Y" data-uid="SadRogue.Primitives.Rectangle.Y">Y</h4>
   <div class="markdown level1 summary"><p>Y-coordinate of position of the rectangle.</p>
@@ -377,7 +383,8 @@ public static readonly Rectangle Empty</code></pre>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public readonly int Y</code></pre>
+    <pre><code class="lang-csharp hljs">[DataMember]
+public readonly int Y</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -389,7 +396,7 @@ public static readonly Rectangle Empty</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -401,7 +408,7 @@ public static readonly Rectangle Empty</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Area.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Area%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L68">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L72">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Area_" data-uid="SadRogue.Primitives.Rectangle.Area*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Area" data-uid="SadRogue.Primitives.Rectangle.Area">Area</h4>
@@ -422,7 +429,7 @@ public static readonly Rectangle Empty</code></pre>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -432,7 +439,7 @@ public static readonly Rectangle Empty</code></pre>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Center.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Center%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L74">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L78">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Center_" data-uid="SadRogue.Primitives.Rectangle.Center*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Center" data-uid="SadRogue.Primitives.Rectangle.Center">Center</h4>
@@ -464,7 +471,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_IsEmpty.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.IsEmpty%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L84">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L88">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_IsEmpty_" data-uid="SadRogue.Primitives.Rectangle.IsEmpty*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_IsEmpty" data-uid="SadRogue.Primitives.Rectangle.IsEmpty">IsEmpty</h4>
@@ -485,7 +492,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -495,7 +502,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MaxExtent.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MaxExtent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L89">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L93">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MaxExtent_" data-uid="SadRogue.Primitives.Rectangle.MaxExtent*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MaxExtent" data-uid="SadRogue.Primitives.Rectangle.MaxExtent">MaxExtent</h4>
@@ -526,7 +533,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MaxExtentX.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MaxExtentX%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L94">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L98">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MaxExtentX_" data-uid="SadRogue.Primitives.Rectangle.MaxExtentX*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MaxExtentX" data-uid="SadRogue.Primitives.Rectangle.MaxExtentX">MaxExtentX</h4>
@@ -547,7 +554,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -557,7 +564,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MaxExtentY.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MaxExtentY%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L99">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L103">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MaxExtentY_" data-uid="SadRogue.Primitives.Rectangle.MaxExtentY*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MaxExtentY" data-uid="SadRogue.Primitives.Rectangle.MaxExtentY">MaxExtentY</h4>
@@ -578,7 +585,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -588,7 +595,7 @@ positions. The center of a rectangle with width/height 1 is its <a class="xref" 
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MinExtent.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MinExtent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L106">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L110">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MinExtent_" data-uid="SadRogue.Primitives.Rectangle.MinExtent*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MinExtent" data-uid="SadRogue.Primitives.Rectangle.MinExtent">MinExtent</h4>
@@ -621,7 +628,7 @@ minimum extent.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MinExtentX.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MinExtentX%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L113">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L117">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MinExtentX_" data-uid="SadRogue.Primitives.Rectangle.MinExtentX*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MinExtentX" data-uid="SadRogue.Primitives.Rectangle.MinExtentX">MinExtentX</h4>
@@ -644,7 +651,7 @@ by its minimum extent.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -654,7 +661,7 @@ by its minimum extent.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MinExtentY.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MinExtentY%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L120">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L124">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MinExtentY_" data-uid="SadRogue.Primitives.Rectangle.MinExtentY*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MinExtentY" data-uid="SadRogue.Primitives.Rectangle.MinExtentY">MinExtentY</h4>
@@ -677,7 +684,7 @@ by its minimum extent.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td></td>
       </tr>
     </tbody>
@@ -687,7 +694,7 @@ by its minimum extent.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Position.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L125">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L129">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Position_" data-uid="SadRogue.Primitives.Rectangle.Position*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Position" data-uid="SadRogue.Primitives.Rectangle.Position">Position</h4>
@@ -718,7 +725,7 @@ by its minimum extent.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Size.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Size%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L130">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L134">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Size_" data-uid="SadRogue.Primitives.Rectangle.Size*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Size" data-uid="SadRogue.Primitives.Rectangle.Size">Size</h4>
@@ -748,19 +755,19 @@ by its minimum extent.</p>
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_BottomEdgePositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.BottomEdgePositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Bisect.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Bisect%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L784">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L1043">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Rectangle_BottomEdgePositions_" data-uid="SadRogue.Primitives.Rectangle.BottomEdgePositions*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_BottomEdgePositions" data-uid="SadRogue.Primitives.Rectangle.BottomEdgePositions">BottomEdgePositions()</h4>
-  <div class="markdown level1 summary"><p>Returns all positions on the bottom edge of the rectangle.</p>
+  <a id="SadRogue_Primitives_Rectangle_Bisect_" data-uid="SadRogue.Primitives.Rectangle.Bisect*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_Bisect" data-uid="SadRogue.Primitives.Rectangle.Bisect">Bisect()</h4>
+  <div class="markdown level1 summary"><p>Bisects the rectangle into two halves along its longest axis.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; BottomEdgePositions()</code></pre>
+    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Rectangle&gt; Bisect()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -772,28 +779,67 @@ by its minimum extent.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
-        <td><p>All positions on the bottom edge of the rectangle.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</td>
+        <td><p>An IEnumerable of either Top and Bottom halves, or Left and Right halves,
+at indexes 0 and 1 respectively.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="SadRogue_Primitives_Rectangle_Bisect_remarks">Remarks</h5>
+  <div class="markdown level1 remarks"><p>Cuts the rectangle by reducing it's longest dimension by half. For example, a
+rectangle that extends from (3, 3) to (18, 7) that calls DivideInHalf will
+return an IEnumerable with two rectangles. The rectangle at index 0
+starts at (3, 3) and extends to (9, 7), and the rectangle at index 1 extends from
+(10, 3) to (18, 7)</p>
+</div>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_BisectHorizontally.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.BisectHorizontally%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L1059">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_BisectHorizontally_" data-uid="SadRogue.Primitives.Rectangle.BisectHorizontally*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_BisectHorizontally" data-uid="SadRogue.Primitives.Rectangle.BisectHorizontally">BisectHorizontally()</h4>
+  <div class="markdown level1 summary"><p>Bisects the rectangle into top and bottom halves</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Rectangle&gt; BisectHorizontally()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</td>
+        <td><p>An IEnumerable with Top and Bottom Rectangles in indexes 0 and 1, respectively</p>
 </td>
       </tr>
     </tbody>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangeHeight_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangeHeight(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_BisectRecursive_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.BisectRecursive(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L325">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L1015">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Rectangle_ChangeHeight_" data-uid="SadRogue.Primitives.Rectangle.ChangeHeight*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_ChangeHeight_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.ChangeHeight(System.Int32)">ChangeHeight(Int32)</h4>
-  <div class="markdown level1 summary"><p>Creates and returns a new rectangle whose position is the same as the current one, but
-has its height changed by the given delta-change value.</p>
+  <a id="SadRogue_Primitives_Rectangle_BisectRecursive_" data-uid="SadRogue.Primitives.Rectangle.BisectRecursive*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_BisectRecursive_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.BisectRecursive(System.Int32)">BisectRecursive(Int32)</h4>
+  <div class="markdown level1 summary"><p>Recursively divides this rectangle in half until the small rectangles are between minimumDimension and 2 * minimumDimenson.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle ChangeHeight(int deltaHeight)</code></pre>
+    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Rectangle&gt; BisectRecursive(int minimumDimension)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -806,7 +852,91 @@ has its height changed by the given delta-change value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">minimumDimension</span></td>
+        <td><p>The smallest allowable dimension for a rectangle to be.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</td>
+        <td><p>A list of all rectangles that add up to the original rectangle</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_BisectVertically.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.BisectVertically%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L1077">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_BisectVertically_" data-uid="SadRogue.Primitives.Rectangle.BisectVertically*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_BisectVertically" data-uid="SadRogue.Primitives.Rectangle.BisectVertically">BisectVertically()</h4>
+  <div class="markdown level1 summary"><p>Divides the rectangle into a left and right half.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Rectangle&gt; BisectVertically()</code></pre>
+  </div>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</td>
+        <td><p>An IEnumerable with the Left and Right rectangles in index 0 and 1 respectively.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangeHeight_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangeHeight(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L340">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_ChangeHeight_" data-uid="SadRogue.Primitives.Rectangle.ChangeHeight*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_ChangeHeight_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.ChangeHeight(System.Int32)">ChangeHeight(Int32)</h4>
+  <div class="markdown level1 summary"><p>Creates and returns a new rectangle whose position is the same as the current one, but
+has its height changed by the given delta-change value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangeHeight(int deltaHeight)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">deltaHeight</span></td>
         <td><p>Delta-change for the height of the new rectangle.</p>
 </td>
@@ -831,10 +961,113 @@ has its height changed by the given delta-change value.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangePosition_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L377">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_ChangePosition_" data-uid="SadRogue.Primitives.Rectangle.ChangePosition*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_ChangePosition_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Direction)">ChangePosition(Direction)</h4>
+  <div class="markdown level1 summary"><p>Creates and returns a new rectangle that has its position moved in the given direction.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangePosition(Direction direction)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">direction</span></td>
+        <td><p>The direction to move the new rectangle in.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><p>A new rectangle that has its position moved in the given direction.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangePosition_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L389">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_ChangePosition_" data-uid="SadRogue.Primitives.Rectangle.ChangePosition*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_ChangePosition_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Point)">ChangePosition(Point)</h4>
+  <div class="markdown level1 summary"><p>Creates and returns a new rectangle whose position has been moved by the given
+delta-change values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangePosition(Point deltaChange)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">deltaChange</span></td>
+        <td><p>Delta-x and delta-y values by which to move the new rectangle.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><p>A new rectangle, whose position has been moved by the given delta-change values.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangeSize_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangeSize(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L339">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L356">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_ChangeSize_" data-uid="SadRogue.Primitives.Rectangle.ChangeSize*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_ChangeSize_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.ChangeSize(SadRogue.Primitives.Point)">ChangeSize(Point)</h4>
@@ -844,7 +1077,8 @@ has its width and height changed by the given delta-change values.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle ChangeSize(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangeSize(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -886,7 +1120,7 @@ of the new Rectangle.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangeWidth_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangeWidth(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L348">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L367">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_ChangeWidth_" data-uid="SadRogue.Primitives.Rectangle.ChangeWidth*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_ChangeWidth_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.ChangeWidth(System.Int32)">ChangeWidth(Int32)</h4>
@@ -896,7 +1130,8 @@ has its width changed by the given delta-change value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle ChangeWidth(int deltaWidth)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangeWidth(int deltaWidth)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,7 +1144,7 @@ has its width changed by the given delta-change value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">deltaWidth</span></td>
         <td><p>Delta-change for the width of the new rectangle.</p>
 </td>
@@ -934,10 +1169,112 @@ has its width changed by the given delta-change value.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangeX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangeX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L398">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_ChangeX_" data-uid="SadRogue.Primitives.Rectangle.ChangeX*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_ChangeX_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.ChangeX(System.Int32)">ChangeX(Int32)</h4>
+  <div class="markdown level1 summary"><p>Creates and returns a new rectangle whose x-position has been moved by the given delta value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangeX(int dx)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dx</span></td>
+        <td><p>Value by which to move the new rectangle's x-position.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><p>A new rectangle, whose x-position has been moved by the given delta-x value.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ChangeY_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ChangeY(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L407">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_ChangeY_" data-uid="SadRogue.Primitives.Rectangle.ChangeY*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_ChangeY_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.ChangeY(System.Int32)">ChangeY(Int32)</h4>
+  <div class="markdown level1 summary"><p>Creates and returns a new rectangle whose y-position has been moved by the given delta value.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle ChangeY(int dy)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td><span class="parametername">dy</span></td>
+        <td><p>Value by which to move the new rectangle's y-position.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><p>A new rectangle, whose y-position has been moved by the given delta-y value.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Contains_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Contains(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L356">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L416">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Contains_" data-uid="SadRogue.Primitives.Rectangle.Contains*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Contains_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.Contains(SadRogue.Primitives.Point)">Contains(Point)</h4>
@@ -946,7 +1283,8 @@ has its width changed by the given delta-change value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Contains(Point position)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Contains(Point position)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -976,7 +1314,7 @@ has its width changed by the given delta-change value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>Whether or not the specified point is considered within the rectangle.</p>
 </td>
       </tr>
@@ -987,7 +1325,7 @@ has its width changed by the given delta-change value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Contains_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Contains(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L366">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L429">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Contains_" data-uid="SadRogue.Primitives.Rectangle.Contains*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Contains_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.Contains(SadRogue.Primitives.Rectangle)">Contains(Rectangle)</h4>
@@ -997,7 +1335,8 @@ the current one.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Contains(Rectangle other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Contains(Rectangle other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1027,7 +1366,7 @@ the current one.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the given rectangle is completely contained within the current one, false otherwise.</p>
 </td>
       </tr>
@@ -1038,7 +1377,7 @@ the current one.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Deconstruct_SadRogue_Primitives_Point__SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Deconstruct(SadRogue.Primitives.Point%40%2CSadRogue.Primitives.Point%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L679">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L832">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Deconstruct_" data-uid="SadRogue.Primitives.Rectangle.Deconstruct*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Deconstruct_SadRogue_Primitives_Point__SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Rectangle.Deconstruct(SadRogue.Primitives.Point@,SadRogue.Primitives.Point@)">Deconstruct(out Point, out Point)</h4>
@@ -1047,7 +1386,8 @@ the current one.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out Point minExtent, out Point maxExtent)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out Point minExtent, out Point maxExtent)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,7 +1416,7 @@ the current one.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Deconstruct_System_Int32__System_Int32__System_Int32__System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Deconstruct(System.Int32%40%2CSystem.Int32%40%2CSystem.Int32%40%2CSystem.Int32%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L608">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L737">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Deconstruct_" data-uid="SadRogue.Primitives.Rectangle.Deconstruct*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Deconstruct_System_Int32__System_Int32__System_Int32__System_Int32__" data-uid="SadRogue.Primitives.Rectangle.Deconstruct(System.Int32@,System.Int32@,System.Int32@,System.Int32@)">Deconstruct(out Int32, out Int32, out Int32, out Int32)</h4>
@@ -1085,7 +1425,8 @@ the current one.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void Deconstruct(out int x, out int y, out int width, out int height)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public void Deconstruct(out int x, out int y, out int width, out int height)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1098,24 +1439,91 @@ the current one.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">height</span></td>
         <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Divide_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Divide(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L1098">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_Rectangle_Divide_" data-uid="SadRogue.Primitives.Rectangle.Divide*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_Divide_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.Divide(SadRogue.Primitives.Rectangle)">Divide(Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Divides this rectangle by another, and returns an IEnumerable of divisor-sized rectangles that fit
+within the dividend.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Rectangle&gt; Divide(Rectangle divisor)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">divisor</span></td>
+        <td><p>The rectangle by which to divide</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>&gt;</td>
+        <td><p>IEnumerable of Rectangles the size of divisor, that fit within this rectangle.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="exceptions">Exceptions</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Condition</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.argumentoutofrangeexception">ArgumentOutOfRangeException</a></td>
+        <td><p>Thrown when the width or height of the divisor is 0 or less</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -1124,7 +1532,7 @@ the current one.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Equals_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Equals(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L376">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L442">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Equals_" data-uid="SadRogue.Primitives.Rectangle.Equals*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Equals_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.Equals(SadRogue.Primitives.Rectangle)">Equals(Rectangle)</h4>
@@ -1134,7 +1542,8 @@ in both position and extents.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals(Rectangle other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals(Rectangle other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1163,7 +1572,7 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>true if the area of the two rectangles encompass the exact same area, false otherwise.</p>
 </td>
       </tr>
@@ -1174,7 +1583,7 @@ in both position and extents.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Equals_System_Object_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L385">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L453">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Equals_" data-uid="SadRogue.Primitives.Rectangle.Equals*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Equals_System_Object_" data-uid="SadRogue.Primitives.Rectangle.Equals(System.Object)">Equals(Object)</h4>
@@ -1183,7 +1592,8 @@ in both position and extents.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override bool Equals(object obj)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override bool Equals(object obj)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1196,7 +1606,7 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Object</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
@@ -1212,20 +1622,20 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>true if the object specified is a rectangle instance and encompasses the same area, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Equals_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Equals(System.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L726">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L886">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Equals_" data-uid="SadRogue.Primitives.Rectangle.Equals*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Equals_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Rectangle.Equals(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})">Equals((Point minExtent, Point maxExtent))</h4>
@@ -1234,7 +1644,8 @@ in both position and extents.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals((Point minExtent, Point maxExtent) other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals((Point minExtent, Point maxExtent) other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1247,7 +1658,7 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">other</span></td>
         <td><p>Point to compare.</p>
 </td>
@@ -1264,7 +1675,7 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
@@ -1275,7 +1686,7 @@ in both position and extents.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Equals_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Equals(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L657">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L793">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Equals_" data-uid="SadRogue.Primitives.Rectangle.Equals*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Equals_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Rectangle.Equals(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})">Equals((Int32 x, Int32 y, Int32 width, Int32 height))</h4>
@@ -1284,7 +1695,8 @@ in both position and extents.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Equals((int x, int y, int width, int height) other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Equals((int x, int y, int width, int height) other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1297,7 +1709,7 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">other</span></td>
         <td><p>Point to compare.</p>
 </td>
@@ -1314,7 +1726,7 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
@@ -1325,16 +1737,18 @@ in both position and extents.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Expand_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Expand(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L397">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L467">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Expand_" data-uid="SadRogue.Primitives.Rectangle.Expand*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Expand_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.Expand(System.Int32,System.Int32)">Expand(Int32, Int32)</h4>
-  <div class="markdown level1 summary"><p>Returns a new rectangle, expanded to include the additional specified rows/columns.</p>
+  <div class="markdown level1 summary"><p>Returns a new rectangle, expanded on each side by the given amounts.  Negative change values
+can be used to shrink the rectangle on each side.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle Expand(int horizontalChange, int verticalChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle Expand(int horizontalChange, int verticalChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1347,15 +1761,15 @@ in both position and extents.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">horizontalChange</span></td>
-        <td><p>Number of additional columns to include on the left/right of the rectangle.</p>
+        <td><p>Number of additional columns to include on the left and right of the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">verticalChange</span></td>
-        <td><p>Number of additional rows to include on the top/bottom of the rectangle.</p>
+        <td><p>Number of additional rows to include on the top and bottom of the rectangle.</p>
 </td>
       </tr>
     </tbody>
@@ -1381,7 +1795,7 @@ in both position and extents.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_GetDifference_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.GetDifference(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L198">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L213">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_GetDifference_" data-uid="SadRogue.Primitives.Rectangle.GetDifference*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_GetDifference_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.GetDifference(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">GetDifference(Rectangle, Rectangle)</h4>
@@ -1391,7 +1805,8 @@ is NOT in <code data-dev-comment-type="paramref" class="paramref">rect2</code>.<
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Area GetDifference(Rectangle rect1, Rectangle rect2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Area GetDifference(Rectangle rect1, Rectangle rect2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1437,7 +1852,7 @@ is NOT in <code data-dev-comment-type="paramref" class="paramref">rect2</code>.<
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_GetExactUnion_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.GetExactUnion(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L222">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L236">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_GetExactUnion_" data-uid="SadRogue.Primitives.Rectangle.GetExactUnion*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_GetExactUnion_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.GetExactUnion(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">GetExactUnion(Rectangle, Rectangle)</h4>
@@ -1447,7 +1862,8 @@ an area containing all locations from either rectangle.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Area GetExactUnion(Rectangle r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Area GetExactUnion(Rectangle r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1492,7 +1908,7 @@ an area containing all locations from either rectangle.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_GetHashCode.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L404">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L477">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_GetHashCode_" data-uid="SadRogue.Primitives.Rectangle.GetHashCode*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_GetHashCode" data-uid="SadRogue.Primitives.Rectangle.GetHashCode">GetHashCode()</h4>
@@ -1501,7 +1917,8 @@ an area containing all locations from either rectangle.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override int GetHashCode()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override int GetHashCode()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1513,20 +1930,20 @@ an area containing all locations from either rectangle.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><p>Hash code for rectangle.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.GetHashCode()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_GetIntersection_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.GetIntersection(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L255">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L262">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_GetIntersection_" data-uid="SadRogue.Primitives.Rectangle.GetIntersection*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_GetIntersection_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.GetIntersection(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">GetIntersection(Rectangle, Rectangle)</h4>
@@ -1536,7 +1953,8 @@ or the empty rectangle if the specified rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Rectangle GetIntersection(Rectangle r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Rectangle GetIntersection(Rectangle r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1582,7 +2000,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_GetUnion_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.GetUnion(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L281">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L289">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_GetUnion_" data-uid="SadRogue.Primitives.Rectangle.GetUnion*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_GetUnion_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.GetUnion(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">GetUnion(Rectangle, Rectangle)</h4>
@@ -1592,7 +2010,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Rectangle GetUnion(Rectangle r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Rectangle GetUnion(Rectangle r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1638,7 +2057,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Intersects_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Intersects(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L411">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L486">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Intersects_" data-uid="SadRogue.Primitives.Rectangle.Intersects*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Intersects_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.Intersects(SadRogue.Primitives.Rectangle)">Intersects(Rectangle)</h4>
@@ -1647,7 +2066,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool Intersects(Rectangle other)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Intersects(Rectangle other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1677,7 +2097,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the given rectangle intersects with the current one, false otherwise.</p>
 </td>
       </tr>
@@ -1685,19 +2105,20 @@ the empty rectangle if the two rectangles do not intersect.</p>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_IsOnBottomEdge_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.IsOnBottomEdge(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_IsOnSide_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.IsOnSide(SadRogue.Primitives.Point%2CSadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L825">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L934">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Rectangle_IsOnBottomEdge_" data-uid="SadRogue.Primitives.Rectangle.IsOnBottomEdge*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_IsOnBottomEdge_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.IsOnBottomEdge(SadRogue.Primitives.Point)">IsOnBottomEdge(Point)</h4>
-  <div class="markdown level1 summary"><p>Returns whether or not the given position lies on the bottom edge of the rectangle.</p>
+  <a id="SadRogue_Primitives_Rectangle_IsOnSide_" data-uid="SadRogue.Primitives.Rectangle.IsOnSide*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_IsOnSide_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Rectangle.IsOnSide(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)">IsOnSide(Point, Direction)</h4>
+  <div class="markdown level1 summary"><p>Returns whether or not the given position lines on the given edge of the rectangle.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool IsOnBottomEdge(Point point)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool IsOnSide(Point point, Direction side)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1714,53 +2135,9 @@ the empty rectangle if the two rectangles do not intersect.</p>
         <td><span class="parametername">point</span></td>
         <td></td>
       </tr>
-    </tbody>
-  </table>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
       <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the given position lies along the bottom edge of the rectangle, false otherwise.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_IsOnLeftEdge_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.IsOnLeftEdge(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L836">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Rectangle_IsOnLeftEdge_" data-uid="SadRogue.Primitives.Rectangle.IsOnLeftEdge*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_IsOnLeftEdge_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.IsOnLeftEdge(SadRogue.Primitives.Point)">IsOnLeftEdge(Point)</h4>
-  <div class="markdown level1 summary"><p>Returns whether or not the given position lies on the left edge of the rectangle.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool IsOnLeftEdge(Point point)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
-        <td><span class="parametername">point</span></td>
+        <td><a class="xref" href="SadRogue.Primitives.Direction.html">Direction</a></td>
+        <td><span class="parametername">side</span></td>
         <td></td>
       </tr>
     </tbody>
@@ -1775,27 +2152,29 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the given position lies along the left edge of the rectangle, false otherwise.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the given position lies along the given edge of the rectangle, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_IsOnRightEdge_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.IsOnRightEdge(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Matches_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Matches(SadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L818">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L499">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Rectangle_IsOnRightEdge_" data-uid="SadRogue.Primitives.Rectangle.IsOnRightEdge*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_IsOnRightEdge_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.IsOnRightEdge(SadRogue.Primitives.Point)">IsOnRightEdge(Point)</h4>
-  <div class="markdown level1 summary"><p>Returns whether or not the given position lies on the right edge of the rectangle.</p>
+  <a id="SadRogue_Primitives_Rectangle_Matches_" data-uid="SadRogue.Primitives.Rectangle.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_Matches_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.Matches(SadRogue.Primitives.Rectangle)">Matches(Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Compares based upon whether or not the areas contained within the rectangle are identical
+in both position and extents.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool IsOnRightEdge(Point point)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches(Rectangle other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1808,8 +2187,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
-        <td><span class="parametername">point</span></td>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
@@ -1824,27 +2203,28 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the given position lies along the right edge of the rectangle, false otherwise.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>true if the area of the two rectangles encompass the exact same area, false otherwise.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_IsOnTopEdge_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.IsOnTopEdge(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Matches_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Matches(System.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L807">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L895">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Rectangle_IsOnTopEdge_" data-uid="SadRogue.Primitives.Rectangle.IsOnTopEdge*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_IsOnTopEdge_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.IsOnTopEdge(SadRogue.Primitives.Point)">IsOnTopEdge(Point)</h4>
-  <div class="markdown level1 summary"><p>Returns whether or not the given position lies on the top edge of the rectangle.</p>
+  <a id="SadRogue_Primitives_Rectangle_Matches_" data-uid="SadRogue.Primitives.Rectangle.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_Matches_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Rectangle.Matches(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})">Matches((Point minExtent, Point maxExtent))</h4>
+  <div class="markdown level1 summary"><p>True if the given position has equal x and y values to the current one.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public bool IsOnTopEdge(Point point)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches((Point minExtent, Point maxExtent) other)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1857,9 +2237,10 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
-        <td><span class="parametername">point</span></td>
-        <td></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Point to compare.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -1873,28 +2254,47 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
-        <td><p>True if the given position lies along the top edge of the rectangle, false otherwise.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_LeftEdgePositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.LeftEdgePositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Matches_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Matches(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L796">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L802">View Source</a>
   </span>
-  <a id="SadRogue_Primitives_Rectangle_LeftEdgePositions_" data-uid="SadRogue.Primitives.Rectangle.LeftEdgePositions*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_LeftEdgePositions" data-uid="SadRogue.Primitives.Rectangle.LeftEdgePositions">LeftEdgePositions()</h4>
-  <div class="markdown level1 summary"><p>Returns all positions on the left edge of the rectangle.</p>
+  <a id="SadRogue_Primitives_Rectangle_Matches_" data-uid="SadRogue.Primitives.Rectangle.Matches*"></a>
+  <h4 id="SadRogue_Primitives_Rectangle_Matches_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Rectangle.Matches(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})">Matches((Int32 x, Int32 y, Int32 width, Int32 height))</h4>
+  <div class="markdown level1 summary"><p>True if the given position has equal x and y values to the current one.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; LeftEdgePositions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public bool Matches((int x, int y, int width, int height) other)</code></pre>
   </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
+        <td><span class="parametername">other</span></td>
+        <td><p>Point to compare.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1905,8 +2305,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
-        <td><p>All positions on the left edge of the rectangle.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td><p>True if the two positions are equal, false if not.</p>
 </td>
       </tr>
     </tbody>
@@ -1916,7 +2316,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MaxXPositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MaxXPositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L880">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L985">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MaxXPositions_" data-uid="SadRogue.Primitives.Rectangle.MaxXPositions*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MaxXPositions" data-uid="SadRogue.Primitives.Rectangle.MaxXPositions">MaxXPositions()</h4>
@@ -1925,7 +2325,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; MaxXPositions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; MaxXPositions()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1937,7 +2338,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>IEnumerable of all positions that lie on the max-x line of the rectangle.</p>
 </td>
       </tr>
@@ -1948,7 +2349,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MaxYPositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MaxYPositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L856">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L963">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MaxYPositions_" data-uid="SadRogue.Primitives.Rectangle.MaxYPositions*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MaxYPositions" data-uid="SadRogue.Primitives.Rectangle.MaxYPositions">MaxYPositions()</h4>
@@ -1957,7 +2358,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; MaxYPositions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; MaxYPositions()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -1969,7 +2371,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>IEnumerable of all positions that lie on the max-y line of the rectangle.</p>
 </td>
       </tr>
@@ -1980,7 +2382,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MinXPositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MinXPositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L868">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L974">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MinXPositions_" data-uid="SadRogue.Primitives.Rectangle.MinXPositions*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MinXPositions" data-uid="SadRogue.Primitives.Rectangle.MinXPositions">MinXPositions()</h4>
@@ -1989,7 +2391,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; MinXPositions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; MinXPositions()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2001,7 +2404,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>IEnumerable of all positions that lie on the min-x line of the rectangle.</p>
 </td>
       </tr>
@@ -2012,7 +2415,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_MinYPositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.MinYPositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L844">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L952">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_MinYPositions_" data-uid="SadRogue.Primitives.Rectangle.MinYPositions*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_MinYPositions" data-uid="SadRogue.Primitives.Rectangle.MinYPositions">MinYPositions()</h4>
@@ -2021,7 +2424,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; MinYPositions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; MinYPositions()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2033,7 +2437,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>IEnumerable of all positions that lie on the min-y line of the rectangle.</p>
 </td>
       </tr>
@@ -2044,7 +2448,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_PerimeterPositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.PerimeterPositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L735">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L906">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_PerimeterPositions_" data-uid="SadRogue.Primitives.Rectangle.PerimeterPositions*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_PerimeterPositions" data-uid="SadRogue.Primitives.Rectangle.PerimeterPositions">PerimeterPositions()</h4>
@@ -2053,7 +2457,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; PerimeterPositions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PerimeterPositions()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2065,7 +2470,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>IEnumerable of all positions that reside on the inner perimeter of the rectangle.</p>
 </td>
       </tr>
@@ -2076,7 +2481,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Positions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Positions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L450">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L547">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Positions_" data-uid="SadRogue.Primitives.Rectangle.Positions*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Positions" data-uid="SadRogue.Primitives.Rectangle.Positions">Positions()</h4>
@@ -2085,7 +2490,8 @@ the empty rectangle if the two rectangles do not intersect.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; Positions()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; Positions()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2097,7 +2503,7 @@ the empty rectangle if the two rectangles do not intersect.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><p>All positions in the rectangle.</p>
 </td>
       </tr>
@@ -2108,17 +2514,18 @@ the empty rectangle if the two rectangles do not intersect.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_PositionsOnSide_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.PositionsOnSide(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L894">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L998">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_PositionsOnSide_" data-uid="SadRogue.Primitives.Rectangle.PositionsOnSide*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_PositionsOnSide_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Rectangle.PositionsOnSide(SadRogue.Primitives.Direction)">PositionsOnSide(Direction)</h4>
-  <div class="markdown level1 summary"><p>Gets an IEnumerable of all positions that line on the inner perimiter of the rectangle,
+  <div class="markdown level1 summary"><p>Gets an IEnumerable of all positions that line on the inner perimeter of the rectangle,
 on the given side of the rectangle.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; PositionsOnSide(Direction side)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public IEnumerable&lt;Point&gt; PositionsOnSide(Direction side)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2148,72 +2555,8 @@ on the given side of the rectangle.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
-        <td><p>IEnumerable of all positions that line on the inner perimieter of the rectangle on the given side.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_RightEdgePositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.RightEdgePositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L774">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Rectangle_RightEdgePositions_" data-uid="SadRogue.Primitives.Rectangle.RightEdgePositions*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_RightEdgePositions" data-uid="SadRogue.Primitives.Rectangle.RightEdgePositions">RightEdgePositions()</h4>
-  <div class="markdown level1 summary"><p>Returns all positions on the right edge of the rectangle.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; RightEdgePositions()</code></pre>
-  </div>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
-        <td><p>All positions on the right edge of the rectangle.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  <span class="small pull-right mobile-hide">
-    <span class="divider">|</span>
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_TopEdgePositions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.TopEdgePositions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
-  </span>
-  <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L762">View Source</a>
-  </span>
-  <a id="SadRogue_Primitives_Rectangle_TopEdgePositions_" data-uid="SadRogue.Primitives.Rectangle.TopEdgePositions*"></a>
-  <h4 id="SadRogue_Primitives_Rectangle_TopEdgePositions" data-uid="SadRogue.Primitives.Rectangle.TopEdgePositions">TopEdgePositions()</h4>
-  <div class="markdown level1 summary"><p>Returns all positions on the top edge of the rectangle.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;Point&gt; TopEdgePositions()</code></pre>
-  </div>
-  <h5 class="returns">Returns</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
-        <td><p>All positions on the top edge of the rectangle.</p>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.ienumerable-1">IEnumerable</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><p>IEnumerable of all positions that line on the inner perimeter of the rectangle on the given side.</p>
 </td>
       </tr>
     </tbody>
@@ -2223,7 +2566,7 @@ on the given side of the rectangle.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_ToString.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L557">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L672">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_ToString_" data-uid="SadRogue.Primitives.Rectangle.ToString*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_ToString" data-uid="SadRogue.Primitives.Rectangle.ToString">ToString()</h4>
@@ -2233,7 +2576,8 @@ on the given side of the rectangle.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public override string ToString()</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public override string ToString()</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2245,20 +2589,20 @@ on the given side of the rectangle.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.String</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.string">String</a></td>
         <td><p>String formatted as above.</p>
 </td>
       </tr>
     </tbody>
   </table>
   <h5 class="overrides">Overrides</h5>
-  <div><span class="xref">System.ValueType.ToString()</span></div>
+  <div><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Translate_SadRogue_Primitives_Direction_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Translate(SadRogue.Primitives.Direction)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L426">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L517">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Translate_" data-uid="SadRogue.Primitives.Rectangle.Translate*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Translate_SadRogue_Primitives_Direction_" data-uid="SadRogue.Primitives.Rectangle.Translate(SadRogue.Primitives.Direction)">Translate(Direction)</h4>
@@ -2267,7 +2611,8 @@ on the given side of the rectangle.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle Translate(Direction direction)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle Translate(Direction direction)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2308,7 +2653,7 @@ on the given side of the rectangle.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_Translate_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.Translate(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L567">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L683">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_Translate_" data-uid="SadRogue.Primitives.Rectangle.Translate*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_Translate_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.Translate(SadRogue.Primitives.Point)">Translate(Point)</h4>
@@ -2318,7 +2663,8 @@ delta-change values.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle Translate(Point deltaChange)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle Translate(Point deltaChange)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2359,7 +2705,7 @@ delta-change values.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_TranslateX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.TranslateX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L575">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L693">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_TranslateX_" data-uid="SadRogue.Primitives.Rectangle.TranslateX*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_TranslateX_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.TranslateX(System.Int32)">TranslateX(Int32)</h4>
@@ -2368,7 +2714,8 @@ delta-change values.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle TranslateX(int dx)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle TranslateX(int dx)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2381,7 +2728,7 @@ delta-change values.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">dx</span></td>
         <td><p>Value by which to move the new rectangle's x-position.</p>
 </td>
@@ -2409,7 +2756,7 @@ delta-change values.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_TranslateY_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.TranslateY(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L583">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L703">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_TranslateY_" data-uid="SadRogue.Primitives.Rectangle.TranslateY*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_TranslateY_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.TranslateY(System.Int32)">TranslateY(Int32)</h4>
@@ -2418,7 +2765,8 @@ delta-change values.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle TranslateY(int dy)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle TranslateY(int dy)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2431,7 +2779,7 @@ delta-change values.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">dy</span></td>
         <td><p>Value by which to move the new rectangle's y-position.</p>
 </td>
@@ -2459,7 +2807,7 @@ delta-change values.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithCenter_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithCenter(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L316">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L329">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithCenter_" data-uid="SadRogue.Primitives.Rectangle.WithCenter*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithCenter_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithCenter(SadRogue.Primitives.Point)">WithCenter(Point)</h4>
@@ -2469,7 +2817,8 @@ the center moved to the given position.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithCenter(Point center)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithCenter(Point center)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2511,7 +2860,7 @@ the given location.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithExtents_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithExtents(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L154">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L158">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithExtents_" data-uid="SadRogue.Primitives.Rectangle.WithExtents*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithExtents_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithExtents(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">WithExtents(Point, Point)</h4>
@@ -2521,7 +2870,8 @@ constructor, but with extra overloads not possible to provide in constructors al
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Rectangle WithExtents(Point minExtent, Point maxExtent)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Rectangle WithExtents(Point minExtent, Point maxExtent)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2568,7 +2918,7 @@ constructor, but with extra overloads not possible to provide in constructors al
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithHeight_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithHeight(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L467">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L562">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithHeight_" data-uid="SadRogue.Primitives.Rectangle.WithHeight*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithHeight_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithHeight(System.Int32)">WithHeight(Int32)</h4>
@@ -2578,7 +2928,8 @@ one, but with the height changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithHeight(int height)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithHeight(int height)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2591,7 +2942,7 @@ one, but with the height changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">height</span></td>
         <td><p>The height for the new rectangle.</p>
 </td>
@@ -2619,7 +2970,7 @@ one, but with the height changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithMaxExtent_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithMaxExtent(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L476">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L573">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithMaxExtent_" data-uid="SadRogue.Primitives.Rectangle.WithMaxExtent*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithMaxExtent_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithMaxExtent(SadRogue.Primitives.Point)">WithMaxExtent(Point)</h4>
@@ -2629,7 +2980,8 @@ the maximum extent is the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithMaxExtent(Point maxExtent)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithMaxExtent(Point maxExtent)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2670,7 +3022,7 @@ the maximum extent is the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithMaxExtentX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithMaxExtentX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L485">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L584">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithMaxExtentX_" data-uid="SadRogue.Primitives.Rectangle.WithMaxExtentX*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithMaxExtentX_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithMaxExtentX(System.Int32)">WithMaxExtentX(Int32)</h4>
@@ -2680,7 +3032,8 @@ the x-value of maximum extent is changed to the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithMaxExtentX(int x)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithMaxExtentX(int x)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2693,7 +3046,7 @@ the x-value of maximum extent is changed to the specified value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>The x-coordinate for the maximum extent of the new rectangle.</p>
 </td>
@@ -2721,7 +3074,7 @@ the x-value of maximum extent is changed to the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithMaxExtentY_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithMaxExtentY(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L494">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L595">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithMaxExtentY_" data-uid="SadRogue.Primitives.Rectangle.WithMaxExtentY*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithMaxExtentY_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithMaxExtentY(System.Int32)">WithMaxExtentY(Int32)</h4>
@@ -2731,7 +3084,8 @@ the y-value of maximum extent is changed to the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithMaxExtentY(int y)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithMaxExtentY(int y)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2744,7 +3098,7 @@ the y-value of maximum extent is changed to the specified value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>The y-coordinate for the maximum extent of the new rectangle.</p>
 </td>
@@ -2772,7 +3126,7 @@ the y-value of maximum extent is changed to the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithMinExtent_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithMinExtent(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L503">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L606">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithMinExtent_" data-uid="SadRogue.Primitives.Rectangle.WithMinExtent*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithMinExtent_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithMinExtent(SadRogue.Primitives.Point)">WithMinExtent(Point)</h4>
@@ -2782,7 +3136,8 @@ the minimum extent is the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithMinExtent(Point minExtent)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithMinExtent(Point minExtent)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2823,7 +3178,7 @@ the minimum extent is the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithMinExtentX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithMinExtentX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L512">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L617">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithMinExtentX_" data-uid="SadRogue.Primitives.Rectangle.WithMinExtentX*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithMinExtentX_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithMinExtentX(System.Int32)">WithMinExtentX(Int32)</h4>
@@ -2833,7 +3188,8 @@ the x-value of minimum extent is changed to the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithMinExtentX(int x)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithMinExtentX(int x)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2846,7 +3202,7 @@ the x-value of minimum extent is changed to the specified value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>The x-coordinate for the minimum extent of the new rectangle.</p>
 </td>
@@ -2874,7 +3230,7 @@ the x-value of minimum extent is changed to the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithMinExtentY_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithMinExtentY(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L522">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L629">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithMinExtentY_" data-uid="SadRogue.Primitives.Rectangle.WithMinExtentY*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithMinExtentY_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithMinExtentY(System.Int32)">WithMinExtentY(Int32)</h4>
@@ -2884,7 +3240,8 @@ the y-value of minimum extent is changed to the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithMinExtentY(int y)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithMinExtentY(int y)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2897,7 +3254,7 @@ the y-value of minimum extent is changed to the specified value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>The y-coordinate for the minimum extent of the new rectangle.</p>
 </td>
@@ -2925,7 +3282,7 @@ the y-value of minimum extent is changed to the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithPosition_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithPosition(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L418">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L507">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithPosition_" data-uid="SadRogue.Primitives.Rectangle.WithPosition*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithPosition_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithPosition(SadRogue.Primitives.Point)">WithPosition(Point)</h4>
@@ -2934,7 +3291,8 @@ the y-value of minimum extent is changed to the specified value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithPosition(Point position)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithPosition(Point position)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -2975,7 +3333,7 @@ the y-value of minimum extent is changed to the specified value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithPositionAndSize_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithPositionAndSize(SadRogue.Primitives.Point%2CSadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L188">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L200">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithPositionAndSize_" data-uid="SadRogue.Primitives.Rectangle.WithPositionAndSize*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithPositionAndSize_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithPositionAndSize(SadRogue.Primitives.Point,SadRogue.Primitives.Point)">WithPositionAndSize(Point, Point)</h4>
@@ -2985,7 +3343,8 @@ extra overloads not possible to provide in constructors alone.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Rectangle WithPositionAndSize(Point position, Point size)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Rectangle WithPositionAndSize(Point position, Point size)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3032,7 +3391,7 @@ extra overloads not possible to provide in constructors alone.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithPositionAndSize_SadRogue_Primitives_Point_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithPositionAndSize(SadRogue.Primitives.Point%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L179">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L188">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithPositionAndSize_" data-uid="SadRogue.Primitives.Rectangle.WithPositionAndSize*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithPositionAndSize_SadRogue_Primitives_Point_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithPositionAndSize(SadRogue.Primitives.Point,System.Int32,System.Int32)">WithPositionAndSize(Point, Int32, Int32)</h4>
@@ -3042,7 +3401,8 @@ extra overloads not possible to provide in constructors alone.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Rectangle WithPositionAndSize(Point position, int width, int height)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Rectangle WithPositionAndSize(Point position, int width, int height)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3061,13 +3421,13 @@ extra overloads not possible to provide in constructors alone.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>Width of the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">height</span></td>
         <td><p>Height of the rectangle.</p>
 </td>
@@ -3095,7 +3455,7 @@ extra overloads not possible to provide in constructors alone.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithRadius_SadRogue_Primitives_Point_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithRadius(SadRogue.Primitives.Point%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L169">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L175">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithRadius_" data-uid="SadRogue.Primitives.Rectangle.WithRadius*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithRadius_SadRogue_Primitives_Point_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithRadius(SadRogue.Primitives.Point,System.Int32,System.Int32)">WithRadius(Point, Int32, Int32)</h4>
@@ -3106,7 +3466,8 @@ to provide in constructors alone.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static Rectangle WithRadius(Point center, int horizontalRadius, int verticalRadius)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static Rectangle WithRadius(Point center, int horizontalRadius, int verticalRadius)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3125,13 +3486,13 @@ to provide in constructors alone.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">horizontalRadius</span></td>
         <td><p>Number of units to the left and right of the center point that are included within the rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">verticalRadius</span></td>
         <td><p>Number of units to the top and bottom of the center point that are included within the rectangle.</p>
 </td>
@@ -3159,7 +3520,7 @@ to provide in constructors alone.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithSize_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithSize(SadRogue.Primitives.Point)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L541">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L652">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithSize_" data-uid="SadRogue.Primitives.Rectangle.WithSize*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithSize_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.WithSize(SadRogue.Primitives.Point)">WithSize(Point)</h4>
@@ -3169,7 +3530,8 @@ has the specified width and height.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithSize(Point size)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithSize(Point size)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3210,7 +3572,7 @@ has the specified width and height.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithSize_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithSize(System.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L532">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L641">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithSize_" data-uid="SadRogue.Primitives.Rectangle.WithSize*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithSize_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithSize(System.Int32,System.Int32)">WithSize(Int32, Int32)</h4>
@@ -3220,7 +3582,8 @@ has the specified width and height.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithSize(int width, int height)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithSize(int width, int height)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3233,13 +3596,13 @@ has the specified width and height.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width for the new rectangle.</p>
 </td>
       </tr>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">height</span></td>
         <td><p>The height for the new rectangle.</p>
 </td>
@@ -3267,7 +3630,7 @@ has the specified width and height.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithWidth_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithWidth(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L550">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L663">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithWidth_" data-uid="SadRogue.Primitives.Rectangle.WithWidth*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithWidth_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithWidth(System.Int32)">WithWidth(Int32)</h4>
@@ -3277,7 +3640,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithWidth(int width)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithWidth(int width)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3290,7 +3654,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">width</span></td>
         <td><p>The width for the new rectangle.</p>
 </td>
@@ -3318,7 +3682,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithX_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithX(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L437">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L530">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithX_" data-uid="SadRogue.Primitives.Rectangle.WithX*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithX_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithX(System.Int32)">WithX(Int32)</h4>
@@ -3327,7 +3691,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithX(int x)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithX(int x)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3340,7 +3705,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">x</span></td>
         <td><p>The X value for the new rectangle.</p>
 </td>
@@ -3368,7 +3733,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_WithY_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.WithY(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L444">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L539">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_WithY_" data-uid="SadRogue.Primitives.Rectangle.WithY*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_WithY_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.WithY(System.Int32)">WithY(Int32)</h4>
@@ -3377,7 +3742,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public Rectangle WithY(int y)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public Rectangle WithY(int y)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3390,7 +3756,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
         <td><span class="parametername">y</span></td>
         <td><p>The Y value for the new rectangle.</p>
 </td>
@@ -3420,7 +3786,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Equality_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Equality(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L305">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L316">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Equality_" data-uid="SadRogue.Primitives.Rectangle.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Equality_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.op_Equality(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">Equality(Rectangle, Rectangle)</h4>
@@ -3429,7 +3795,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Rectangle r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Rectangle r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3463,7 +3830,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>true if the area of the two rectangles encompass the exact same area, false otherwise.</p>
 </td>
       </tr>
@@ -3474,7 +3841,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Equality_SadRogue_Primitives_Rectangle_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Equality(SadRogue.Primitives.Rectangle%2CSystem.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L691">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L845">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Equality_" data-uid="SadRogue.Primitives.Rectangle.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Equality_SadRogue_Primitives_Rectangle_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Rectangle.op_Equality(SadRogue.Primitives.Rectangle,System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})">Equality(Rectangle, (Point minExtent, Point maxExtent))</h4>
@@ -3483,7 +3850,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Rectangle r1, (Point minExtent, Point maxExtent) r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Rectangle r1, (Point minExtent, Point maxExtent) r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3501,7 +3869,7 @@ the width changed to the given value.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">r2</span></td>
         <td></td>
       </tr>
@@ -3517,7 +3885,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two rectangles are equal, false if not.</p>
 </td>
       </tr>
@@ -3528,7 +3896,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Equality_SadRogue_Primitives_Rectangle_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Equality(SadRogue.Primitives.Rectangle%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L622">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L752">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Equality_" data-uid="SadRogue.Primitives.Rectangle.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Equality_SadRogue_Primitives_Rectangle_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Rectangle.op_Equality(SadRogue.Primitives.Rectangle,System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})">Equality(Rectangle, (Int32 x, Int32 y, Int32 width, Int32 height))</h4>
@@ -3537,7 +3905,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==(Rectangle r1, (int x, int y, int width, int height) r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3555,7 +3924,7 @@ the width changed to the given value.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">r2</span></td>
         <td></td>
       </tr>
@@ -3571,7 +3940,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two rectangles are equal, false if not.</p>
 </td>
       </tr>
@@ -3582,7 +3951,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Equality_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Equality(System.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L709">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L866">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Equality_" data-uid="SadRogue.Primitives.Rectangle.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Equality_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.op_Equality(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point},SadRogue.Primitives.Rectangle)">Equality((Point minExtent, Point maxExtent), Rectangle)</h4>
@@ -3591,7 +3960,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==((Point minExtent, Point maxExtent) r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==((Point minExtent, Point maxExtent) r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3604,7 +3974,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">r1</span></td>
         <td></td>
       </tr>
@@ -3625,7 +3995,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two rectangles are equal, false if not.</p>
 </td>
       </tr>
@@ -3636,7 +4006,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Equality_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Equality(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L640">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L773">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Equality_" data-uid="SadRogue.Primitives.Rectangle.op_Equality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Equality_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.op_Equality(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32},SadRogue.Primitives.Rectangle)">Equality((Int32 x, Int32 y, Int32 width, Int32 height), Rectangle)</h4>
@@ -3645,7 +4015,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator ==((int x, int y, int width, int height) r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3658,7 +4029,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">r1</span></td>
         <td></td>
       </tr>
@@ -3679,7 +4050,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if the two rectangles are equal, false if not.</p>
 </td>
       </tr>
@@ -3690,7 +4061,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Implicit_SadRogue_Primitives_Rectangle__System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Implicit(SadRogue.Primitives.Rectangle)~System.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L666">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L814">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Implicit_" data-uid="SadRogue.Primitives.Rectangle.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Implicit_SadRogue_Primitives_Rectangle__System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point_" data-uid="SadRogue.Primitives.Rectangle.op_Implicit(SadRogue.Primitives.Rectangle)~System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point}">Implicit(Rectangle to (Point minExtent, Point maxExtent))</h4>
@@ -3699,7 +4070,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator (Point minExtent, Point maxExtent)(Rectangle rect)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator (Point minExtent, Point maxExtent)(Rectangle rect)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3728,7 +4100,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td></td>
       </tr>
     </tbody>
@@ -3738,7 +4110,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Implicit_SadRogue_Primitives_Rectangle__System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Implicit(SadRogue.Primitives.Rectangle)~System.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L593">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L717">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Implicit_" data-uid="SadRogue.Primitives.Rectangle.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Implicit_SadRogue_Primitives_Rectangle__System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32_" data-uid="SadRogue.Primitives.Rectangle.op_Implicit(SadRogue.Primitives.Rectangle)~System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32}">Implicit(Rectangle to (Int32 x, Int32 y, Int32 width, Int32 height))</h4>
@@ -3747,7 +4119,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator (int x, int y, int width, int height)(Rectangle rect)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator (int x, int y, int width, int height)(Rectangle rect)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3776,7 +4149,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td></td>
       </tr>
     </tbody>
@@ -3786,7 +4159,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Implicit_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point___SadRogue_Primitives_Rectangle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Implicit(System.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D)~SadRogue.Primitives.Rectangle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L672">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L823">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Implicit_" data-uid="SadRogue.Primitives.Rectangle.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Implicit_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point___SadRogue_Primitives_Rectangle" data-uid="SadRogue.Primitives.Rectangle.op_Implicit(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})~SadRogue.Primitives.Rectangle">Implicit((Point minExtent, Point maxExtent) to Rectangle)</h4>
@@ -3795,7 +4168,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator Rectangle((Point minExtent, Point maxExtent) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Rectangle((Point minExtent, Point maxExtent) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3808,7 +4182,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -3834,7 +4208,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Implicit_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32___SadRogue_Primitives_Rectangle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Implicit(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D)~SadRogue.Primitives.Rectangle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L599">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L726">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Implicit_" data-uid="SadRogue.Primitives.Rectangle.op_Implicit*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Implicit_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32___SadRogue_Primitives_Rectangle" data-uid="SadRogue.Primitives.Rectangle.op_Implicit(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})~SadRogue.Primitives.Rectangle">Implicit((Int32 x, Int32 y, Int32 width, Int32 height) to Rectangle)</h4>
@@ -3843,7 +4217,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static implicit operator Rectangle((int x, int y, int width, int height) tuple)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static implicit operator Rectangle((int x, int y, int width, int height) tuple)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3856,7 +4231,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">tuple</span></td>
         <td></td>
       </tr>
@@ -3882,7 +4257,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Inequality_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Inequality(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L295">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L305">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Inequality_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Inequality_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">Inequality(Rectangle, Rectangle)</h4>
@@ -3891,7 +4266,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Rectangle r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Rectangle r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3925,7 +4301,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>true if the rectangles do NOT encompass the same area, false otherwise.</p>
 </td>
       </tr>
@@ -3936,7 +4312,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Inequality_SadRogue_Primitives_Rectangle_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Inequality(SadRogue.Primitives.Rectangle%2CSystem.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L701">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L857">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Inequality_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Inequality_SadRogue_Primitives_Rectangle_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__" data-uid="SadRogue.Primitives.Rectangle.op_Inequality(SadRogue.Primitives.Rectangle,System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})">Inequality(Rectangle, (Point minExtent, Point maxExtent))</h4>
@@ -3945,7 +4321,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Rectangle r1, (Point minExtent, Point maxExtent) r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Rectangle r1, (Point minExtent, Point maxExtent) r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -3963,7 +4340,7 @@ the width changed to the given value.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">r2</span></td>
         <td></td>
       </tr>
@@ -3979,7 +4356,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if any of the x/y/width/height values are not equal, false if they are all equal.</p>
 </td>
       </tr>
@@ -3990,7 +4367,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Inequality_SadRogue_Primitives_Rectangle_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Inequality(SadRogue.Primitives.Rectangle%2CSystem.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L632">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L764">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Inequality_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Inequality_SadRogue_Primitives_Rectangle_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__" data-uid="SadRogue.Primitives.Rectangle.op_Inequality(SadRogue.Primitives.Rectangle,System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})">Inequality(Rectangle, (Int32 x, Int32 y, Int32 width, Int32 height))</h4>
@@ -3999,7 +4376,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=(Rectangle r1, (int x, int y, int width, int height) r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=(Rectangle r1, (int x, int y, int width, int height) r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -4017,7 +4395,7 @@ the width changed to the given value.</p>
         <td></td>
       </tr>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">r2</span></td>
         <td></td>
       </tr>
@@ -4033,7 +4411,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if any of the x/y/width/height values are not equal, false if they are all equal.</p>
 </td>
       </tr>
@@ -4044,7 +4422,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Inequality_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Inequality(System.ValueTuple%7BSadRogue.Primitives.Point%2CSadRogue.Primitives.Point%7D%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L719">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L878">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Inequality_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Inequality_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point},SadRogue.Primitives.Rectangle)">Inequality((Point minExtent, Point maxExtent), Rectangle)</h4>
@@ -4053,7 +4431,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=((Point minExtent, Point maxExtent) r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=((Point minExtent, Point maxExtent) r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -4066,7 +4445,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-2">ValueTuple</a>&lt;<a class="xref" href="SadRogue.Primitives.Point.html">Point</a>, <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>&gt;</td>
         <td><span class="parametername">r1</span></td>
         <td></td>
       </tr>
@@ -4087,7 +4466,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if any of the x/y/width/height values are not equal, false if they are all equal.</p>
 </td>
       </tr>
@@ -4098,7 +4477,7 @@ the width changed to the given value.</p>
     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle_op_Inequality_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle.op_Inequality(System.ValueTuple%7BSystem.Int32%2CSystem.Int32%2CSystem.Int32%2CSystem.Int32%7D%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L650">View Source</a>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L785">View Source</a>
   </span>
   <a id="SadRogue_Primitives_Rectangle_op_Inequality_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality*"></a>
   <h4 id="SadRogue_Primitives_Rectangle_op_Inequality_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.Rectangle.op_Inequality(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32},SadRogue.Primitives.Rectangle)">Inequality((Int32 x, Int32 y, Int32 width, Int32 height), Rectangle)</h4>
@@ -4107,7 +4486,8 @@ the width changed to the given value.</p>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public static bool operator !=((int x, int y, int width, int height) r1, Rectangle r2)</code></pre>
+    <pre><code class="lang-csharp hljs">[Pure]
+public static bool operator !=((int x, int y, int width, int height) r1, Rectangle r2)</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -4120,7 +4500,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.ValueTuple</span>&lt;<span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>, <span class="xref">System.Int32</span>&gt;</td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetuple-4">ValueTuple</a>&lt;<a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>, <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a>&gt;</td>
         <td><span class="parametername">r1</span></td>
         <td></td>
       </tr>
@@ -4141,7 +4521,7 @@ the width changed to the given value.</p>
     </thead>
     <tbody>
       <tr>
-        <td><span class="xref">System.Boolean</span></td>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
         <td><p>True if any of the x/y/width/height values are not equal, false if they are all equal.</p>
 </td>
       </tr>
@@ -4149,10 +4529,26 @@ the width changed to the given value.</p>
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
   </div>
   <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.iequatable-1">System.IEquatable&lt;T&gt;</a>
+  </div>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a>
+  </div>
+  <h3 id="extensionmethods">Extension Methods</h3>
+  <div>
+      <a class="xref" href="SadRogue.Primitives.RectangleExtensions.html#SadRogue_Primitives_RectangleExtensions_Matches_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_">RectangleExtensions.Matches(Rectangle, Rectangle)</a>
   </div>
 </article>
           </div>
@@ -4165,7 +4561,7 @@ the width changed to the given value.</p>
                     <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_Rectangle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.Rectangle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L10" class="contribution-link">View Source</a>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/Rectangle.cs/#L13" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/SadRogue.Primitives.RectangleExtensions.html
+++ b/docs/api/SadRogue.Primitives.RectangleExtensions.html
@@ -1,0 +1,211 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Class RectangleExtensions
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Class RectangleExtensions
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.RectangleExtensions">
+  
+  
+  <h1 id="SadRogue_Primitives_RectangleExtensions" data-uid="SadRogue.Primitives.RectangleExtensions" class="text-break">Class RectangleExtensions
+  </h1>
+  <div class="markdown level0 summary"><p>Contains set of operators that match ones defined by other packages for interoperability,
+so syntax may be uniform.  Functionality is similar to the corresponding actual operators for Color.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritance">
+    <h5>Inheritance</h5>
+    <div class="level0"><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object">Object</a></div>
+    <div class="level1"><span class="xref">RectangleExtensions</span></div>
+  </div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_">Object.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gethashcode#System_Object_GetHashCode">Object.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.memberwiseclone#System_Object_MemberwiseClone">Object.MemberwiseClone()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.tostring#System_Object_ToString">Object.ToString()</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.html">SadRogue.Primitives</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_RectangleExtensions_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static class RectangleExtensions</code></pre>
+  </div>
+  <h3 id="methods">Methods
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RectangleExtensions_Matches_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RectangleExtensions.Matches(SadRogue.Primitives.Rectangle%2CSadRogue.Primitives.Rectangle)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/RectangleExtensions.cs/#L15">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_RectangleExtensions_Matches_" data-uid="SadRogue.Primitives.RectangleExtensions.Matches*"></a>
+  <h4 id="SadRogue_Primitives_RectangleExtensions_Matches_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_" data-uid="SadRogue.Primitives.RectangleExtensions.Matches(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)">Matches(Rectangle, Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Compares a two rectangles for equality.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static bool Matches(this Rectangle self, Rectangle other)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">self</span></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">other</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_RectangleExtensions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.RectangleExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/RectangleExtensions.cs/#L7" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html
@@ -1,0 +1,278 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct AreaSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct AreaSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_AreaSerialized" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized" class="text-break">Struct AreaSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing an <a class="xref" href="SadRogue.Primitives.Area.html">Area</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_AreaSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct AreaSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_AreaSerialized_Positions.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.AreaSerialized.Positions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Area.cs/#L16">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_AreaSerialized_Positions" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized.Positions">Positions</h4>
+  <div class="markdown level1 summary"><p>Positions in the area.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public List&lt;PointSerialized&gt; Positions</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1">List</a>&lt;<a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a>&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_SadRogue_Primitives_Area__SadRogue_Primitives_SerializedTypes_AreaSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.Area)~SadRogue.Primitives.SerializedTypes.AreaSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Area.cs/#L31">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_SadRogue_Primitives_Area__SadRogue_Primitives_SerializedTypes_AreaSerialized" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.Area)~SadRogue.Primitives.SerializedTypes.AreaSerialized">Implicit(Area to AreaSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.Area.html">Area</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.AreaSerialized.html">AreaSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator AreaSerialized(Area area)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Area.html">Area</a></td>
+        <td><span class="parametername">area</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.AreaSerialized.html">AreaSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_AreaSerialized__SadRogue_Primitives_Area.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.AreaSerialized)~SadRogue.Primitives.Area%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Area.cs/#L23">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_AreaSerialized__SadRogue_Primitives_Area" data-uid="SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.AreaSerialized)~SadRogue.Primitives.Area">Implicit(AreaSerialized to Area)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.AreaSerialized.html">AreaSerialized</a> to <a class="xref" href="SadRogue.Primitives.Area.html">Area</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Area(AreaSerialized serialized)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.AreaSerialized.html">AreaSerialized</a></td>
+        <td><span class="parametername">serialized</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Area.html">Area</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_AreaSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.AreaSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Area.cs/#L10" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html
@@ -1,0 +1,308 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct BoundedRectangleSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct BoundedRectangleSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized" class="text-break">Struct BoundedRectangleSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct BoundedRectangleSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_Area.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Area%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs/#L14">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_Area" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Area">Area</h4>
+  <div class="markdown level1 summary"><p>Area the rectangle encompasses.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public RectangleSerialized Area</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_Bounds.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Bounds%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs/#L19">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_Bounds" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Bounds">Bounds</h4>
+  <div class="markdown level1 summary"><p>Bounds the area is restricted to.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public RectangleSerialized Bounds</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_SadRogue_Primitives_BoundedRectangle__SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.BoundedRectangle)~SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs/#L26">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_SadRogue_Primitives_BoundedRectangle__SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.BoundedRectangle)~SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized">Implicit(BoundedRectangle to BoundedRectangleSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html">BoundedRectangleSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator BoundedRectangleSerialized(BoundedRectangle rect)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></td>
+        <td><span class="parametername">rect</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html">BoundedRectangleSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized__SadRogue_Primitives_BoundedRectangle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized)~SadRogue.Primitives.BoundedRectangle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs/#L34">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized__SadRogue_Primitives_BoundedRectangle" data-uid="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized)~SadRogue.Primitives.BoundedRectangle">Implicit(BoundedRectangleSerialized to BoundedRectangle)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html">BoundedRectangleSerialized</a> to <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator BoundedRectangle(BoundedRectangleSerialized rect)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html">BoundedRectangleSerialized</a></td>
+        <td><span class="parametername">rect</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/BoundedRectangle.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html
@@ -1,0 +1,368 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct ColorSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct ColorSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_ColorSerialized" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized" class="text-break">Struct ColorSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct ColorSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized_A.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized.A%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L29">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_A" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.A">A</h4>
+  <div class="markdown level1 summary"><p>Alpha-value for the color.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public byte A</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized_B.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized.B%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L24">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_B" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.B">B</h4>
+  <div class="markdown level1 summary"><p>&quot;B&quot; value for the color.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public byte B</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized_G.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized.G%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L19">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_G" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.G">G</h4>
+  <div class="markdown level1 summary"><p>&quot;G&quot; value for the color.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public byte G</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized_R.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized.R%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L14">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_R" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.R">R</h4>
+  <div class="markdown level1 summary"><p>&quot;R&quot; value for the color.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public byte R</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.byte">Byte</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_SadRogue_Primitives_Color__SadRogue_Primitives_SerializedTypes_ColorSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.SerializedTypes.ColorSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L36">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_SadRogue_Primitives_Color__SadRogue_Primitives_SerializedTypes_ColorSerialized" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.SerializedTypes.ColorSerialized">Implicit(Color to ColorSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.Color.html">Color</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator ColorSerialized(Color color)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td><span class="parametername">color</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_ColorSerialized__SadRogue_Primitives_Color.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.ColorSerialized)~SadRogue.Primitives.Color%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L44">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_ColorSerialized__SadRogue_Primitives_Color" data-uid="SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.ColorSerialized)~SadRogue.Primitives.Color">Implicit(ColorSerialized to Color)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a> to <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Color(ColorSerialized color)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a></td>
+        <td><span class="parametername">color</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_ColorSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.ColorSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Color.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html
@@ -1,0 +1,278 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct GradientSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct GradientSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GradientSerialized" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized" class="text-break">Struct GradientSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_GradientSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct GradientSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientSerialized_Stops.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientSerialized.Stops%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L49">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientSerialized_Stops" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized.Stops">Stops</h4>
+  <div class="markdown level1 summary"><p>Colors/stop locations that describe the gradient.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public List&lt;GradientStopSerialized&gt; Stops</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1">List</a>&lt;<a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html">GradientStopSerialized</a>&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_SadRogue_Primitives_Gradient__SadRogue_Primitives_SerializedTypes_GradientSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.SerializedTypes.GradientSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L69">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_SadRogue_Primitives_Gradient__SadRogue_Primitives_SerializedTypes_GradientSerialized" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.SerializedTypes.GradientSerialized">Implicit(Gradient to GradientSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientSerialized.html">GradientSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator GradientSerialized(Gradient gradient)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a></td>
+        <td><span class="parametername">gradient</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientSerialized.html">GradientSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_GradientSerialized__SadRogue_Primitives_Gradient.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientSerialized)~SadRogue.Primitives.Gradient%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L56">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_GradientSerialized__SadRogue_Primitives_Gradient" data-uid="SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientSerialized)~SadRogue.Primitives.Gradient">Implicit(GradientSerialized to Gradient)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientSerialized.html">GradientSerialized</a> to <a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Gradient(GradientSerialized serialized)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientSerialized.html">GradientSerialized</a></td>
+        <td><span class="parametername">serialized</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L43" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html
@@ -1,0 +1,308 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct GradientStopSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct GradientStopSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized" class="text-break">Struct GradientStopSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct GradientStopSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientStopSerialized_Color.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Color%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L16">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_Color" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Color">Color</h4>
+  <div class="markdown level1 summary"><p>Color of the stop.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ColorSerialized Color</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientStopSerialized_Stop.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Stop%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L21">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_Stop" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Stop">Stop</h4>
+  <div class="markdown level1 summary"><p>Location where the stop is used.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public float Stop</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.single">Single</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_SadRogue_Primitives_GradientStop__SadRogue_Primitives_SerializedTypes_GradientStopSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.GradientStop)~SadRogue.Primitives.SerializedTypes.GradientStopSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L36">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_SadRogue_Primitives_GradientStop__SadRogue_Primitives_SerializedTypes_GradientStopSerialized" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.GradientStop)~SadRogue.Primitives.SerializedTypes.GradientStopSerialized">Implicit(GradientStop to GradientStopSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html">GradientStopSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator GradientStopSerialized(GradientStop stop)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a></td>
+        <td><span class="parametername">stop</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html">GradientStopSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_GradientStopSerialized__SadRogue_Primitives_GradientStop.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientStopSerialized)~SadRogue.Primitives.GradientStop%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L28">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_GradientStopSerialized__SadRogue_Primitives_GradientStop" data-uid="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientStopSerialized)~SadRogue.Primitives.GradientStop">Implicit(GradientStopSerialized to GradientStop)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html">GradientStopSerialized</a> to <a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator GradientStop(GradientStopSerialized serialized)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html">GradientStopSerialized</a></td>
+        <td><span class="parametername">serialized</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GradientStopSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GradientStopSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Gradient.cs/#L10" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html
@@ -1,0 +1,324 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct ArrayViewSerialized&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct ArrayViewSerialized&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1" class="text-break">Struct ArrayViewSerialized&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing an <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.html">SadRogue.Primitives.SerializedTypes.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct ArrayViewSerialized&lt;T&gt;</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value being exposed via the grid view.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_Data.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%601.Data%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/ArrayView.cs/#L21">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_Data" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.Data">Data</h4>
+  <div class="markdown level1 summary"><p>The data from the array view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T[] Data</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>T[]</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%601.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/ArrayView.cs/#L16">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_Width" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.Width">Width</h4>
+  <div class="markdown level1 summary"><p>Width of the array view.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Width</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView__0___SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%601.op_Implicit(SadRogue.Primitives.GridViews.ArrayView%7B%600%7D)~SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/ArrayView.cs/#L28">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView__0___SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView{`0})~SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized{`0}">Implicit(ArrayView&lt;T&gt; to ArrayViewSerialized&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html">ArrayViewSerialized&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator ArrayViewSerialized&lt;T&gt;(ArrayView&lt;T&gt; arrayView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView</a>&lt;T&gt;</td>
+        <td><span class="parametername">arrayView</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html">ArrayViewSerialized</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized__0___SadRogue_Primitives_GridViews_ArrayView__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%601.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%7B%600%7D)~SadRogue.Primitives.GridViews.ArrayView%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/ArrayView.cs/#L40">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized__0___SadRogue_Primitives_GridViews_ArrayView__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized{`0})~SadRogue.Primitives.GridViews.ArrayView{`0}">Implicit(ArrayViewSerialized&lt;T&gt; to ArrayView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html">ArrayViewSerialized&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator ArrayView&lt;T&gt;(ArrayViewSerialized&lt;T&gt; arrayView)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html">ArrayViewSerialized</a>&lt;T&gt;</td>
+        <td><span class="parametername">arrayView</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/ArrayView.cs/#L10" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html
@@ -1,0 +1,385 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct DiffAwareGridViewSerialized&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct DiffAwareGridViewSerialized&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1" class="text-break">Struct DiffAwareGridViewSerialized&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.html">SadRogue.Primitives.SerializedTypes.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct DiffAwareGridViewSerialized&lt;T&gt;
+    where T : struct</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value being changed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_AutoCompress.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601.AutoCompress%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L110">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_AutoCompress" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.AutoCompress">AutoCompress</h4>
+  <div class="markdown level1 summary"><p>Whether or not to automatically compress diffs when the currently applied diff is changed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public bool AutoCompress</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.boolean">Boolean</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_BaseGrid.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601.BaseGrid%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L95">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_BaseGrid" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.BaseGrid">BaseGrid</h4>
+  <div class="markdown level1 summary"><p>The grid view whose changes are being recorded in diffs.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public ISettableGridView&lt;T&gt; BaseGrid</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ISettableGridView-1.html">ISettableGridView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_CurrentDiffIndex.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601.CurrentDiffIndex%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L100">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_CurrentDiffIndex" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.CurrentDiffIndex">CurrentDiffIndex</h4>
+  <div class="markdown level1 summary"><p>The index of the diff whose ending state is currently reflected in <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_BaseGrid">BaseGrid</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int CurrentDiffIndex</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_Diffs.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601.Diffs%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L105">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_Diffs" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.Diffs">Diffs</h4>
+  <div class="markdown level1 summary"><p>All diffs recorded for the current grid view, and their changes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public List&lt;DiffSerialized&lt;T&gt;&gt; Diffs</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1">List</a>&lt;<a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html">DiffSerialized</a>&lt;T&gt;&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_DiffAwareGridView__0___SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601.op_Implicit(SadRogue.Primitives.GridViews.DiffAwareGridView%7B%600%7D)~SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L117">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_DiffAwareGridView__0___SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.DiffAwareGridView{`0})~SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized{`0}">Implicit(DiffAwareGridView&lt;T&gt; to DiffAwareGridViewSerialized&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html">DiffAwareGridViewSerialized&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator DiffAwareGridViewSerialized&lt;T&gt;(DiffAwareGridView&lt;T&gt; view)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView</a>&lt;T&gt;</td>
+        <td><span class="parametername">view</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html">DiffAwareGridViewSerialized</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized__0___SadRogue_Primitives_GridViews_DiffAwareGridView__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%7B%600%7D)~SadRogue.Primitives.GridViews.DiffAwareGridView%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L132">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized__0___SadRogue_Primitives_GridViews_DiffAwareGridView__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized{`0})~SadRogue.Primitives.GridViews.DiffAwareGridView{`0}">Implicit(DiffAwareGridViewSerialized&lt;T&gt; to DiffAwareGridView&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html">DiffAwareGridViewSerialized&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator DiffAwareGridView&lt;T&gt;(DiffAwareGridViewSerialized&lt;T&gt; view)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html">DiffAwareGridViewSerialized</a>&lt;T&gt;</td>
+        <td><span class="parametername">view</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L89" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html
@@ -1,0 +1,295 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct DiffSerialized&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct DiffSerialized&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1" class="text-break">Struct DiffSerialized&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.html">SadRogue.Primitives.SerializedTypes.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct DiffSerialized&lt;T&gt;
+    where T : struct</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value being changed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_Changes.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized%601.Changes%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L18">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_Changes" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.Changes">Changes</h4>
+  <div class="markdown level1 summary"><p>Changes recorded in this diff.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public List&lt;ValueChangeSerialized&lt;T&gt;&gt; Changes</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1">List</a>&lt;<a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html">ValueChangeSerialized</a>&lt;T&gt;&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_Diff__0___SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized%601.op_Implicit(SadRogue.Primitives.GridViews.Diff%7B%600%7D)~SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L25">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_Diff__0___SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.Diff{`0})~SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized{`0}">Implicit(Diff&lt;T&gt; to DiffSerialized&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html">DiffSerialized&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator DiffSerialized&lt;T&gt;(Diff&lt;T&gt; diff)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff</a>&lt;T&gt;</td>
+        <td><span class="parametername">diff</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html">DiffSerialized</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized__0___SadRogue_Primitives_GridViews_Diff__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized%601.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized%7B%600%7D)~SadRogue.Primitives.GridViews.Diff%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L37">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized__0___SadRogue_Primitives_GridViews_Diff__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized{`0})~SadRogue.Primitives.GridViews.Diff{`0}">Implicit(DiffSerialized&lt;T&gt; to Diff&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html">DiffSerialized&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Diff&lt;T&gt;(DiffSerialized&lt;T&gt; diff)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html">DiffSerialized</a>&lt;T&gt;</td>
+        <td><span class="parametername">diff</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L12" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html
@@ -1,0 +1,355 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct ValueChangeSerialized&lt;T&gt;
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct ValueChangeSerialized&lt;T&gt;
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1" class="text-break">Struct ValueChangeSerialized&lt;T&gt;
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.html">SadRogue.Primitives.SerializedTypes.GridViews</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct ValueChangeSerialized&lt;T&gt;
+    where T : struct</code></pre>
+  </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">T</span></td>
+        <td><p>Type of value being changed.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_NewValue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%601.NewValue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L61">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_NewValue" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.NewValue">NewValue</h4>
+  <div class="markdown level1 summary"><p>New value that was set.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T NewValue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_OldValue.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%601.OldValue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L56">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_OldValue" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.OldValue">OldValue</h4>
+  <div class="markdown level1 summary"><p>Original value that was changed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public T OldValue</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">T</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_Position.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%601.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L51">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_Position" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.Position">Position</h4>
+  <div class="markdown level1 summary"><p>Position whose value was changed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public PointSerialized Position</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_ValueChange__0___SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%601.op_Implicit(SadRogue.Primitives.GridViews.ValueChange%7B%600%7D)~SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L68">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_ValueChange__0___SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.ValueChange{`0})~SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized{`0}">Implicit(ValueChange&lt;T&gt; to ValueChangeSerialized&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html">ValueChangeSerialized&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator ValueChangeSerialized&lt;T&gt;(ValueChange&lt;T&gt; valueChange)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td><span class="parametername">valueChange</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html">ValueChangeSerialized</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized__0___SadRogue_Primitives_GridViews_ValueChange__0_.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%601.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%7B%600%7D)~SadRogue.Primitives.GridViews.ValueChange%7B%600%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L81">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized__0___SadRogue_Primitives_GridViews_ValueChange__0_" data-uid="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized{`0})~SadRogue.Primitives.GridViews.ValueChange{`0}">Implicit(ValueChangeSerialized&lt;T&gt; to ValueChange&lt;T&gt;)</h4>
+  <div class="markdown level1 summary"><p>Converts <a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html">ValueChangeSerialized&lt;T&gt;</a> to <a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange&lt;T&gt;</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator ValueChange&lt;T&gt;(ValueChangeSerialized&lt;T&gt; valueChange)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html">ValueChangeSerialized</a>&lt;T&gt;</td>
+        <td><span class="parametername">valueChange</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange</a>&lt;T&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/GridViews/DiffAwareGridView.cs/#L45" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.GridViews.html
@@ -1,0 +1,127 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace SadRogue.Primitives.SerializedTypes.GridViews
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace SadRogue.Primitives.SerializedTypes.GridViews
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.GridViews">
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_GridViews" data-uid="SadRogue.Primitives.SerializedTypes.GridViews" class="text-break">Namespace SadRogue.Primitives.SerializedTypes.GridViews
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="structs">Structs
+  </h3>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html">ArrayViewSerialized&lt;T&gt;</a></h4>
+      <section><p>Serializable (pure-data) object representing an <a class="xref" href="SadRogue.Primitives.GridViews.ArrayView-1.html">ArrayView&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html">DiffAwareGridViewSerialized&lt;T&gt;</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html">DiffAwareGridView&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html">DiffSerialized&lt;T&gt;</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GridViews.Diff-1.html">Diff&lt;T&gt;</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html">ValueChangeSerialized&lt;T&gt;</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GridViews.ValueChange-1.html">ValueChange&lt;T&gt;</a>.</p>
+</section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html
@@ -1,0 +1,278 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct PaletteSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct PaletteSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_PaletteSerialized" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized" class="text-break">Struct PaletteSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_PaletteSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct PaletteSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PaletteSerialized_Colors.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PaletteSerialized.Colors%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Palette.cs/#L16">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PaletteSerialized_Colors" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized.Colors">Colors</h4>
+  <div class="markdown level1 summary"><p>Colors in the palette.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public List&lt;ColorSerialized&gt; Colors</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1">List</a>&lt;<a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a>&gt;</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_SadRogue_Primitives_Palette__SadRogue_Primitives_SerializedTypes_PaletteSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.Palette)~SadRogue.Primitives.SerializedTypes.PaletteSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Palette.cs/#L31">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_SadRogue_Primitives_Palette__SadRogue_Primitives_SerializedTypes_PaletteSerialized" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.Palette)~SadRogue.Primitives.SerializedTypes.PaletteSerialized">Implicit(Palette to PaletteSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.PaletteSerialized.html">PaletteSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator PaletteSerialized(Palette palette)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a></td>
+        <td><span class="parametername">palette</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PaletteSerialized.html">PaletteSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PaletteSerialized__SadRogue_Primitives_Palette.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PaletteSerialized)~SadRogue.Primitives.Palette%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Palette.cs/#L23">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PaletteSerialized__SadRogue_Primitives_Palette" data-uid="SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PaletteSerialized)~SadRogue.Primitives.Palette">Implicit(PaletteSerialized to Palette)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.SerializedTypes.PaletteSerialized.html">PaletteSerialized</a> to <a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Palette(PaletteSerialized serialized)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PaletteSerialized.html">PaletteSerialized</a></td>
+        <td><span class="parametername">serialized</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PaletteSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PaletteSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Palette.cs/#L10" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.PointSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.PointSerialized.html
@@ -1,0 +1,308 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct PointSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct PointSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_PointSerialized" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized" class="text-break">Struct PointSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_PointSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct PointSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PointSerialized_X.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PointSerialized.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Point.cs/#L14">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PointSerialized_X" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized.X">X</h4>
+  <div class="markdown level1 summary"><p>X-coordinate of the point.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int X</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PointSerialized_Y.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PointSerialized.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Point.cs/#L19">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PointSerialized_Y" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized.Y">Y</h4>
+  <div class="markdown level1 summary"><p>Y-coordinate of the point.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Y</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_SadRogue_Primitives_Point__SadRogue_Primitives_SerializedTypes_PointSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.SerializedTypes.PointSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Point.cs/#L26">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_SadRogue_Primitives_Point__SadRogue_Primitives_SerializedTypes_PointSerialized" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.SerializedTypes.PointSerialized">Implicit(Point to PointSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.Point.html">Point</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator PointSerialized(Point point)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td><span class="parametername">point</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PointSerialized__SadRogue_Primitives_Point.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PointSerialized)~SadRogue.Primitives.Point%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Point.cs/#L34">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PointSerialized__SadRogue_Primitives_Point" data-uid="SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PointSerialized)~SadRogue.Primitives.Point">Implicit(PointSerialized to Point)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a> to <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Point(PointSerialized serialized)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a></td>
+        <td><span class="parametername">serialized</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Point.html">Point</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PointSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PointSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Point.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html
@@ -1,0 +1,308 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct PolarCoordinateSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct PolarCoordinateSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized" class="text-break">Struct PolarCoordinateSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct PolarCoordinateSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_Radius.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Radius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs/#L14">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_Radius" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Radius">Radius</h4>
+  <div class="markdown level1 summary"><p>The distance away from the Origin (0,0) of this Polar Coord</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public double Radius</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_Theta.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Theta%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs/#L19">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_Theta" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Theta">Theta</h4>
+  <div class="markdown level1 summary"><p>The angle of rotation, clockwise, in radians</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public double Theta</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.double">Double</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_SadRogue_Primitives_PolarCoordinate__SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs/#L26">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_SadRogue_Primitives_PolarCoordinate__SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized">Implicit(PolarCoordinate to PolarCoordinateSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html">PolarCoordinateSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator PolarCoordinateSerialized(PolarCoordinate point)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td><span class="parametername">point</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html">PolarCoordinateSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized__SadRogue_Primitives_PolarCoordinate.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized)~SadRogue.Primitives.PolarCoordinate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs/#L34">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized__SadRogue_Primitives_PolarCoordinate" data-uid="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized)~SadRogue.Primitives.PolarCoordinate">Implicit(PolarCoordinateSerialized to PolarCoordinate)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html">PolarCoordinateSerialized</a> to <a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator PolarCoordinate(PolarCoordinateSerialized serialized)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html">PolarCoordinateSerialized</a></td>
+        <td><span class="parametername">serialized</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/PolarCoordinate.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html
@@ -1,0 +1,368 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Struct RectangleSerialized
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Struct RectangleSerialized
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized">
+  
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized" class="text-break">Struct RectangleSerialized
+  </h1>
+  <div class="markdown level0 summary"><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>.</p>
+</div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="inheritedMembers">
+    <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.equals#System_ValueType_Equals_System_Object_">ValueType.Equals(Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.gethashcode#System_ValueType_GetHashCode">ValueType.GetHashCode()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.valuetype.tostring#System_ValueType_ToString">ValueType.ToString()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.equals#System_Object_Equals_System_Object_System_Object_">Object.Equals(Object, Object)</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.gettype#System_Object_GetType">Object.GetType()</a>
+    </div>
+    <div>
+      <a class="xref" href="https://docs.microsoft.com/dotnet/api/system.object.referenceequals#System_Object_ReferenceEquals_System_Object_System_Object_">Object.ReferenceEquals(Object, Object)</a>
+    </div>
+  </div>
+  <h6><strong>Namespace</strong>: <a class="xref" href="SadRogue.Primitives.SerializedTypes.html">SadRogue.Primitives.SerializedTypes</a></h6>
+  <h6><strong>Assembly</strong>: TheSadRogue.Primitives.dll</h6>
+  <h5 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_syntax">Syntax</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">[Serializable]
+public struct RectangleSerialized</code></pre>
+  </div>
+  <h3 id="fields">Fields
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized_Height.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized.Height%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L29">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_Height" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.Height">Height</h4>
+  <div class="markdown level1 summary"><p>Height of the rectangle.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Height</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized_Width.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized.Width%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L24">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_Width" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.Width">Width</h4>
+  <div class="markdown level1 summary"><p>Width of the rectangle.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Width</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized_X.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L14">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_X" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.X">X</h4>
+  <div class="markdown level1 summary"><p>X-coordinate of the minimum extent of the rectangle.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int X</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized_Y.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L19">View Source</a>
+  </span>
+  <h4 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_Y" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.Y">Y</h4>
+  <div class="markdown level1 summary"><p>Y-coordinate of the minimum extent of the rectangle.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public int Y</code></pre>
+  </div>
+  <h5 class="fieldValue">Field Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="https://docs.microsoft.com/dotnet/api/system.int32">Int32</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h3 id="operators">Operators
+  </h3>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_SadRogue_Primitives_Rectangle__SadRogue_Primitives_SerializedTypes_RectangleSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.Rectangle)~SadRogue.Primitives.SerializedTypes.RectangleSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L36">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_SadRogue_Primitives_Rectangle__SadRogue_Primitives_SerializedTypes_RectangleSerialized" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.Rectangle)~SadRogue.Primitives.SerializedTypes.RectangleSerialized">Implicit(Rectangle to RectangleSerialized)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a> to <a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator RectangleSerialized(Rectangle rect)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td><span class="parametername">rect</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <span class="small pull-right mobile-hide">
+    <span class="divider">|</span>
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_RectangleSerialized__SadRogue_Primitives_Rectangle.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.RectangleSerialized)~SadRogue.Primitives.Rectangle%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+  </span>
+  <span class="small pull-right mobile-hide">
+    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L46">View Source</a>
+  </span>
+  <a id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit*"></a>
+  <h4 id="SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_RectangleSerialized__SadRogue_Primitives_Rectangle" data-uid="SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.RectangleSerialized)~SadRogue.Primitives.Rectangle">Implicit(RectangleSerialized to Rectangle)</h4>
+  <div class="markdown level1 summary"><p>Converts from <a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a> to <a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static implicit operator Rectangle(RectangleSerialized rect)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a></td>
+        <td><span class="parametername">rect</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/new/develop-chris3606/apiSpec/new?filename=SadRogue_Primitives_SerializedTypes_RectangleSerialized.md&amp;value=---%0Auid%3A%20SadRogue.Primitives.SerializedTypes.RectangleSerialized%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                  </li>
+                  <li>
+                    <a href="https://github.com/thesadrogue/TheSadRogue.Primitives/blob/develop-chris3606/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs/#L8" class="contribution-link">View Source</a>
+                  </li>
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.SerializedTypes.html
+++ b/docs/api/SadRogue.Primitives.SerializedTypes.html
@@ -1,0 +1,142 @@
+﻿<!DOCTYPE html>
+<!--[if IE]><![endif]-->
+<html>
+  
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Namespace SadRogue.Primitives.SerializedTypes
+   </title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="title" content="Namespace SadRogue.Primitives.SerializedTypes
+   ">
+    <meta name="generator" content="docfx 2.52.0.0">
+    
+    <link rel="shortcut icon" href="../favicon.ico">
+    <link rel="stylesheet" href="../styles/docfx.vendor.css">
+    <link rel="stylesheet" href="../styles/docfx.css">
+    <link rel="stylesheet" href="../styles/main.css">
+    <meta property="docfx:navrel" content="../toc.html">
+    <meta property="docfx:tocrel" content="toc.html">
+    
+    
+    
+  </head>
+  <body data-spy="scroll" data-target="#affix" data-offset="120">
+    <div id="wrapper">
+      <header>
+        
+        <nav id="autocollapse" class="navbar navbar-inverse ng-scope" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              
+              <a class="navbar-brand" href="../index.html">
+                <img id="logo" class="svg" src="../logo.svg" alt="">
+              </a>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar">
+              <form class="navbar-form navbar-right" role="search" id="search">
+                <div class="form-group">
+                  <input type="text" class="form-control" id="search-query" placeholder="Search" autocomplete="off">
+                </div>
+              </form>
+            </div>
+          </div>
+        </nav>
+        
+        <div class="subnav navbar navbar-default">
+          <div class="container hide-when-search" id="breadcrumb">
+            <ul class="breadcrumb">
+              <li></li>
+            </ul>
+          </div>
+        </div>
+      </header>
+      <div role="main" class="container body-content hide-when-search">
+        
+        <div class="sidenav hide-when-search">
+          <a class="btn toc-toggle collapse" data-toggle="collapse" href="#sidetoggle" aria-expanded="false" aria-controls="sidetoggle">Show / Hide Table of Contents</a>
+          <div class="sidetoggle collapse" id="sidetoggle">
+            <div id="sidetoc"></div>
+          </div>
+        </div>
+        <div class="article row grid-right">
+          <div class="col-md-10">
+            <article class="content wrap" id="_content" data-uid="SadRogue.Primitives.SerializedTypes">
+  
+  <h1 id="SadRogue_Primitives_SerializedTypes" data-uid="SadRogue.Primitives.SerializedTypes" class="text-break">Namespace SadRogue.Primitives.SerializedTypes
+  </h1>
+  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 conceptual"></div>
+  <div class="markdown level0 remarks"></div>
+    <h3 id="structs">Structs
+  </h3>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.AreaSerialized.html">AreaSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing an <a class="xref" href="SadRogue.Primitives.Area.html">Area</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html">BoundedRectangleSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html">ColorSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Color.html">Color</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientSerialized.html">GradientSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html">GradientStopSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.GradientStop.html">GradientStop</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.PaletteSerialized.html">PaletteSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Palette.html">Palette</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.PointSerialized.html">PointSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Point.html">Point</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html">PolarCoordinateSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a>.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html">RectangleSerialized</a></h4>
+      <section><p>Serializable (pure-data) object representing a <a class="xref" href="SadRogue.Primitives.Rectangle.html">Rectangle</a>.</p>
+</section>
+</article>
+          </div>
+          
+          <div class="hidden-sm col-md-2" role="complementary">
+            <div class="sideaffix">
+              <div class="contribution">
+                <ul class="nav">
+                </ul>
+              </div>
+              <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <footer>
+        <div class="grad-bottom"></div>
+        <div class="footer">
+          <div class="container">
+            <span class="pull-right">
+              <a href="#top">Back to top</a>
+            </span>
+            
+            <span>Generated by <strong>DocFX</strong></span>
+          </div>
+        </div>
+      </footer>
+    </div>
+    
+    <script type="text/javascript" src="../styles/docfx.vendor.js"></script>
+    <script type="text/javascript" src="../styles/docfx.js"></script>
+    <script type="text/javascript" src="../styles/main.js"></script>
+  </body>
+</html>

--- a/docs/api/SadRogue.Primitives.html
+++ b/docs/api/SadRogue.Primitives.html
@@ -82,9 +82,13 @@
 unique position in the area.</p>
 </section>
       <h4><a class="xref" href="SadRogue.Primitives.BoundedRectangle.html">BoundedRectangle</a></h4>
-      <section><p>This class defines a 2D rectanglar area, whose area is automatically &quot;locked&quot; to
+      <section><p>This class defines a 2D rectangular area, whose area is automatically &quot;locked&quot; to
 being inside a rectangular bounding box as it is changed. A typical use might be
 keeping track of a camera's view area.</p>
+</section>
+      <h4><a class="xref" href="SadRogue.Primitives.ColorExtensions.html">ColorExtensions</a></h4>
+      <section><p>Contains set of operators that match ones defined by other packages for interoperability,
+so syntax may be uniform.  Functionality is similar to the corresponding actual operators for Color.</p>
 </section>
       <h4><a class="xref" href="SadRogue.Primitives.Gradient.html">Gradient</a></h4>
       <section><p>Represents a gradient with multiple color stops.</p>
@@ -106,11 +110,15 @@ so syntax may be uniform.  Functionality is similar to the corresponding actual 
 more performant in cases where you're getting the positions in a radius of the same size many times,
 even if the location center point or shape of the radius is changing.</p>
 </section>
+      <h4><a class="xref" href="SadRogue.Primitives.RectangleExtensions.html">RectangleExtensions</a></h4>
+      <section><p>Contains set of operators that match ones defined by other packages for interoperability,
+so syntax may be uniform.  Functionality is similar to the corresponding actual operators for Color.</p>
+</section>
     <h3 id="structs">Structs
   </h3>
       <h4><a class="xref" href="SadRogue.Primitives.AdjacencyRule.html">AdjacencyRule</a></h4>
       <section><p>Structure representing a method for determining which coordinates are adjacent to a given
-coordinate, and which directions those neighbors are in. Cannot be instantiated -- premade
+coordinate, and which directions those neighbors are in. Cannot be instantiated -- pre-made
 static instances are provided.</p>
 </section>
       <h4><a class="xref" href="SadRogue.Primitives.Color.html">Color</a></h4>
@@ -134,6 +142,9 @@ various distance calculations.</p>
       <section><p>A structure that represents a standard 2D point.  Provides numerous functions and operators that enable
 common grid/position-related math and operations.</p>
 </section>
+      <h4><a class="xref" href="SadRogue.Primitives.PolarCoordinate.html">PolarCoordinate</a></h4>
+      <section><p>A Polar Coordinate.</p>
+</section>
       <h4><a class="xref" href="SadRogue.Primitives.Radius.html">Radius</a></h4>
       <section><p>Structure representing different shapes that define the concept of a radius on a grid. You cannot
 create instances of this class using a constructor -- instead, this class contains static instances
@@ -145,8 +156,12 @@ involving rectangles.</p>
 </section>
     <h3 id="interfaces">Interfaces
   </h3>
+      <h4><a class="xref" href="SadRogue.Primitives.IMatchable-1.html">IMatchable&lt;T&gt;</a></h4>
+      <section><p>Interface implemented to define a form of checking value equality, without guarantees that it corresponds
+to GetHashCode.</p>
+</section>
       <h4><a class="xref" href="SadRogue.Primitives.IReadOnlyArea.html">IReadOnlyArea</a></h4>
-      <section><p>Read-only interface for an arbitry 2D area.</p>
+      <section><p>Read-only interface for an arbitrary 2D area.</p>
 </section>
     <h3 id="enums">Enums
   </h3>

--- a/docs/api/toc.html
+++ b/docs/api/toc.html
@@ -33,6 +33,9 @@
                               <a href="SadRogue.Primitives.Color.html" name="" title="Color">Color</a>
                           </li>
                           <li>
+                              <a href="SadRogue.Primitives.ColorExtensions.html" name="" title="ColorExtensions">ColorExtensions</a>
+                          </li>
+                          <li>
                               <a href="SadRogue.Primitives.Direction.html" name="" title="Direction">Direction</a>
                           </li>
                           <li>
@@ -51,6 +54,9 @@
                               <a href="SadRogue.Primitives.GradientStop.html" name="" title="GradientStop">GradientStop</a>
                           </li>
                           <li>
+                              <a href="SadRogue.Primitives.IMatchable-1.html" name="" title="IMatchable&lt;T&gt;">IMatchable&lt;T&gt;</a>
+                          </li>
+                          <li>
                               <a href="SadRogue.Primitives.IReadOnlyArea.html" name="" title="IReadOnlyArea">IReadOnlyArea</a>
                           </li>
                           <li>
@@ -66,6 +72,9 @@
                               <a href="SadRogue.Primitives.PointExtensions.html" name="" title="PointExtensions">PointExtensions</a>
                           </li>
                           <li>
+                              <a href="SadRogue.Primitives.PolarCoordinate.html" name="" title="PolarCoordinate">PolarCoordinate</a>
+                          </li>
+                          <li>
                               <a href="SadRogue.Primitives.Radius.html" name="" title="Radius">Radius</a>
                           </li>
                           <li>
@@ -76,6 +85,126 @@
                           </li>
                           <li>
                               <a href="SadRogue.Primitives.Rectangle.html" name="" title="Rectangle">Rectangle</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.RectangleExtensions.html" name="" title="RectangleExtensions">RectangleExtensions</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="SadRogue.Primitives.GridViews.html" name="" title="SadRogue.Primitives.GridViews">SadRogue.Primitives.GridViews</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.ArrayView-1.html" name="" title="ArrayView&lt;T&gt;">ArrayView&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.ArrayView2D-1.html" name="" title="ArrayView2D&lt;T&gt;">ArrayView2D&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.Diff-1.html" name="" title="Diff&lt;T&gt;">Diff&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.DiffAwareGridView-1.html" name="" title="DiffAwareGridView&lt;T&gt;">DiffAwareGridView&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.GridViewBase-1.html" name="" title="GridViewBase&lt;T&gt;">GridViewBase&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.GridViewExtensions.html" name="" title="GridViewExtensions">GridViewExtensions</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.IGridView-1.html" name="" title="IGridView&lt;T&gt;">IGridView&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.ISettableGridView-1.html" name="" title="ISettableGridView&lt;T&gt;">ISettableGridView&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.LambdaGridView-1.html" name="" title="LambdaGridView&lt;T&gt;">LambdaGridView&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html" name="" title="LambdaSettableGridView&lt;T&gt;">LambdaSettableGridView&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html" name="" title="LambdaSettableTranslationGridView&lt;T1, T2&gt;">LambdaSettableTranslationGridView&lt;T1, T2&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html" name="" title="LambdaTranslationGridView&lt;T1, T2&gt;">LambdaTranslationGridView&lt;T1, T2&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.SettableGridViewBase-1.html" name="" title="SettableGridViewBase&lt;T&gt;">SettableGridViewBase&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html" name="" title="SettableTranslationGridView&lt;T1, T2&gt;">SettableTranslationGridView&lt;T1, T2&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.SettableViewport-1.html" name="" title="SettableViewport&lt;T&gt;">SettableViewport&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.TranslationGridView-2.html" name="" title="TranslationGridView&lt;T1, T2&gt;">TranslationGridView&lt;T1, T2&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.UnboundedViewport-1.html" name="" title="UnboundedViewport&lt;T&gt;">UnboundedViewport&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.ValueChange-1.html" name="" title="ValueChange&lt;T&gt;">ValueChange&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.GridViews.Viewport-1.html" name="" title="Viewport&lt;T&gt;">Viewport&lt;T&gt;</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="SadRogue.Primitives.SerializedTypes.html" name="" title="SadRogue.Primitives.SerializedTypes">SadRogue.Primitives.SerializedTypes</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.AreaSerialized.html" name="" title="AreaSerialized">AreaSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html" name="" title="BoundedRectangleSerialized">BoundedRectangleSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.ColorSerialized.html" name="" title="ColorSerialized">ColorSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.GradientSerialized.html" name="" title="GradientSerialized">GradientSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html" name="" title="GradientStopSerialized">GradientStopSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.PaletteSerialized.html" name="" title="PaletteSerialized">PaletteSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.PointSerialized.html" name="" title="PointSerialized">PointSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html" name="" title="PolarCoordinateSerialized">PolarCoordinateSerialized</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.RectangleSerialized.html" name="" title="RectangleSerialized">RectangleSerialized</a>
+                          </li>
+                    </ul>
+                </li>
+                <li>
+                    <span class="expand-stub"></span>
+                    <a href="SadRogue.Primitives.SerializedTypes.GridViews.html" name="" title="SadRogue.Primitives.SerializedTypes.GridViews">SadRogue.Primitives.SerializedTypes.GridViews</a>
+                    
+                    <ul class="nav level2">
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html" name="" title="ArrayViewSerialized&lt;T&gt;">ArrayViewSerialized&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html" name="" title="DiffAwareGridViewSerialized&lt;T&gt;">DiffAwareGridViewSerialized&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html" name="" title="DiffSerialized&lt;T&gt;">DiffSerialized&lt;T&gt;</a>
+                          </li>
+                          <li>
+                              <a href="SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html" name="" title="ValueChangeSerialized&lt;T&gt;">ValueChangeSerialized&lt;T&gt;</a>
                           </li>
                     </ul>
                 </li>

--- a/docs/articles/intro.html
+++ b/docs/articles/intro.html
@@ -5,9 +5,9 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Add your introductions here! </title>
+    <title>Articles/How-Tos </title>
     <meta name="viewport" content="width=device-width">
-    <meta name="title" content="Add your introductions here! ">
+    <meta name="title" content="Articles/How-Tos ">
     <meta name="generator" content="docfx 2.52.0.0">
     
     <link rel="shortcut icon" href="../favicon.ico">
@@ -67,8 +67,9 @@
         <div class="article row grid-right">
           <div class="col-md-10">
             <article class="content wrap" id="_content" data-uid="">
-<h1 id="add-your-introductions-here">Add your introductions here!</h1>
+<h1 id="articleshow-tos">Articles/How-Tos</h1>
 
+<p>Nothing here yet, check back often!  There will eventually be helpful articles detailing how to use various features.</p>
 </article>
           </div>
           

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,7 @@
             <article class="content wrap" id="_content" data-uid="">
 <h1 id="thesadrogueprimitives-documentation">TheSadRogue.Primitives Documentation</h1>
 
-<p>Welcome to the documentation for TheSadRogue.Primitives library!  Currently, we have only the API documentation hosted under the API Documentation tab.  More coming soon!</p>
+<p>Welcome to the documentation for TheSadRogue.Primitives library!  Currently, we have only the API documentation hosted under the API Documentation tab.  This documents every class/function/property in the library, so should help you get started.  Additional helpful articles will be posted in the future as well.</p>
 </article>
           </div>
           

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 {
   "homepages": [],
-  "source_base_path": "D:/Google Drive/Documents/Development/CSharp/TheSadRogue.Primitives/TheSadRogue.Primitives.Docs",
+  "source_base_path": "D:/Documents/Development/CSharp/TheSadRogue.Primitives/TheSadRogue.Primitives.Docs",
   "xrefmap": "xrefmap.yml",
   "files": [
     {
@@ -9,10 +9,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.AdjacencyRule.Types.html",
-          "hash": "COnZc7NrOge8jiS91kw8cA=="
+          "hash": "ysBkFqN0+doJFTdmJcPJUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -21,10 +21,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.AdjacencyRule.html",
-          "hash": "Yp6oc2NTuzuswQHopze8Wg=="
+          "hash": "l80u/eLZ2kOWYfDDpSlTFQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -33,10 +33,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Area.html",
-          "hash": "Hr8LfLl90H1UonlMMx6mmQ=="
+          "hash": "hmZNwcQxbX8Ngz3pooRHYg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -45,10 +45,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.BoundedRectangle.html",
-          "hash": "lpe/DgkFRhoF4iPGfEaPhA=="
+          "hash": "gh5PuwQFaaoFUPb8dAvxAg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -57,10 +57,22 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Color.html",
-          "hash": "fm+M+YyH1zftY5cB2qpjLQ=="
+          "hash": "2nqCkgcwoMou/yiXIixJZA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.ColorExtensions.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.ColorExtensions.html",
+          "hash": "ZHAfCH7iAU3Pr0PUt2XxlA=="
+        }
+      },
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -69,10 +81,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Direction.Types.html",
-          "hash": "qrvncrEK2LEaR+fFvZd8gw=="
+          "hash": "C2Ngyhpu4sDE0Vsn1f22xw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -81,10 +93,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Direction.html",
-          "hash": "0R9R4aNTJXyRKeNtR1kPGg=="
+          "hash": "tcb6hedptU8x1QhbHfiRtQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -93,10 +105,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Distance.Types.html",
-          "hash": "BP7TL9Z68WGvktT/+vKZrA=="
+          "hash": "6BG8544dmAtDEkFrI2FPLw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -105,10 +117,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Distance.html",
-          "hash": "as7dZbUNslTpHY0wXcnCiA=="
+          "hash": "pvaSQ2JwyAuQcdIEyjh8PQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -117,10 +129,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Gradient.html",
-          "hash": "plqLGB9ZgqViwJsBAPD6CQ=="
+          "hash": "6L4iiuZK9+4MYVElfal73w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -129,10 +141,262 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.GradientStop.html",
-          "hash": "LOuLq5pJDLnGGU4AIneVdg=="
+          "hash": "N9xvV9lpp6g1349Fb83dGg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.ArrayView-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.ArrayView-1.html",
+          "hash": "DnTsMIqPPj6KL75hkaUk+A=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.ArrayView2D-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.ArrayView2D-1.html",
+          "hash": "M7dFsXFQ/IyPbc+UQxSyJg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.Diff-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.Diff-1.html",
+          "hash": "kH0Sv5/QnBUbJ2t6XUFVZg=="
         }
       },
       "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html",
+          "hash": "J/vd4B+mUgHM7gYQgm2AaQ=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.GridViewBase-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.GridViewBase-1.html",
+          "hash": "AZj6OELRnweKr69PDS36GQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.GridViewExtensions.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.GridViewExtensions.html",
+          "hash": "0inkH4/zT3F16SGnjSnrcg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.IGridView-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.IGridView-1.html",
+          "hash": "qCYUjWfL0QvwJfsrFt4IDQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.ISettableGridView-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.ISettableGridView-1.html",
+          "hash": "u/34qYZmYoFUHFhs85aoVA=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.LambdaGridView-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.LambdaGridView-1.html",
+          "hash": "S0GTQZfgNK+sqWMySmFI4A=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html",
+          "hash": "O935FMeofx28RnGiHau0mA=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html",
+          "hash": "Mb858H6/5wnKGImfevsvCQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html",
+          "hash": "O0rR0lUm6SbMKXS2oojPaw=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html",
+          "hash": "7+X0oK1t9/yGW+f6C6TfyQ=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html",
+          "hash": "LIOZ2IxKhzZIiIpiuqXwRw=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.SettableViewport-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.SettableViewport-1.html",
+          "hash": "dAF7pINXwHabe4DIGVmBQw=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.TranslationGridView-2.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.TranslationGridView-2.html",
+          "hash": "QakLiwtn/2jyQt5ZY5qQ/Q=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.UnboundedViewport-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html",
+          "hash": "L9VVAqw76rnhaiEyIlRf9g=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.ValueChange-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.ValueChange-1.html",
+          "hash": "JG3tmRSWknLczDT1/OkXxg=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.Viewport-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.Viewport-1.html",
+          "hash": "cUFzYcLRa9Ku25foYEDCWg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.GridViews.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.GridViews.html",
+          "hash": "DdTiiDupAssLKLliR3jXow=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.IMatchable-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.IMatchable-1.html",
+          "hash": "JhQA74PtFH7MzJqlZoOwZQ=="
+        }
+      },
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -141,10 +405,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.IReadOnlyArea.html",
-          "hash": "xem1igag2E1hVkI8p0tXGw=="
+          "hash": "3siUxefUClSeCKMLZqaCPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -153,10 +417,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.MathHelpers.html",
-          "hash": "3cWSbVUeAi3TK8wTX0HoOQ=="
+          "hash": "oo6VT0LufPcHY/JOi5NO7Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -165,10 +429,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Palette.html",
-          "hash": "zyCCN+wM1zHKAjnCYimlgw=="
+          "hash": "hl1T/8S9QVVT4LCRMtGCEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -177,10 +441,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Point.html",
-          "hash": "vSL5NEFv1bYJZGwFWelESw=="
+          "hash": "neCT/ws03BQljaBJYibHRg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -189,10 +453,22 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.PointExtensions.html",
-          "hash": "a5tXacVqiA+sb6qpSUS2LA=="
+          "hash": "2ma+2ViHqi5ooWeVK35FBQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.PolarCoordinate.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.PolarCoordinate.html",
+          "hash": "oSmziZ3231stOV93IGIHZQ=="
+        }
+      },
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -201,10 +477,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Radius.Types.html",
-          "hash": "Kcb6gusHpg5js/vfDRGOPg=="
+          "hash": "W9qudGPxDeOKuEhAWFcNsg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -213,10 +489,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Radius.html",
-          "hash": "b5Aksn8UYpEXHAvBu535nQ=="
+          "hash": "4a0/yLDDBDx4nEwEfoWZ9A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -225,10 +501,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.RadiusLocationContext.html",
-          "hash": "nvmsoaz50Yose8ikVdnOlQ=="
+          "hash": "fdHZsp2zYNIA+HQ2EObJFg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -237,10 +513,202 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.Rectangle.html",
-          "hash": "EILEHndne+ncgtZO6XUcUQ=="
+          "hash": "NF6cB4PaA6K5pG/EhQAZvA=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.RectangleExtensions.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.RectangleExtensions.html",
+          "hash": "xSIXgHW5KIonyEd1jXHgog=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.AreaSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html",
+          "hash": "oQJwcK2PuHe0YtnJvL5oAg=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html",
+          "hash": "/YEBaDU24iSzgyZGmFHFfQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.ColorSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html",
+          "hash": "cyjKkzUnqGI36X/Fii5L1A=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GradientSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html",
+          "hash": "t2pHrkY/hFMjV8bzSkL83g=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html",
+          "hash": "OtwYTDfHgWLg2BTo/czzkQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html",
+          "hash": "roOIxAnCVePbZqnovbltrQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html",
+          "hash": "QljOaP1ztgYYo6kR+wT83w=="
         }
       },
       "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html",
+          "hash": "v86CXuk/5RR0kwALtqhX7A=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html",
+          "hash": "xxVpic6UmI7ONlVHzkxvtA=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.GridViews.html",
+          "hash": "NKumxM6E2WaKo30zuiBxuA=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html",
+          "hash": "J4EITiu5wRj5wNn6dNiScQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.PointSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.PointSerialized.html",
+          "hash": "e6MAzw56GUhC57krCUFhRw=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html",
+          "hash": "R+nPBbyFIi5RqGRhLf4yPw=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html",
+          "hash": "7KReXoaMSNle8mGoLqfXoQ=="
+        }
+      },
+      "is_incremental": true,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadRogue.Primitives.SerializedTypes.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadRogue.Primitives.SerializedTypes.html",
+          "hash": "wPN3Q0kRZqtBaz7lyLepDg=="
+        }
+      },
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -249,10 +717,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadRogue.Primitives.html",
-          "hash": "DxIVCb+bwoiLePay9OzFmw=="
+          "hash": "JVrP4Kr/ITfFCHD1n16Aqg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -264,7 +732,7 @@
           "hash": "t/GeRx5JE/qlwCu1uh3WpA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -273,7 +741,7 @@
       "output": {
         ".html": {
           "relative_path": "api/toc.html",
-          "hash": "AcXiVEd6lzSSQmZ0hF2aqg=="
+          "hash": "4EP8tPcW2mZI2ax2A7hI2A=="
         }
       },
       "is_incremental": false,
@@ -285,10 +753,10 @@
       "output": {
         ".html": {
           "relative_path": "articles/intro.html",
-          "hash": "pSb/aHzMRZW1BuBOJcuEWA=="
+          "hash": "ZJGzvySd9ae+BuextTAzDg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -309,10 +777,10 @@
       "output": {
         ".html": {
           "relative_path": "index.html",
-          "hash": "9mHxj4d/UmsuiggESE0uVA=="
+          "hash": "ISi63RYvcy+7a40sEyX3sQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -331,25 +799,23 @@
   "incremental_info": [
     {
       "status": {
-        "can_incremental": false,
-        "details": "Cannot build incrementally because docfx version changed from 2.41.0.0 to 2.52.0.0.",
+        "can_incremental": true,
         "incrementalPhase": "build",
         "total_file_count": 0,
-        "skipped_file_count": 0,
-        "full_build_reason_code": "DocfxVersionChanged"
+        "skipped_file_count": 0
       },
       "processors": {
         "ConceptualDocumentProcessor": {
-          "can_incremental": false,
+          "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 3,
-          "skipped_file_count": 0
+          "skipped_file_count": 3
         },
         "ManagedReferenceDocumentProcessor": {
-          "can_incremental": false,
+          "can_incremental": true,
           "incrementalPhase": "build",
-          "total_file_count": 21,
-          "skipped_file_count": 0
+          "total_file_count": 60,
+          "skipped_file_count": 57
         },
         "TocDocumentProcessor": {
           "can_incremental": false,

--- a/docs/xrefmap.yml
+++ b/docs/xrefmap.yml
@@ -102,12 +102,31 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.AdjacencyRule.GetHashCode
   nameWithType: AdjacencyRule.GetHashCode
+- uid: SadRogue.Primitives.AdjacencyRule.Matches(SadRogue.Primitives.AdjacencyRule)
+  name: Matches(AdjacencyRule)
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_Matches_SadRogue_Primitives_AdjacencyRule_
+  commentId: M:SadRogue.Primitives.AdjacencyRule.Matches(SadRogue.Primitives.AdjacencyRule)
+  fullName: SadRogue.Primitives.AdjacencyRule.Matches(SadRogue.Primitives.AdjacencyRule)
+  nameWithType: AdjacencyRule.Matches(AdjacencyRule)
+- uid: SadRogue.Primitives.AdjacencyRule.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_Matches_
+  commentId: Overload:SadRogue.Primitives.AdjacencyRule.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.AdjacencyRule.Matches
+  nameWithType: AdjacencyRule.Matches
 - uid: SadRogue.Primitives.AdjacencyRule.Neighbors(SadRogue.Primitives.Point)
   name: Neighbors(Point)
   href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_Neighbors_SadRogue_Primitives_Point_
   commentId: M:SadRogue.Primitives.AdjacencyRule.Neighbors(SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.AdjacencyRule.Neighbors(SadRogue.Primitives.Point)
   nameWithType: AdjacencyRule.Neighbors(Point)
+- uid: SadRogue.Primitives.AdjacencyRule.Neighbors(System.Int32,System.Int32)
+  name: Neighbors(Int32, Int32)
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_Neighbors_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.AdjacencyRule.Neighbors(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.AdjacencyRule.Neighbors(System.Int32, System.Int32)
+  nameWithType: AdjacencyRule.Neighbors(Int32, Int32)
 - uid: SadRogue.Primitives.AdjacencyRule.Neighbors*
   name: Neighbors
   href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_Neighbors_
@@ -121,6 +140,12 @@ references:
   commentId: M:SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)
   fullName: SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(SadRogue.Primitives.Point, SadRogue.Primitives.Direction)
   nameWithType: AdjacencyRule.NeighborsClockwise(Point, Direction)
+- uid: SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(System.Int32,System.Int32,SadRogue.Primitives.Direction)
+  name: NeighborsClockwise(Int32, Int32, Direction)
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_System_Int32_System_Int32_SadRogue_Primitives_Direction_
+  commentId: M:SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(System.Int32,System.Int32,SadRogue.Primitives.Direction)
+  fullName: SadRogue.Primitives.AdjacencyRule.NeighborsClockwise(System.Int32, System.Int32, SadRogue.Primitives.Direction)
+  nameWithType: AdjacencyRule.NeighborsClockwise(Int32, Int32, Direction)
 - uid: SadRogue.Primitives.AdjacencyRule.NeighborsClockwise*
   name: NeighborsClockwise
   href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_NeighborsClockwise_
@@ -134,6 +159,12 @@ references:
   commentId: M:SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)
   fullName: SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(SadRogue.Primitives.Point, SadRogue.Primitives.Direction)
   nameWithType: AdjacencyRule.NeighborsCounterClockwise(Point, Direction)
+- uid: SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(System.Int32,System.Int32,SadRogue.Primitives.Direction)
+  name: NeighborsCounterClockwise(Int32, Int32, Direction)
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_System_Int32_System_Int32_SadRogue_Primitives_Direction_
+  commentId: M:SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(System.Int32,System.Int32,SadRogue.Primitives.Direction)
+  fullName: SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise(System.Int32, System.Int32, SadRogue.Primitives.Direction)
+  nameWithType: AdjacencyRule.NeighborsCounterClockwise(Int32, Int32, Direction)
 - uid: SadRogue.Primitives.AdjacencyRule.NeighborsCounterClockwise*
   name: NeighborsCounterClockwise
   href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_NeighborsCounterClockwise_
@@ -154,6 +185,34 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.AdjacencyRule.Equality
   nameWithType: AdjacencyRule.Equality
+- uid: SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule)~SadRogue.Primitives.AdjacencyRule.Types
+  name: Implicit(AdjacencyRule to AdjacencyRule.Types)
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_op_Implicit_SadRogue_Primitives_AdjacencyRule__SadRogue_Primitives_AdjacencyRule_Types
+  commentId: M:SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule)~SadRogue.Primitives.AdjacencyRule.Types
+  name.vb: Widening(AdjacencyRule to AdjacencyRule.Types)
+  fullName: SadRogue.Primitives.AdjacencyRule.Implicit(SadRogue.Primitives.AdjacencyRule to SadRogue.Primitives.AdjacencyRule.Types)
+  fullName.vb: SadRogue.Primitives.AdjacencyRule.Widening(SadRogue.Primitives.AdjacencyRule to SadRogue.Primitives.AdjacencyRule.Types)
+  nameWithType: AdjacencyRule.Implicit(AdjacencyRule to AdjacencyRule.Types)
+  nameWithType.vb: AdjacencyRule.Widening(AdjacencyRule to AdjacencyRule.Types)
+- uid: SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule.Types)~SadRogue.Primitives.AdjacencyRule
+  name: Implicit(AdjacencyRule.Types to AdjacencyRule)
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_op_Implicit_SadRogue_Primitives_AdjacencyRule_Types__SadRogue_Primitives_AdjacencyRule
+  commentId: M:SadRogue.Primitives.AdjacencyRule.op_Implicit(SadRogue.Primitives.AdjacencyRule.Types)~SadRogue.Primitives.AdjacencyRule
+  name.vb: Widening(AdjacencyRule.Types to AdjacencyRule)
+  fullName: SadRogue.Primitives.AdjacencyRule.Implicit(SadRogue.Primitives.AdjacencyRule.Types to SadRogue.Primitives.AdjacencyRule)
+  fullName.vb: SadRogue.Primitives.AdjacencyRule.Widening(SadRogue.Primitives.AdjacencyRule.Types to SadRogue.Primitives.AdjacencyRule)
+  nameWithType: AdjacencyRule.Implicit(AdjacencyRule.Types to AdjacencyRule)
+  nameWithType.vb: AdjacencyRule.Widening(AdjacencyRule.Types to AdjacencyRule)
+- uid: SadRogue.Primitives.AdjacencyRule.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.AdjacencyRule.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.AdjacencyRule.Implicit
+  fullName.vb: SadRogue.Primitives.AdjacencyRule.Widening
+  nameWithType: AdjacencyRule.Implicit
+  nameWithType.vb: AdjacencyRule.Widening
 - uid: SadRogue.Primitives.AdjacencyRule.op_Inequality(SadRogue.Primitives.AdjacencyRule,SadRogue.Primitives.AdjacencyRule)
   name: Inequality(AdjacencyRule, AdjacencyRule)
   href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_op_Inequality_SadRogue_Primitives_AdjacencyRule_SadRogue_Primitives_AdjacencyRule_
@@ -167,19 +226,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.AdjacencyRule.Inequality
   nameWithType: AdjacencyRule.Inequality
-- uid: SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule(SadRogue.Primitives.AdjacencyRule.Types)
-  name: ToAdjacencyRule(AdjacencyRule.Types)
-  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_ToAdjacencyRule_SadRogue_Primitives_AdjacencyRule_Types_
-  commentId: M:SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule(SadRogue.Primitives.AdjacencyRule.Types)
-  fullName: SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule(SadRogue.Primitives.AdjacencyRule.Types)
-  nameWithType: AdjacencyRule.ToAdjacencyRule(AdjacencyRule.Types)
-- uid: SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule*
-  name: ToAdjacencyRule
-  href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_ToAdjacencyRule_
-  commentId: Overload:SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule
-  isSpec: "True"
-  fullName: SadRogue.Primitives.AdjacencyRule.ToAdjacencyRule
-  nameWithType: AdjacencyRule.ToAdjacencyRule
 - uid: SadRogue.Primitives.AdjacencyRule.ToString
   name: ToString()
   href: api/SadRogue.Primitives.AdjacencyRule.html#SadRogue_Primitives_AdjacencyRule_ToString
@@ -235,6 +281,24 @@ references:
   commentId: M:SadRogue.Primitives.Area.#ctor
   fullName: SadRogue.Primitives.Area.Area()
   nameWithType: Area.Area()
+- uid: SadRogue.Primitives.Area.#ctor(SadRogue.Primitives.Point[])
+  name: Area(Point[])
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area__ctor_SadRogue_Primitives_Point___
+  commentId: M:SadRogue.Primitives.Area.#ctor(SadRogue.Primitives.Point[])
+  name.vb: Area(Point())
+  fullName: SadRogue.Primitives.Area.Area(SadRogue.Primitives.Point[])
+  fullName.vb: SadRogue.Primitives.Area.Area(SadRogue.Primitives.Point())
+  nameWithType: Area.Area(Point[])
+  nameWithType.vb: Area.Area(Point())
+- uid: SadRogue.Primitives.Area.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.Point})
+  name: Area(IEnumerable<Point>)
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_Point__
+  commentId: M:SadRogue.Primitives.Area.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.Point})
+  name.vb: Area(IEnumerable(Of Point))
+  fullName: SadRogue.Primitives.Area.Area(System.Collections.Generic.IEnumerable<SadRogue.Primitives.Point>)
+  fullName.vb: SadRogue.Primitives.Area.Area(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.Point))
+  nameWithType: Area.Area(IEnumerable<Point>)
+  nameWithType.vb: Area.Area(IEnumerable(Of Point))
 - uid: SadRogue.Primitives.Area.#ctor*
   name: Area
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area__ctor_
@@ -269,6 +333,12 @@ references:
   fullName.vb: SadRogue.Primitives.Area.Add(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.Point))
   nameWithType: Area.Add(IEnumerable<Point>)
   nameWithType.vb: Area.Add(IEnumerable(Of Point))
+- uid: SadRogue.Primitives.Area.Add(System.Int32,System.Int32)
+  name: Add(Int32, Int32)
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Add_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Area.Add(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Area.Add(System.Int32, System.Int32)
+  nameWithType: Area.Add(Int32, Int32)
 - uid: SadRogue.Primitives.Area.Add*
   name: Add
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Add_
@@ -301,6 +371,12 @@ references:
   commentId: M:SadRogue.Primitives.Area.Contains(SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Area.Contains(SadRogue.Primitives.Point)
   nameWithType: Area.Contains(Point)
+- uid: SadRogue.Primitives.Area.Contains(System.Int32,System.Int32)
+  name: Contains(Int32, Int32)
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Contains_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Area.Contains(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Area.Contains(System.Int32, System.Int32)
+  nameWithType: Area.Contains(Int32, Int32)
 - uid: SadRogue.Primitives.Area.Contains*
   name: Contains
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Contains_
@@ -321,19 +397,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Area.Count
   nameWithType: Area.Count
-- uid: SadRogue.Primitives.Area.Equals(System.Object)
-  name: Equals(Object)
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Equals_System_Object_
-  commentId: M:SadRogue.Primitives.Area.Equals(System.Object)
-  fullName: SadRogue.Primitives.Area.Equals(System.Object)
-  nameWithType: Area.Equals(Object)
-- uid: SadRogue.Primitives.Area.Equals*
-  name: Equals
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Equals_
-  commentId: Overload:SadRogue.Primitives.Area.Equals
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Area.Equals
-  nameWithType: Area.Equals
 - uid: SadRogue.Primitives.Area.GetDifference(SadRogue.Primitives.IReadOnlyArea,SadRogue.Primitives.IReadOnlyArea)
   name: GetDifference(IReadOnlyArea, IReadOnlyArea)
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_GetDifference_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_
@@ -347,19 +410,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Area.GetDifference
   nameWithType: Area.GetDifference
-- uid: SadRogue.Primitives.Area.GetHashCode
-  name: GetHashCode()
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_GetHashCode
-  commentId: M:SadRogue.Primitives.Area.GetHashCode
-  fullName: SadRogue.Primitives.Area.GetHashCode()
-  nameWithType: Area.GetHashCode()
-- uid: SadRogue.Primitives.Area.GetHashCode*
-  name: GetHashCode
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_GetHashCode_
-  commentId: Overload:SadRogue.Primitives.Area.GetHashCode
+- uid: SadRogue.Primitives.Area.GetEnumerator
+  name: GetEnumerator()
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_GetEnumerator
+  commentId: M:SadRogue.Primitives.Area.GetEnumerator
+  fullName: SadRogue.Primitives.Area.GetEnumerator()
+  nameWithType: Area.GetEnumerator()
+- uid: SadRogue.Primitives.Area.GetEnumerator*
+  name: GetEnumerator
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_GetEnumerator_
+  commentId: Overload:SadRogue.Primitives.Area.GetEnumerator
   isSpec: "True"
-  fullName: SadRogue.Primitives.Area.GetHashCode
-  nameWithType: Area.GetHashCode
+  fullName: SadRogue.Primitives.Area.GetEnumerator
+  nameWithType: Area.GetEnumerator
 - uid: SadRogue.Primitives.Area.GetIntersection(SadRogue.Primitives.IReadOnlyArea,SadRogue.Primitives.IReadOnlyArea)
   name: GetIntersection(IReadOnlyArea, IReadOnlyArea)
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_GetIntersection_SadRogue_Primitives_IReadOnlyArea_SadRogue_Primitives_IReadOnlyArea_
@@ -399,6 +462,35 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Area.Intersects
   nameWithType: Area.Intersects
+- uid: SadRogue.Primitives.Area.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.Area.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.Area.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.Area.Item(System.Int32)
+  nameWithType: Area.Item[Int32]
+  nameWithType.vb: Area.Item(Int32)
+- uid: SadRogue.Primitives.Area.Item*
+  name: Item
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Item_
+  commentId: Overload:SadRogue.Primitives.Area.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Area.Item
+  nameWithType: Area.Item
+- uid: SadRogue.Primitives.Area.Matches(SadRogue.Primitives.IReadOnlyArea)
+  name: Matches(IReadOnlyArea)
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Matches_SadRogue_Primitives_IReadOnlyArea_
+  commentId: M:SadRogue.Primitives.Area.Matches(SadRogue.Primitives.IReadOnlyArea)
+  fullName: SadRogue.Primitives.Area.Matches(SadRogue.Primitives.IReadOnlyArea)
+  nameWithType: Area.Matches(IReadOnlyArea)
+- uid: SadRogue.Primitives.Area.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Matches_
+  commentId: Overload:SadRogue.Primitives.Area.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Area.Matches
+  nameWithType: Area.Matches
 - uid: SadRogue.Primitives.Area.op_Addition(SadRogue.Primitives.Area,SadRogue.Primitives.Point)
   name: Addition(Area, Point)
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_op_Addition_SadRogue_Primitives_Area_SadRogue_Primitives_Point_
@@ -412,45 +504,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Area.Addition
   nameWithType: Area.Addition
-- uid: SadRogue.Primitives.Area.op_Equality(SadRogue.Primitives.Area,SadRogue.Primitives.Area)
-  name: Equality(Area, Area)
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_op_Equality_SadRogue_Primitives_Area_SadRogue_Primitives_Area_
-  commentId: M:SadRogue.Primitives.Area.op_Equality(SadRogue.Primitives.Area,SadRogue.Primitives.Area)
-  fullName: SadRogue.Primitives.Area.Equality(SadRogue.Primitives.Area, SadRogue.Primitives.Area)
-  nameWithType: Area.Equality(Area, Area)
-- uid: SadRogue.Primitives.Area.op_Equality*
-  name: Equality
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_op_Equality_
-  commentId: Overload:SadRogue.Primitives.Area.op_Equality
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Area.Equality
-  nameWithType: Area.Equality
-- uid: SadRogue.Primitives.Area.op_Inequality(SadRogue.Primitives.Area,SadRogue.Primitives.Area)
-  name: Inequality(Area, Area)
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_op_Inequality_SadRogue_Primitives_Area_SadRogue_Primitives_Area_
-  commentId: M:SadRogue.Primitives.Area.op_Inequality(SadRogue.Primitives.Area,SadRogue.Primitives.Area)
-  fullName: SadRogue.Primitives.Area.Inequality(SadRogue.Primitives.Area, SadRogue.Primitives.Area)
-  nameWithType: Area.Inequality(Area, Area)
-- uid: SadRogue.Primitives.Area.op_Inequality*
-  name: Inequality
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_op_Inequality_
-  commentId: Overload:SadRogue.Primitives.Area.op_Inequality
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Area.Inequality
-  nameWithType: Area.Inequality
-- uid: SadRogue.Primitives.Area.Positions
-  name: Positions
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Positions
-  commentId: P:SadRogue.Primitives.Area.Positions
-  fullName: SadRogue.Primitives.Area.Positions
-  nameWithType: Area.Positions
-- uid: SadRogue.Primitives.Area.Positions*
-  name: Positions
-  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Positions_
-  commentId: Overload:SadRogue.Primitives.Area.Positions
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Area.Positions
-  nameWithType: Area.Positions
 - uid: SadRogue.Primitives.Area.Remove(SadRogue.Primitives.IReadOnlyArea)
   name: Remove(IReadOnlyArea)
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Remove_SadRogue_Primitives_IReadOnlyArea_
@@ -496,6 +549,12 @@ references:
   fullName.vb: SadRogue.Primitives.Area.Remove(System.Func(Of SadRogue.Primitives.Point, System.Boolean))
   nameWithType: Area.Remove(Func<Point, Boolean>)
   nameWithType.vb: Area.Remove(Func(Of Point, Boolean))
+- uid: SadRogue.Primitives.Area.Remove(System.Int32,System.Int32)
+  name: Remove(Int32, Int32)
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Remove_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Area.Remove(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Area.Remove(System.Int32, System.Int32)
+  nameWithType: Area.Remove(Int32, Int32)
 - uid: SadRogue.Primitives.Area.Remove*
   name: Remove
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_Remove_
@@ -503,6 +562,23 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Area.Remove
   nameWithType: Area.Remove
+- uid: SadRogue.Primitives.Area.System#Collections#IEnumerable#GetEnumerator
+  name: IEnumerable.GetEnumerator()
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_System_Collections_IEnumerable_GetEnumerator
+  commentId: M:SadRogue.Primitives.Area.System#Collections#IEnumerable#GetEnumerator
+  name.vb: System.Collections.IEnumerable.GetEnumerator()
+  fullName: SadRogue.Primitives.Area.System.Collections.IEnumerable.GetEnumerator()
+  nameWithType: Area.IEnumerable.GetEnumerator()
+  nameWithType.vb: Area.System.Collections.IEnumerable.GetEnumerator()
+- uid: SadRogue.Primitives.Area.System#Collections#IEnumerable#GetEnumerator*
+  name: IEnumerable.GetEnumerator
+  href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_System_Collections_IEnumerable_GetEnumerator_
+  commentId: Overload:SadRogue.Primitives.Area.System#Collections#IEnumerable#GetEnumerator
+  isSpec: "True"
+  name.vb: System.Collections.IEnumerable.GetEnumerator
+  fullName: SadRogue.Primitives.Area.System.Collections.IEnumerable.GetEnumerator
+  nameWithType: Area.IEnumerable.GetEnumerator
+  nameWithType.vb: Area.System.Collections.IEnumerable.GetEnumerator
 - uid: SadRogue.Primitives.Area.ToString
   name: ToString()
   href: api/SadRogue.Primitives.Area.html#SadRogue_Primitives_Area_ToString
@@ -561,64 +637,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.BoundedRectangle.BoundingBox
   nameWithType: BoundedRectangle.BoundingBox
-- uid: SadRogue.Primitives.BoundedRectangle.Equals(SadRogue.Primitives.BoundedRectangle)
-  name: Equals(BoundedRectangle)
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_Equals_SadRogue_Primitives_BoundedRectangle_
-  commentId: M:SadRogue.Primitives.BoundedRectangle.Equals(SadRogue.Primitives.BoundedRectangle)
-  fullName: SadRogue.Primitives.BoundedRectangle.Equals(SadRogue.Primitives.BoundedRectangle)
-  nameWithType: BoundedRectangle.Equals(BoundedRectangle)
-- uid: SadRogue.Primitives.BoundedRectangle.Equals(System.Object)
-  name: Equals(Object)
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_Equals_System_Object_
-  commentId: M:SadRogue.Primitives.BoundedRectangle.Equals(System.Object)
-  fullName: SadRogue.Primitives.BoundedRectangle.Equals(System.Object)
-  nameWithType: BoundedRectangle.Equals(Object)
-- uid: SadRogue.Primitives.BoundedRectangle.Equals*
-  name: Equals
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_Equals_
-  commentId: Overload:SadRogue.Primitives.BoundedRectangle.Equals
+- uid: SadRogue.Primitives.BoundedRectangle.Matches(SadRogue.Primitives.BoundedRectangle)
+  name: Matches(BoundedRectangle)
+  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_Matches_SadRogue_Primitives_BoundedRectangle_
+  commentId: M:SadRogue.Primitives.BoundedRectangle.Matches(SadRogue.Primitives.BoundedRectangle)
+  fullName: SadRogue.Primitives.BoundedRectangle.Matches(SadRogue.Primitives.BoundedRectangle)
+  nameWithType: BoundedRectangle.Matches(BoundedRectangle)
+- uid: SadRogue.Primitives.BoundedRectangle.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_Matches_
+  commentId: Overload:SadRogue.Primitives.BoundedRectangle.Matches
   isSpec: "True"
-  fullName: SadRogue.Primitives.BoundedRectangle.Equals
-  nameWithType: BoundedRectangle.Equals
-- uid: SadRogue.Primitives.BoundedRectangle.GetHashCode
-  name: GetHashCode()
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_GetHashCode
-  commentId: M:SadRogue.Primitives.BoundedRectangle.GetHashCode
-  fullName: SadRogue.Primitives.BoundedRectangle.GetHashCode()
-  nameWithType: BoundedRectangle.GetHashCode()
-- uid: SadRogue.Primitives.BoundedRectangle.GetHashCode*
-  name: GetHashCode
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_GetHashCode_
-  commentId: Overload:SadRogue.Primitives.BoundedRectangle.GetHashCode
-  isSpec: "True"
-  fullName: SadRogue.Primitives.BoundedRectangle.GetHashCode
-  nameWithType: BoundedRectangle.GetHashCode
-- uid: SadRogue.Primitives.BoundedRectangle.op_Equality(SadRogue.Primitives.BoundedRectangle,SadRogue.Primitives.BoundedRectangle)
-  name: Equality(BoundedRectangle, BoundedRectangle)
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_op_Equality_SadRogue_Primitives_BoundedRectangle_SadRogue_Primitives_BoundedRectangle_
-  commentId: M:SadRogue.Primitives.BoundedRectangle.op_Equality(SadRogue.Primitives.BoundedRectangle,SadRogue.Primitives.BoundedRectangle)
-  fullName: SadRogue.Primitives.BoundedRectangle.Equality(SadRogue.Primitives.BoundedRectangle, SadRogue.Primitives.BoundedRectangle)
-  nameWithType: BoundedRectangle.Equality(BoundedRectangle, BoundedRectangle)
-- uid: SadRogue.Primitives.BoundedRectangle.op_Equality*
-  name: Equality
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_op_Equality_
-  commentId: Overload:SadRogue.Primitives.BoundedRectangle.op_Equality
-  isSpec: "True"
-  fullName: SadRogue.Primitives.BoundedRectangle.Equality
-  nameWithType: BoundedRectangle.Equality
-- uid: SadRogue.Primitives.BoundedRectangle.op_Inequality(SadRogue.Primitives.BoundedRectangle,SadRogue.Primitives.BoundedRectangle)
-  name: Inequality(BoundedRectangle, BoundedRectangle)
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_op_Inequality_SadRogue_Primitives_BoundedRectangle_SadRogue_Primitives_BoundedRectangle_
-  commentId: M:SadRogue.Primitives.BoundedRectangle.op_Inequality(SadRogue.Primitives.BoundedRectangle,SadRogue.Primitives.BoundedRectangle)
-  fullName: SadRogue.Primitives.BoundedRectangle.Inequality(SadRogue.Primitives.BoundedRectangle, SadRogue.Primitives.BoundedRectangle)
-  nameWithType: BoundedRectangle.Inequality(BoundedRectangle, BoundedRectangle)
-- uid: SadRogue.Primitives.BoundedRectangle.op_Inequality*
-  name: Inequality
-  href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_op_Inequality_
-  commentId: Overload:SadRogue.Primitives.BoundedRectangle.op_Inequality
-  isSpec: "True"
-  fullName: SadRogue.Primitives.BoundedRectangle.Inequality
-  nameWithType: BoundedRectangle.Inequality
+  fullName: SadRogue.Primitives.BoundedRectangle.Matches
+  nameWithType: BoundedRectangle.Matches
 - uid: SadRogue.Primitives.BoundedRectangle.SetArea(SadRogue.Primitives.Rectangle)
   name: SetArea(Rectangle)
   href: api/SadRogue.Primitives.BoundedRectangle.html#SadRogue_Primitives_BoundedRectangle_SetArea_SadRogue_Primitives_Rectangle_
@@ -722,14 +753,7 @@ references:
 - uid: SadRogue.Primitives.Color.AliceBlue
   name: AliceBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_AliceBlue
-  commentId: P:SadRogue.Primitives.Color.AliceBlue
-  fullName: SadRogue.Primitives.Color.AliceBlue
-  nameWithType: Color.AliceBlue
-- uid: SadRogue.Primitives.Color.AliceBlue*
-  name: AliceBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_AliceBlue_
-  commentId: Overload:SadRogue.Primitives.Color.AliceBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.AliceBlue
   fullName: SadRogue.Primitives.Color.AliceBlue
   nameWithType: Color.AliceBlue
 - uid: SadRogue.Primitives.Color.AnsiBlack
@@ -831,53 +855,25 @@ references:
 - uid: SadRogue.Primitives.Color.AntiqueWhite
   name: AntiqueWhite
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_AntiqueWhite
-  commentId: P:SadRogue.Primitives.Color.AntiqueWhite
-  fullName: SadRogue.Primitives.Color.AntiqueWhite
-  nameWithType: Color.AntiqueWhite
-- uid: SadRogue.Primitives.Color.AntiqueWhite*
-  name: AntiqueWhite
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_AntiqueWhite_
-  commentId: Overload:SadRogue.Primitives.Color.AntiqueWhite
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.AntiqueWhite
   fullName: SadRogue.Primitives.Color.AntiqueWhite
   nameWithType: Color.AntiqueWhite
 - uid: SadRogue.Primitives.Color.Aqua
   name: Aqua
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Aqua
-  commentId: P:SadRogue.Primitives.Color.Aqua
-  fullName: SadRogue.Primitives.Color.Aqua
-  nameWithType: Color.Aqua
-- uid: SadRogue.Primitives.Color.Aqua*
-  name: Aqua
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Aqua_
-  commentId: Overload:SadRogue.Primitives.Color.Aqua
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Aqua
   fullName: SadRogue.Primitives.Color.Aqua
   nameWithType: Color.Aqua
 - uid: SadRogue.Primitives.Color.Aquamarine
   name: Aquamarine
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Aquamarine
-  commentId: P:SadRogue.Primitives.Color.Aquamarine
-  fullName: SadRogue.Primitives.Color.Aquamarine
-  nameWithType: Color.Aquamarine
-- uid: SadRogue.Primitives.Color.Aquamarine*
-  name: Aquamarine
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Aquamarine_
-  commentId: Overload:SadRogue.Primitives.Color.Aquamarine
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Aquamarine
   fullName: SadRogue.Primitives.Color.Aquamarine
   nameWithType: Color.Aquamarine
 - uid: SadRogue.Primitives.Color.Azure
   name: Azure
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Azure
-  commentId: P:SadRogue.Primitives.Color.Azure
-  fullName: SadRogue.Primitives.Color.Azure
-  nameWithType: Color.Azure
-- uid: SadRogue.Primitives.Color.Azure*
-  name: Azure
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Azure_
-  commentId: Overload:SadRogue.Primitives.Color.Azure
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Azure
   fullName: SadRogue.Primitives.Color.Azure
   nameWithType: Color.Azure
 - uid: SadRogue.Primitives.Color.B
@@ -896,430 +892,199 @@ references:
 - uid: SadRogue.Primitives.Color.Beige
   name: Beige
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Beige
-  commentId: P:SadRogue.Primitives.Color.Beige
-  fullName: SadRogue.Primitives.Color.Beige
-  nameWithType: Color.Beige
-- uid: SadRogue.Primitives.Color.Beige*
-  name: Beige
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Beige_
-  commentId: Overload:SadRogue.Primitives.Color.Beige
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Beige
   fullName: SadRogue.Primitives.Color.Beige
   nameWithType: Color.Beige
 - uid: SadRogue.Primitives.Color.Bisque
   name: Bisque
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Bisque
-  commentId: P:SadRogue.Primitives.Color.Bisque
-  fullName: SadRogue.Primitives.Color.Bisque
-  nameWithType: Color.Bisque
-- uid: SadRogue.Primitives.Color.Bisque*
-  name: Bisque
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Bisque_
-  commentId: Overload:SadRogue.Primitives.Color.Bisque
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Bisque
   fullName: SadRogue.Primitives.Color.Bisque
   nameWithType: Color.Bisque
 - uid: SadRogue.Primitives.Color.Black
   name: Black
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Black
-  commentId: P:SadRogue.Primitives.Color.Black
-  fullName: SadRogue.Primitives.Color.Black
-  nameWithType: Color.Black
-- uid: SadRogue.Primitives.Color.Black*
-  name: Black
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Black_
-  commentId: Overload:SadRogue.Primitives.Color.Black
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Black
   fullName: SadRogue.Primitives.Color.Black
   nameWithType: Color.Black
 - uid: SadRogue.Primitives.Color.BlanchedAlmond
   name: BlanchedAlmond
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_BlanchedAlmond
-  commentId: P:SadRogue.Primitives.Color.BlanchedAlmond
-  fullName: SadRogue.Primitives.Color.BlanchedAlmond
-  nameWithType: Color.BlanchedAlmond
-- uid: SadRogue.Primitives.Color.BlanchedAlmond*
-  name: BlanchedAlmond
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_BlanchedAlmond_
-  commentId: Overload:SadRogue.Primitives.Color.BlanchedAlmond
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.BlanchedAlmond
   fullName: SadRogue.Primitives.Color.BlanchedAlmond
   nameWithType: Color.BlanchedAlmond
 - uid: SadRogue.Primitives.Color.Blue
   name: Blue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Blue
-  commentId: P:SadRogue.Primitives.Color.Blue
-  fullName: SadRogue.Primitives.Color.Blue
-  nameWithType: Color.Blue
-- uid: SadRogue.Primitives.Color.Blue*
-  name: Blue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Blue_
-  commentId: Overload:SadRogue.Primitives.Color.Blue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Blue
   fullName: SadRogue.Primitives.Color.Blue
   nameWithType: Color.Blue
 - uid: SadRogue.Primitives.Color.BlueViolet
   name: BlueViolet
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_BlueViolet
-  commentId: P:SadRogue.Primitives.Color.BlueViolet
-  fullName: SadRogue.Primitives.Color.BlueViolet
-  nameWithType: Color.BlueViolet
-- uid: SadRogue.Primitives.Color.BlueViolet*
-  name: BlueViolet
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_BlueViolet_
-  commentId: Overload:SadRogue.Primitives.Color.BlueViolet
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.BlueViolet
   fullName: SadRogue.Primitives.Color.BlueViolet
   nameWithType: Color.BlueViolet
 - uid: SadRogue.Primitives.Color.Brown
   name: Brown
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Brown
-  commentId: P:SadRogue.Primitives.Color.Brown
-  fullName: SadRogue.Primitives.Color.Brown
-  nameWithType: Color.Brown
-- uid: SadRogue.Primitives.Color.Brown*
-  name: Brown
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Brown_
-  commentId: Overload:SadRogue.Primitives.Color.Brown
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Brown
   fullName: SadRogue.Primitives.Color.Brown
   nameWithType: Color.Brown
 - uid: SadRogue.Primitives.Color.BurlyWood
   name: BurlyWood
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_BurlyWood
-  commentId: P:SadRogue.Primitives.Color.BurlyWood
-  fullName: SadRogue.Primitives.Color.BurlyWood
-  nameWithType: Color.BurlyWood
-- uid: SadRogue.Primitives.Color.BurlyWood*
-  name: BurlyWood
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_BurlyWood_
-  commentId: Overload:SadRogue.Primitives.Color.BurlyWood
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.BurlyWood
   fullName: SadRogue.Primitives.Color.BurlyWood
   nameWithType: Color.BurlyWood
 - uid: SadRogue.Primitives.Color.CadetBlue
   name: CadetBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_CadetBlue
-  commentId: P:SadRogue.Primitives.Color.CadetBlue
-  fullName: SadRogue.Primitives.Color.CadetBlue
-  nameWithType: Color.CadetBlue
-- uid: SadRogue.Primitives.Color.CadetBlue*
-  name: CadetBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_CadetBlue_
-  commentId: Overload:SadRogue.Primitives.Color.CadetBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.CadetBlue
   fullName: SadRogue.Primitives.Color.CadetBlue
   nameWithType: Color.CadetBlue
 - uid: SadRogue.Primitives.Color.Chartreuse
   name: Chartreuse
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Chartreuse
-  commentId: P:SadRogue.Primitives.Color.Chartreuse
-  fullName: SadRogue.Primitives.Color.Chartreuse
-  nameWithType: Color.Chartreuse
-- uid: SadRogue.Primitives.Color.Chartreuse*
-  name: Chartreuse
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Chartreuse_
-  commentId: Overload:SadRogue.Primitives.Color.Chartreuse
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Chartreuse
   fullName: SadRogue.Primitives.Color.Chartreuse
   nameWithType: Color.Chartreuse
 - uid: SadRogue.Primitives.Color.Chocolate
   name: Chocolate
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Chocolate
-  commentId: P:SadRogue.Primitives.Color.Chocolate
-  fullName: SadRogue.Primitives.Color.Chocolate
-  nameWithType: Color.Chocolate
-- uid: SadRogue.Primitives.Color.Chocolate*
-  name: Chocolate
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Chocolate_
-  commentId: Overload:SadRogue.Primitives.Color.Chocolate
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Chocolate
   fullName: SadRogue.Primitives.Color.Chocolate
   nameWithType: Color.Chocolate
 - uid: SadRogue.Primitives.Color.Coral
   name: Coral
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Coral
-  commentId: P:SadRogue.Primitives.Color.Coral
-  fullName: SadRogue.Primitives.Color.Coral
-  nameWithType: Color.Coral
-- uid: SadRogue.Primitives.Color.Coral*
-  name: Coral
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Coral_
-  commentId: Overload:SadRogue.Primitives.Color.Coral
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Coral
   fullName: SadRogue.Primitives.Color.Coral
   nameWithType: Color.Coral
 - uid: SadRogue.Primitives.Color.CornflowerBlue
   name: CornflowerBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_CornflowerBlue
-  commentId: P:SadRogue.Primitives.Color.CornflowerBlue
-  fullName: SadRogue.Primitives.Color.CornflowerBlue
-  nameWithType: Color.CornflowerBlue
-- uid: SadRogue.Primitives.Color.CornflowerBlue*
-  name: CornflowerBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_CornflowerBlue_
-  commentId: Overload:SadRogue.Primitives.Color.CornflowerBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.CornflowerBlue
   fullName: SadRogue.Primitives.Color.CornflowerBlue
   nameWithType: Color.CornflowerBlue
 - uid: SadRogue.Primitives.Color.Cornsilk
   name: Cornsilk
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Cornsilk
-  commentId: P:SadRogue.Primitives.Color.Cornsilk
-  fullName: SadRogue.Primitives.Color.Cornsilk
-  nameWithType: Color.Cornsilk
-- uid: SadRogue.Primitives.Color.Cornsilk*
-  name: Cornsilk
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Cornsilk_
-  commentId: Overload:SadRogue.Primitives.Color.Cornsilk
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Cornsilk
   fullName: SadRogue.Primitives.Color.Cornsilk
   nameWithType: Color.Cornsilk
 - uid: SadRogue.Primitives.Color.Crimson
   name: Crimson
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Crimson
-  commentId: P:SadRogue.Primitives.Color.Crimson
-  fullName: SadRogue.Primitives.Color.Crimson
-  nameWithType: Color.Crimson
-- uid: SadRogue.Primitives.Color.Crimson*
-  name: Crimson
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Crimson_
-  commentId: Overload:SadRogue.Primitives.Color.Crimson
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Crimson
   fullName: SadRogue.Primitives.Color.Crimson
   nameWithType: Color.Crimson
 - uid: SadRogue.Primitives.Color.Cyan
   name: Cyan
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Cyan
-  commentId: P:SadRogue.Primitives.Color.Cyan
-  fullName: SadRogue.Primitives.Color.Cyan
-  nameWithType: Color.Cyan
-- uid: SadRogue.Primitives.Color.Cyan*
-  name: Cyan
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Cyan_
-  commentId: Overload:SadRogue.Primitives.Color.Cyan
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Cyan
   fullName: SadRogue.Primitives.Color.Cyan
   nameWithType: Color.Cyan
 - uid: SadRogue.Primitives.Color.DarkBlue
   name: DarkBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkBlue
-  commentId: P:SadRogue.Primitives.Color.DarkBlue
-  fullName: SadRogue.Primitives.Color.DarkBlue
-  nameWithType: Color.DarkBlue
-- uid: SadRogue.Primitives.Color.DarkBlue*
-  name: DarkBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkBlue_
-  commentId: Overload:SadRogue.Primitives.Color.DarkBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkBlue
   fullName: SadRogue.Primitives.Color.DarkBlue
   nameWithType: Color.DarkBlue
 - uid: SadRogue.Primitives.Color.DarkCyan
   name: DarkCyan
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkCyan
-  commentId: P:SadRogue.Primitives.Color.DarkCyan
-  fullName: SadRogue.Primitives.Color.DarkCyan
-  nameWithType: Color.DarkCyan
-- uid: SadRogue.Primitives.Color.DarkCyan*
-  name: DarkCyan
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkCyan_
-  commentId: Overload:SadRogue.Primitives.Color.DarkCyan
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkCyan
   fullName: SadRogue.Primitives.Color.DarkCyan
   nameWithType: Color.DarkCyan
 - uid: SadRogue.Primitives.Color.DarkGoldenrod
   name: DarkGoldenrod
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkGoldenrod
-  commentId: P:SadRogue.Primitives.Color.DarkGoldenrod
-  fullName: SadRogue.Primitives.Color.DarkGoldenrod
-  nameWithType: Color.DarkGoldenrod
-- uid: SadRogue.Primitives.Color.DarkGoldenrod*
-  name: DarkGoldenrod
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkGoldenrod_
-  commentId: Overload:SadRogue.Primitives.Color.DarkGoldenrod
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkGoldenrod
   fullName: SadRogue.Primitives.Color.DarkGoldenrod
   nameWithType: Color.DarkGoldenrod
 - uid: SadRogue.Primitives.Color.DarkGray
   name: DarkGray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkGray
-  commentId: P:SadRogue.Primitives.Color.DarkGray
-  fullName: SadRogue.Primitives.Color.DarkGray
-  nameWithType: Color.DarkGray
-- uid: SadRogue.Primitives.Color.DarkGray*
-  name: DarkGray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkGray_
-  commentId: Overload:SadRogue.Primitives.Color.DarkGray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkGray
   fullName: SadRogue.Primitives.Color.DarkGray
   nameWithType: Color.DarkGray
 - uid: SadRogue.Primitives.Color.DarkGreen
   name: DarkGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkGreen
-  commentId: P:SadRogue.Primitives.Color.DarkGreen
-  fullName: SadRogue.Primitives.Color.DarkGreen
-  nameWithType: Color.DarkGreen
-- uid: SadRogue.Primitives.Color.DarkGreen*
-  name: DarkGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkGreen_
-  commentId: Overload:SadRogue.Primitives.Color.DarkGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkGreen
   fullName: SadRogue.Primitives.Color.DarkGreen
   nameWithType: Color.DarkGreen
 - uid: SadRogue.Primitives.Color.DarkKhaki
   name: DarkKhaki
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkKhaki
-  commentId: P:SadRogue.Primitives.Color.DarkKhaki
-  fullName: SadRogue.Primitives.Color.DarkKhaki
-  nameWithType: Color.DarkKhaki
-- uid: SadRogue.Primitives.Color.DarkKhaki*
-  name: DarkKhaki
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkKhaki_
-  commentId: Overload:SadRogue.Primitives.Color.DarkKhaki
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkKhaki
   fullName: SadRogue.Primitives.Color.DarkKhaki
   nameWithType: Color.DarkKhaki
 - uid: SadRogue.Primitives.Color.DarkMagenta
   name: DarkMagenta
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkMagenta
-  commentId: P:SadRogue.Primitives.Color.DarkMagenta
-  fullName: SadRogue.Primitives.Color.DarkMagenta
-  nameWithType: Color.DarkMagenta
-- uid: SadRogue.Primitives.Color.DarkMagenta*
-  name: DarkMagenta
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkMagenta_
-  commentId: Overload:SadRogue.Primitives.Color.DarkMagenta
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkMagenta
   fullName: SadRogue.Primitives.Color.DarkMagenta
   nameWithType: Color.DarkMagenta
 - uid: SadRogue.Primitives.Color.DarkOliveGreen
   name: DarkOliveGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkOliveGreen
-  commentId: P:SadRogue.Primitives.Color.DarkOliveGreen
-  fullName: SadRogue.Primitives.Color.DarkOliveGreen
-  nameWithType: Color.DarkOliveGreen
-- uid: SadRogue.Primitives.Color.DarkOliveGreen*
-  name: DarkOliveGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkOliveGreen_
-  commentId: Overload:SadRogue.Primitives.Color.DarkOliveGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkOliveGreen
   fullName: SadRogue.Primitives.Color.DarkOliveGreen
   nameWithType: Color.DarkOliveGreen
 - uid: SadRogue.Primitives.Color.DarkOrange
   name: DarkOrange
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkOrange
-  commentId: P:SadRogue.Primitives.Color.DarkOrange
-  fullName: SadRogue.Primitives.Color.DarkOrange
-  nameWithType: Color.DarkOrange
-- uid: SadRogue.Primitives.Color.DarkOrange*
-  name: DarkOrange
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkOrange_
-  commentId: Overload:SadRogue.Primitives.Color.DarkOrange
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkOrange
   fullName: SadRogue.Primitives.Color.DarkOrange
   nameWithType: Color.DarkOrange
 - uid: SadRogue.Primitives.Color.DarkOrchid
   name: DarkOrchid
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkOrchid
-  commentId: P:SadRogue.Primitives.Color.DarkOrchid
-  fullName: SadRogue.Primitives.Color.DarkOrchid
-  nameWithType: Color.DarkOrchid
-- uid: SadRogue.Primitives.Color.DarkOrchid*
-  name: DarkOrchid
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkOrchid_
-  commentId: Overload:SadRogue.Primitives.Color.DarkOrchid
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkOrchid
   fullName: SadRogue.Primitives.Color.DarkOrchid
   nameWithType: Color.DarkOrchid
 - uid: SadRogue.Primitives.Color.DarkRed
   name: DarkRed
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkRed
-  commentId: P:SadRogue.Primitives.Color.DarkRed
-  fullName: SadRogue.Primitives.Color.DarkRed
-  nameWithType: Color.DarkRed
-- uid: SadRogue.Primitives.Color.DarkRed*
-  name: DarkRed
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkRed_
-  commentId: Overload:SadRogue.Primitives.Color.DarkRed
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkRed
   fullName: SadRogue.Primitives.Color.DarkRed
   nameWithType: Color.DarkRed
 - uid: SadRogue.Primitives.Color.DarkSalmon
   name: DarkSalmon
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSalmon
-  commentId: P:SadRogue.Primitives.Color.DarkSalmon
-  fullName: SadRogue.Primitives.Color.DarkSalmon
-  nameWithType: Color.DarkSalmon
-- uid: SadRogue.Primitives.Color.DarkSalmon*
-  name: DarkSalmon
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSalmon_
-  commentId: Overload:SadRogue.Primitives.Color.DarkSalmon
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkSalmon
   fullName: SadRogue.Primitives.Color.DarkSalmon
   nameWithType: Color.DarkSalmon
 - uid: SadRogue.Primitives.Color.DarkSeaGreen
   name: DarkSeaGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSeaGreen
-  commentId: P:SadRogue.Primitives.Color.DarkSeaGreen
-  fullName: SadRogue.Primitives.Color.DarkSeaGreen
-  nameWithType: Color.DarkSeaGreen
-- uid: SadRogue.Primitives.Color.DarkSeaGreen*
-  name: DarkSeaGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSeaGreen_
-  commentId: Overload:SadRogue.Primitives.Color.DarkSeaGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkSeaGreen
   fullName: SadRogue.Primitives.Color.DarkSeaGreen
   nameWithType: Color.DarkSeaGreen
 - uid: SadRogue.Primitives.Color.DarkSlateBlue
   name: DarkSlateBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSlateBlue
-  commentId: P:SadRogue.Primitives.Color.DarkSlateBlue
-  fullName: SadRogue.Primitives.Color.DarkSlateBlue
-  nameWithType: Color.DarkSlateBlue
-- uid: SadRogue.Primitives.Color.DarkSlateBlue*
-  name: DarkSlateBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSlateBlue_
-  commentId: Overload:SadRogue.Primitives.Color.DarkSlateBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkSlateBlue
   fullName: SadRogue.Primitives.Color.DarkSlateBlue
   nameWithType: Color.DarkSlateBlue
 - uid: SadRogue.Primitives.Color.DarkSlateGray
   name: DarkSlateGray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSlateGray
-  commentId: P:SadRogue.Primitives.Color.DarkSlateGray
-  fullName: SadRogue.Primitives.Color.DarkSlateGray
-  nameWithType: Color.DarkSlateGray
-- uid: SadRogue.Primitives.Color.DarkSlateGray*
-  name: DarkSlateGray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkSlateGray_
-  commentId: Overload:SadRogue.Primitives.Color.DarkSlateGray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkSlateGray
   fullName: SadRogue.Primitives.Color.DarkSlateGray
   nameWithType: Color.DarkSlateGray
 - uid: SadRogue.Primitives.Color.DarkTurquoise
   name: DarkTurquoise
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkTurquoise
-  commentId: P:SadRogue.Primitives.Color.DarkTurquoise
-  fullName: SadRogue.Primitives.Color.DarkTurquoise
-  nameWithType: Color.DarkTurquoise
-- uid: SadRogue.Primitives.Color.DarkTurquoise*
-  name: DarkTurquoise
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkTurquoise_
-  commentId: Overload:SadRogue.Primitives.Color.DarkTurquoise
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkTurquoise
   fullName: SadRogue.Primitives.Color.DarkTurquoise
   nameWithType: Color.DarkTurquoise
 - uid: SadRogue.Primitives.Color.DarkViolet
   name: DarkViolet
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkViolet
-  commentId: P:SadRogue.Primitives.Color.DarkViolet
-  fullName: SadRogue.Primitives.Color.DarkViolet
-  nameWithType: Color.DarkViolet
-- uid: SadRogue.Primitives.Color.DarkViolet*
-  name: DarkViolet
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DarkViolet_
-  commentId: Overload:SadRogue.Primitives.Color.DarkViolet
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DarkViolet
   fullName: SadRogue.Primitives.Color.DarkViolet
   nameWithType: Color.DarkViolet
 - uid: SadRogue.Primitives.Color.Deconstruct(System.Byte@,System.Byte@,System.Byte@)
@@ -1368,53 +1133,25 @@ references:
 - uid: SadRogue.Primitives.Color.DeepPink
   name: DeepPink
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DeepPink
-  commentId: P:SadRogue.Primitives.Color.DeepPink
-  fullName: SadRogue.Primitives.Color.DeepPink
-  nameWithType: Color.DeepPink
-- uid: SadRogue.Primitives.Color.DeepPink*
-  name: DeepPink
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DeepPink_
-  commentId: Overload:SadRogue.Primitives.Color.DeepPink
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DeepPink
   fullName: SadRogue.Primitives.Color.DeepPink
   nameWithType: Color.DeepPink
 - uid: SadRogue.Primitives.Color.DeepSkyBlue
   name: DeepSkyBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DeepSkyBlue
-  commentId: P:SadRogue.Primitives.Color.DeepSkyBlue
-  fullName: SadRogue.Primitives.Color.DeepSkyBlue
-  nameWithType: Color.DeepSkyBlue
-- uid: SadRogue.Primitives.Color.DeepSkyBlue*
-  name: DeepSkyBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DeepSkyBlue_
-  commentId: Overload:SadRogue.Primitives.Color.DeepSkyBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DeepSkyBlue
   fullName: SadRogue.Primitives.Color.DeepSkyBlue
   nameWithType: Color.DeepSkyBlue
 - uid: SadRogue.Primitives.Color.DimGray
   name: DimGray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DimGray
-  commentId: P:SadRogue.Primitives.Color.DimGray
-  fullName: SadRogue.Primitives.Color.DimGray
-  nameWithType: Color.DimGray
-- uid: SadRogue.Primitives.Color.DimGray*
-  name: DimGray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DimGray_
-  commentId: Overload:SadRogue.Primitives.Color.DimGray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DimGray
   fullName: SadRogue.Primitives.Color.DimGray
   nameWithType: Color.DimGray
 - uid: SadRogue.Primitives.Color.DodgerBlue
   name: DodgerBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DodgerBlue
-  commentId: P:SadRogue.Primitives.Color.DodgerBlue
-  fullName: SadRogue.Primitives.Color.DodgerBlue
-  nameWithType: Color.DodgerBlue
-- uid: SadRogue.Primitives.Color.DodgerBlue*
-  name: DodgerBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_DodgerBlue_
-  commentId: Overload:SadRogue.Primitives.Color.DodgerBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.DodgerBlue
   fullName: SadRogue.Primitives.Color.DodgerBlue
   nameWithType: Color.DodgerBlue
 - uid: SadRogue.Primitives.Color.Equals(SadRogue.Primitives.Color)
@@ -1439,40 +1176,19 @@ references:
 - uid: SadRogue.Primitives.Color.Firebrick
   name: Firebrick
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Firebrick
-  commentId: P:SadRogue.Primitives.Color.Firebrick
-  fullName: SadRogue.Primitives.Color.Firebrick
-  nameWithType: Color.Firebrick
-- uid: SadRogue.Primitives.Color.Firebrick*
-  name: Firebrick
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Firebrick_
-  commentId: Overload:SadRogue.Primitives.Color.Firebrick
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Firebrick
   fullName: SadRogue.Primitives.Color.Firebrick
   nameWithType: Color.Firebrick
 - uid: SadRogue.Primitives.Color.FloralWhite
   name: FloralWhite
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_FloralWhite
-  commentId: P:SadRogue.Primitives.Color.FloralWhite
-  fullName: SadRogue.Primitives.Color.FloralWhite
-  nameWithType: Color.FloralWhite
-- uid: SadRogue.Primitives.Color.FloralWhite*
-  name: FloralWhite
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_FloralWhite_
-  commentId: Overload:SadRogue.Primitives.Color.FloralWhite
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.FloralWhite
   fullName: SadRogue.Primitives.Color.FloralWhite
   nameWithType: Color.FloralWhite
 - uid: SadRogue.Primitives.Color.ForestGreen
   name: ForestGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_ForestGreen
-  commentId: P:SadRogue.Primitives.Color.ForestGreen
-  fullName: SadRogue.Primitives.Color.ForestGreen
-  nameWithType: Color.ForestGreen
-- uid: SadRogue.Primitives.Color.ForestGreen*
-  name: ForestGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_ForestGreen_
-  commentId: Overload:SadRogue.Primitives.Color.ForestGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.ForestGreen
   fullName: SadRogue.Primitives.Color.ForestGreen
   nameWithType: Color.ForestGreen
 - uid: SadRogue.Primitives.Color.FromHSL(System.Single,System.Single,System.Single)
@@ -1504,14 +1220,7 @@ references:
 - uid: SadRogue.Primitives.Color.Fuchsia
   name: Fuchsia
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Fuchsia
-  commentId: P:SadRogue.Primitives.Color.Fuchsia
-  fullName: SadRogue.Primitives.Color.Fuchsia
-  nameWithType: Color.Fuchsia
-- uid: SadRogue.Primitives.Color.Fuchsia*
-  name: Fuchsia
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Fuchsia_
-  commentId: Overload:SadRogue.Primitives.Color.Fuchsia
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Fuchsia
   fullName: SadRogue.Primitives.Color.Fuchsia
   nameWithType: Color.Fuchsia
 - uid: SadRogue.Primitives.Color.G
@@ -1530,14 +1239,7 @@ references:
 - uid: SadRogue.Primitives.Color.Gainsboro
   name: Gainsboro
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Gainsboro
-  commentId: P:SadRogue.Primitives.Color.Gainsboro
-  fullName: SadRogue.Primitives.Color.Gainsboro
-  nameWithType: Color.Gainsboro
-- uid: SadRogue.Primitives.Color.Gainsboro*
-  name: Gainsboro
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Gainsboro_
-  commentId: Overload:SadRogue.Primitives.Color.Gainsboro
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Gainsboro
   fullName: SadRogue.Primitives.Color.Gainsboro
   nameWithType: Color.Gainsboro
 - uid: SadRogue.Primitives.Color.GetBrightness
@@ -1608,209 +1310,97 @@ references:
 - uid: SadRogue.Primitives.Color.GhostWhite
   name: GhostWhite
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_GhostWhite
-  commentId: P:SadRogue.Primitives.Color.GhostWhite
-  fullName: SadRogue.Primitives.Color.GhostWhite
-  nameWithType: Color.GhostWhite
-- uid: SadRogue.Primitives.Color.GhostWhite*
-  name: GhostWhite
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_GhostWhite_
-  commentId: Overload:SadRogue.Primitives.Color.GhostWhite
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.GhostWhite
   fullName: SadRogue.Primitives.Color.GhostWhite
   nameWithType: Color.GhostWhite
 - uid: SadRogue.Primitives.Color.Gold
   name: Gold
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Gold
-  commentId: P:SadRogue.Primitives.Color.Gold
-  fullName: SadRogue.Primitives.Color.Gold
-  nameWithType: Color.Gold
-- uid: SadRogue.Primitives.Color.Gold*
-  name: Gold
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Gold_
-  commentId: Overload:SadRogue.Primitives.Color.Gold
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Gold
   fullName: SadRogue.Primitives.Color.Gold
   nameWithType: Color.Gold
 - uid: SadRogue.Primitives.Color.Goldenrod
   name: Goldenrod
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Goldenrod
-  commentId: P:SadRogue.Primitives.Color.Goldenrod
-  fullName: SadRogue.Primitives.Color.Goldenrod
-  nameWithType: Color.Goldenrod
-- uid: SadRogue.Primitives.Color.Goldenrod*
-  name: Goldenrod
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Goldenrod_
-  commentId: Overload:SadRogue.Primitives.Color.Goldenrod
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Goldenrod
   fullName: SadRogue.Primitives.Color.Goldenrod
   nameWithType: Color.Goldenrod
 - uid: SadRogue.Primitives.Color.Gray
   name: Gray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Gray
-  commentId: P:SadRogue.Primitives.Color.Gray
-  fullName: SadRogue.Primitives.Color.Gray
-  nameWithType: Color.Gray
-- uid: SadRogue.Primitives.Color.Gray*
-  name: Gray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Gray_
-  commentId: Overload:SadRogue.Primitives.Color.Gray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Gray
   fullName: SadRogue.Primitives.Color.Gray
   nameWithType: Color.Gray
 - uid: SadRogue.Primitives.Color.Green
   name: Green
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Green
-  commentId: P:SadRogue.Primitives.Color.Green
-  fullName: SadRogue.Primitives.Color.Green
-  nameWithType: Color.Green
-- uid: SadRogue.Primitives.Color.Green*
-  name: Green
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Green_
-  commentId: Overload:SadRogue.Primitives.Color.Green
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Green
   fullName: SadRogue.Primitives.Color.Green
   nameWithType: Color.Green
 - uid: SadRogue.Primitives.Color.GreenYellow
   name: GreenYellow
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_GreenYellow
-  commentId: P:SadRogue.Primitives.Color.GreenYellow
-  fullName: SadRogue.Primitives.Color.GreenYellow
-  nameWithType: Color.GreenYellow
-- uid: SadRogue.Primitives.Color.GreenYellow*
-  name: GreenYellow
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_GreenYellow_
-  commentId: Overload:SadRogue.Primitives.Color.GreenYellow
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.GreenYellow
   fullName: SadRogue.Primitives.Color.GreenYellow
   nameWithType: Color.GreenYellow
 - uid: SadRogue.Primitives.Color.Honeydew
   name: Honeydew
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Honeydew
-  commentId: P:SadRogue.Primitives.Color.Honeydew
-  fullName: SadRogue.Primitives.Color.Honeydew
-  nameWithType: Color.Honeydew
-- uid: SadRogue.Primitives.Color.Honeydew*
-  name: Honeydew
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Honeydew_
-  commentId: Overload:SadRogue.Primitives.Color.Honeydew
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Honeydew
   fullName: SadRogue.Primitives.Color.Honeydew
   nameWithType: Color.Honeydew
 - uid: SadRogue.Primitives.Color.HotPink
   name: HotPink
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_HotPink
-  commentId: P:SadRogue.Primitives.Color.HotPink
-  fullName: SadRogue.Primitives.Color.HotPink
-  nameWithType: Color.HotPink
-- uid: SadRogue.Primitives.Color.HotPink*
-  name: HotPink
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_HotPink_
-  commentId: Overload:SadRogue.Primitives.Color.HotPink
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.HotPink
   fullName: SadRogue.Primitives.Color.HotPink
   nameWithType: Color.HotPink
 - uid: SadRogue.Primitives.Color.IndianRed
   name: IndianRed
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_IndianRed
-  commentId: P:SadRogue.Primitives.Color.IndianRed
-  fullName: SadRogue.Primitives.Color.IndianRed
-  nameWithType: Color.IndianRed
-- uid: SadRogue.Primitives.Color.IndianRed*
-  name: IndianRed
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_IndianRed_
-  commentId: Overload:SadRogue.Primitives.Color.IndianRed
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.IndianRed
   fullName: SadRogue.Primitives.Color.IndianRed
   nameWithType: Color.IndianRed
 - uid: SadRogue.Primitives.Color.Indigo
   name: Indigo
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Indigo
-  commentId: P:SadRogue.Primitives.Color.Indigo
-  fullName: SadRogue.Primitives.Color.Indigo
-  nameWithType: Color.Indigo
-- uid: SadRogue.Primitives.Color.Indigo*
-  name: Indigo
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Indigo_
-  commentId: Overload:SadRogue.Primitives.Color.Indigo
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Indigo
   fullName: SadRogue.Primitives.Color.Indigo
   nameWithType: Color.Indigo
 - uid: SadRogue.Primitives.Color.Ivory
   name: Ivory
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Ivory
-  commentId: P:SadRogue.Primitives.Color.Ivory
-  fullName: SadRogue.Primitives.Color.Ivory
-  nameWithType: Color.Ivory
-- uid: SadRogue.Primitives.Color.Ivory*
-  name: Ivory
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Ivory_
-  commentId: Overload:SadRogue.Primitives.Color.Ivory
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Ivory
   fullName: SadRogue.Primitives.Color.Ivory
   nameWithType: Color.Ivory
 - uid: SadRogue.Primitives.Color.Khaki
   name: Khaki
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Khaki
-  commentId: P:SadRogue.Primitives.Color.Khaki
-  fullName: SadRogue.Primitives.Color.Khaki
-  nameWithType: Color.Khaki
-- uid: SadRogue.Primitives.Color.Khaki*
-  name: Khaki
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Khaki_
-  commentId: Overload:SadRogue.Primitives.Color.Khaki
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Khaki
   fullName: SadRogue.Primitives.Color.Khaki
   nameWithType: Color.Khaki
 - uid: SadRogue.Primitives.Color.Lavender
   name: Lavender
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Lavender
-  commentId: P:SadRogue.Primitives.Color.Lavender
-  fullName: SadRogue.Primitives.Color.Lavender
-  nameWithType: Color.Lavender
-- uid: SadRogue.Primitives.Color.Lavender*
-  name: Lavender
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Lavender_
-  commentId: Overload:SadRogue.Primitives.Color.Lavender
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Lavender
   fullName: SadRogue.Primitives.Color.Lavender
   nameWithType: Color.Lavender
 - uid: SadRogue.Primitives.Color.LavenderBlush
   name: LavenderBlush
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LavenderBlush
-  commentId: P:SadRogue.Primitives.Color.LavenderBlush
-  fullName: SadRogue.Primitives.Color.LavenderBlush
-  nameWithType: Color.LavenderBlush
-- uid: SadRogue.Primitives.Color.LavenderBlush*
-  name: LavenderBlush
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LavenderBlush_
-  commentId: Overload:SadRogue.Primitives.Color.LavenderBlush
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LavenderBlush
   fullName: SadRogue.Primitives.Color.LavenderBlush
   nameWithType: Color.LavenderBlush
 - uid: SadRogue.Primitives.Color.LawnGreen
   name: LawnGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LawnGreen
-  commentId: P:SadRogue.Primitives.Color.LawnGreen
-  fullName: SadRogue.Primitives.Color.LawnGreen
-  nameWithType: Color.LawnGreen
-- uid: SadRogue.Primitives.Color.LawnGreen*
-  name: LawnGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LawnGreen_
-  commentId: Overload:SadRogue.Primitives.Color.LawnGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LawnGreen
   fullName: SadRogue.Primitives.Color.LawnGreen
   nameWithType: Color.LawnGreen
 - uid: SadRogue.Primitives.Color.LemonChiffon
   name: LemonChiffon
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LemonChiffon
-  commentId: P:SadRogue.Primitives.Color.LemonChiffon
-  fullName: SadRogue.Primitives.Color.LemonChiffon
-  nameWithType: Color.LemonChiffon
-- uid: SadRogue.Primitives.Color.LemonChiffon*
-  name: LemonChiffon
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LemonChiffon_
-  commentId: Overload:SadRogue.Primitives.Color.LemonChiffon
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LemonChiffon
   fullName: SadRogue.Primitives.Color.LemonChiffon
   nameWithType: Color.LemonChiffon
 - uid: SadRogue.Primitives.Color.Lerp(SadRogue.Primitives.Color,SadRogue.Primitives.Color,System.Single)
@@ -1842,417 +1432,206 @@ references:
 - uid: SadRogue.Primitives.Color.LightBlue
   name: LightBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightBlue
-  commentId: P:SadRogue.Primitives.Color.LightBlue
-  fullName: SadRogue.Primitives.Color.LightBlue
-  nameWithType: Color.LightBlue
-- uid: SadRogue.Primitives.Color.LightBlue*
-  name: LightBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightBlue_
-  commentId: Overload:SadRogue.Primitives.Color.LightBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightBlue
   fullName: SadRogue.Primitives.Color.LightBlue
   nameWithType: Color.LightBlue
 - uid: SadRogue.Primitives.Color.LightCoral
   name: LightCoral
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightCoral
-  commentId: P:SadRogue.Primitives.Color.LightCoral
-  fullName: SadRogue.Primitives.Color.LightCoral
-  nameWithType: Color.LightCoral
-- uid: SadRogue.Primitives.Color.LightCoral*
-  name: LightCoral
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightCoral_
-  commentId: Overload:SadRogue.Primitives.Color.LightCoral
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightCoral
   fullName: SadRogue.Primitives.Color.LightCoral
   nameWithType: Color.LightCoral
 - uid: SadRogue.Primitives.Color.LightCyan
   name: LightCyan
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightCyan
-  commentId: P:SadRogue.Primitives.Color.LightCyan
-  fullName: SadRogue.Primitives.Color.LightCyan
-  nameWithType: Color.LightCyan
-- uid: SadRogue.Primitives.Color.LightCyan*
-  name: LightCyan
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightCyan_
-  commentId: Overload:SadRogue.Primitives.Color.LightCyan
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightCyan
   fullName: SadRogue.Primitives.Color.LightCyan
   nameWithType: Color.LightCyan
 - uid: SadRogue.Primitives.Color.LightGoldenrodYellow
   name: LightGoldenrodYellow
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightGoldenrodYellow
-  commentId: P:SadRogue.Primitives.Color.LightGoldenrodYellow
-  fullName: SadRogue.Primitives.Color.LightGoldenrodYellow
-  nameWithType: Color.LightGoldenrodYellow
-- uid: SadRogue.Primitives.Color.LightGoldenrodYellow*
-  name: LightGoldenrodYellow
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightGoldenrodYellow_
-  commentId: Overload:SadRogue.Primitives.Color.LightGoldenrodYellow
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightGoldenrodYellow
   fullName: SadRogue.Primitives.Color.LightGoldenrodYellow
   nameWithType: Color.LightGoldenrodYellow
 - uid: SadRogue.Primitives.Color.LightGray
   name: LightGray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightGray
-  commentId: P:SadRogue.Primitives.Color.LightGray
-  fullName: SadRogue.Primitives.Color.LightGray
-  nameWithType: Color.LightGray
-- uid: SadRogue.Primitives.Color.LightGray*
-  name: LightGray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightGray_
-  commentId: Overload:SadRogue.Primitives.Color.LightGray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightGray
   fullName: SadRogue.Primitives.Color.LightGray
   nameWithType: Color.LightGray
 - uid: SadRogue.Primitives.Color.LightGreen
   name: LightGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightGreen
-  commentId: P:SadRogue.Primitives.Color.LightGreen
-  fullName: SadRogue.Primitives.Color.LightGreen
-  nameWithType: Color.LightGreen
-- uid: SadRogue.Primitives.Color.LightGreen*
-  name: LightGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightGreen_
-  commentId: Overload:SadRogue.Primitives.Color.LightGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightGreen
   fullName: SadRogue.Primitives.Color.LightGreen
   nameWithType: Color.LightGreen
 - uid: SadRogue.Primitives.Color.LightPink
   name: LightPink
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightPink
-  commentId: P:SadRogue.Primitives.Color.LightPink
-  fullName: SadRogue.Primitives.Color.LightPink
-  nameWithType: Color.LightPink
-- uid: SadRogue.Primitives.Color.LightPink*
-  name: LightPink
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightPink_
-  commentId: Overload:SadRogue.Primitives.Color.LightPink
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightPink
   fullName: SadRogue.Primitives.Color.LightPink
   nameWithType: Color.LightPink
 - uid: SadRogue.Primitives.Color.LightSalmon
   name: LightSalmon
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSalmon
-  commentId: P:SadRogue.Primitives.Color.LightSalmon
-  fullName: SadRogue.Primitives.Color.LightSalmon
-  nameWithType: Color.LightSalmon
-- uid: SadRogue.Primitives.Color.LightSalmon*
-  name: LightSalmon
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSalmon_
-  commentId: Overload:SadRogue.Primitives.Color.LightSalmon
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightSalmon
   fullName: SadRogue.Primitives.Color.LightSalmon
   nameWithType: Color.LightSalmon
 - uid: SadRogue.Primitives.Color.LightSeaGreen
   name: LightSeaGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSeaGreen
-  commentId: P:SadRogue.Primitives.Color.LightSeaGreen
-  fullName: SadRogue.Primitives.Color.LightSeaGreen
-  nameWithType: Color.LightSeaGreen
-- uid: SadRogue.Primitives.Color.LightSeaGreen*
-  name: LightSeaGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSeaGreen_
-  commentId: Overload:SadRogue.Primitives.Color.LightSeaGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightSeaGreen
   fullName: SadRogue.Primitives.Color.LightSeaGreen
   nameWithType: Color.LightSeaGreen
 - uid: SadRogue.Primitives.Color.LightSkyBlue
   name: LightSkyBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSkyBlue
-  commentId: P:SadRogue.Primitives.Color.LightSkyBlue
-  fullName: SadRogue.Primitives.Color.LightSkyBlue
-  nameWithType: Color.LightSkyBlue
-- uid: SadRogue.Primitives.Color.LightSkyBlue*
-  name: LightSkyBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSkyBlue_
-  commentId: Overload:SadRogue.Primitives.Color.LightSkyBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightSkyBlue
   fullName: SadRogue.Primitives.Color.LightSkyBlue
   nameWithType: Color.LightSkyBlue
 - uid: SadRogue.Primitives.Color.LightSlateGray
   name: LightSlateGray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSlateGray
-  commentId: P:SadRogue.Primitives.Color.LightSlateGray
-  fullName: SadRogue.Primitives.Color.LightSlateGray
-  nameWithType: Color.LightSlateGray
-- uid: SadRogue.Primitives.Color.LightSlateGray*
-  name: LightSlateGray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSlateGray_
-  commentId: Overload:SadRogue.Primitives.Color.LightSlateGray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightSlateGray
   fullName: SadRogue.Primitives.Color.LightSlateGray
   nameWithType: Color.LightSlateGray
 - uid: SadRogue.Primitives.Color.LightSteelBlue
   name: LightSteelBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSteelBlue
-  commentId: P:SadRogue.Primitives.Color.LightSteelBlue
-  fullName: SadRogue.Primitives.Color.LightSteelBlue
-  nameWithType: Color.LightSteelBlue
-- uid: SadRogue.Primitives.Color.LightSteelBlue*
-  name: LightSteelBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightSteelBlue_
-  commentId: Overload:SadRogue.Primitives.Color.LightSteelBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightSteelBlue
   fullName: SadRogue.Primitives.Color.LightSteelBlue
   nameWithType: Color.LightSteelBlue
 - uid: SadRogue.Primitives.Color.LightYellow
   name: LightYellow
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightYellow
-  commentId: P:SadRogue.Primitives.Color.LightYellow
-  fullName: SadRogue.Primitives.Color.LightYellow
-  nameWithType: Color.LightYellow
-- uid: SadRogue.Primitives.Color.LightYellow*
-  name: LightYellow
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LightYellow_
-  commentId: Overload:SadRogue.Primitives.Color.LightYellow
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LightYellow
   fullName: SadRogue.Primitives.Color.LightYellow
   nameWithType: Color.LightYellow
 - uid: SadRogue.Primitives.Color.Lime
   name: Lime
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Lime
-  commentId: P:SadRogue.Primitives.Color.Lime
-  fullName: SadRogue.Primitives.Color.Lime
-  nameWithType: Color.Lime
-- uid: SadRogue.Primitives.Color.Lime*
-  name: Lime
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Lime_
-  commentId: Overload:SadRogue.Primitives.Color.Lime
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Lime
   fullName: SadRogue.Primitives.Color.Lime
   nameWithType: Color.Lime
 - uid: SadRogue.Primitives.Color.LimeGreen
   name: LimeGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LimeGreen
-  commentId: P:SadRogue.Primitives.Color.LimeGreen
-  fullName: SadRogue.Primitives.Color.LimeGreen
-  nameWithType: Color.LimeGreen
-- uid: SadRogue.Primitives.Color.LimeGreen*
-  name: LimeGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_LimeGreen_
-  commentId: Overload:SadRogue.Primitives.Color.LimeGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.LimeGreen
   fullName: SadRogue.Primitives.Color.LimeGreen
   nameWithType: Color.LimeGreen
 - uid: SadRogue.Primitives.Color.Linen
   name: Linen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Linen
-  commentId: P:SadRogue.Primitives.Color.Linen
-  fullName: SadRogue.Primitives.Color.Linen
-  nameWithType: Color.Linen
-- uid: SadRogue.Primitives.Color.Linen*
-  name: Linen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Linen_
-  commentId: Overload:SadRogue.Primitives.Color.Linen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Linen
   fullName: SadRogue.Primitives.Color.Linen
   nameWithType: Color.Linen
 - uid: SadRogue.Primitives.Color.Magenta
   name: Magenta
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Magenta
-  commentId: P:SadRogue.Primitives.Color.Magenta
-  fullName: SadRogue.Primitives.Color.Magenta
-  nameWithType: Color.Magenta
-- uid: SadRogue.Primitives.Color.Magenta*
-  name: Magenta
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Magenta_
-  commentId: Overload:SadRogue.Primitives.Color.Magenta
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Magenta
   fullName: SadRogue.Primitives.Color.Magenta
   nameWithType: Color.Magenta
 - uid: SadRogue.Primitives.Color.Maroon
   name: Maroon
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Maroon
-  commentId: P:SadRogue.Primitives.Color.Maroon
+  commentId: F:SadRogue.Primitives.Color.Maroon
   fullName: SadRogue.Primitives.Color.Maroon
   nameWithType: Color.Maroon
-- uid: SadRogue.Primitives.Color.Maroon*
-  name: Maroon
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Maroon_
-  commentId: Overload:SadRogue.Primitives.Color.Maroon
+- uid: SadRogue.Primitives.Color.Matches(SadRogue.Primitives.Color)
+  name: Matches(Color)
+  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Matches_SadRogue_Primitives_Color_
+  commentId: M:SadRogue.Primitives.Color.Matches(SadRogue.Primitives.Color)
+  fullName: SadRogue.Primitives.Color.Matches(SadRogue.Primitives.Color)
+  nameWithType: Color.Matches(Color)
+- uid: SadRogue.Primitives.Color.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Matches_
+  commentId: Overload:SadRogue.Primitives.Color.Matches
   isSpec: "True"
-  fullName: SadRogue.Primitives.Color.Maroon
-  nameWithType: Color.Maroon
+  fullName: SadRogue.Primitives.Color.Matches
+  nameWithType: Color.Matches
 - uid: SadRogue.Primitives.Color.MediumAquamarine
   name: MediumAquamarine
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumAquamarine
-  commentId: P:SadRogue.Primitives.Color.MediumAquamarine
-  fullName: SadRogue.Primitives.Color.MediumAquamarine
-  nameWithType: Color.MediumAquamarine
-- uid: SadRogue.Primitives.Color.MediumAquamarine*
-  name: MediumAquamarine
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumAquamarine_
-  commentId: Overload:SadRogue.Primitives.Color.MediumAquamarine
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumAquamarine
   fullName: SadRogue.Primitives.Color.MediumAquamarine
   nameWithType: Color.MediumAquamarine
 - uid: SadRogue.Primitives.Color.MediumBlue
   name: MediumBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumBlue
-  commentId: P:SadRogue.Primitives.Color.MediumBlue
-  fullName: SadRogue.Primitives.Color.MediumBlue
-  nameWithType: Color.MediumBlue
-- uid: SadRogue.Primitives.Color.MediumBlue*
-  name: MediumBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumBlue_
-  commentId: Overload:SadRogue.Primitives.Color.MediumBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumBlue
   fullName: SadRogue.Primitives.Color.MediumBlue
   nameWithType: Color.MediumBlue
 - uid: SadRogue.Primitives.Color.MediumOrchid
   name: MediumOrchid
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumOrchid
-  commentId: P:SadRogue.Primitives.Color.MediumOrchid
-  fullName: SadRogue.Primitives.Color.MediumOrchid
-  nameWithType: Color.MediumOrchid
-- uid: SadRogue.Primitives.Color.MediumOrchid*
-  name: MediumOrchid
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumOrchid_
-  commentId: Overload:SadRogue.Primitives.Color.MediumOrchid
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumOrchid
   fullName: SadRogue.Primitives.Color.MediumOrchid
   nameWithType: Color.MediumOrchid
 - uid: SadRogue.Primitives.Color.MediumPurple
   name: MediumPurple
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumPurple
-  commentId: P:SadRogue.Primitives.Color.MediumPurple
-  fullName: SadRogue.Primitives.Color.MediumPurple
-  nameWithType: Color.MediumPurple
-- uid: SadRogue.Primitives.Color.MediumPurple*
-  name: MediumPurple
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumPurple_
-  commentId: Overload:SadRogue.Primitives.Color.MediumPurple
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumPurple
   fullName: SadRogue.Primitives.Color.MediumPurple
   nameWithType: Color.MediumPurple
 - uid: SadRogue.Primitives.Color.MediumSeaGreen
   name: MediumSeaGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumSeaGreen
-  commentId: P:SadRogue.Primitives.Color.MediumSeaGreen
-  fullName: SadRogue.Primitives.Color.MediumSeaGreen
-  nameWithType: Color.MediumSeaGreen
-- uid: SadRogue.Primitives.Color.MediumSeaGreen*
-  name: MediumSeaGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumSeaGreen_
-  commentId: Overload:SadRogue.Primitives.Color.MediumSeaGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumSeaGreen
   fullName: SadRogue.Primitives.Color.MediumSeaGreen
   nameWithType: Color.MediumSeaGreen
 - uid: SadRogue.Primitives.Color.MediumSlateBlue
   name: MediumSlateBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumSlateBlue
-  commentId: P:SadRogue.Primitives.Color.MediumSlateBlue
-  fullName: SadRogue.Primitives.Color.MediumSlateBlue
-  nameWithType: Color.MediumSlateBlue
-- uid: SadRogue.Primitives.Color.MediumSlateBlue*
-  name: MediumSlateBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumSlateBlue_
-  commentId: Overload:SadRogue.Primitives.Color.MediumSlateBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumSlateBlue
   fullName: SadRogue.Primitives.Color.MediumSlateBlue
   nameWithType: Color.MediumSlateBlue
 - uid: SadRogue.Primitives.Color.MediumSpringGreen
   name: MediumSpringGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumSpringGreen
-  commentId: P:SadRogue.Primitives.Color.MediumSpringGreen
-  fullName: SadRogue.Primitives.Color.MediumSpringGreen
-  nameWithType: Color.MediumSpringGreen
-- uid: SadRogue.Primitives.Color.MediumSpringGreen*
-  name: MediumSpringGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumSpringGreen_
-  commentId: Overload:SadRogue.Primitives.Color.MediumSpringGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumSpringGreen
   fullName: SadRogue.Primitives.Color.MediumSpringGreen
   nameWithType: Color.MediumSpringGreen
 - uid: SadRogue.Primitives.Color.MediumTurquoise
   name: MediumTurquoise
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumTurquoise
-  commentId: P:SadRogue.Primitives.Color.MediumTurquoise
-  fullName: SadRogue.Primitives.Color.MediumTurquoise
-  nameWithType: Color.MediumTurquoise
-- uid: SadRogue.Primitives.Color.MediumTurquoise*
-  name: MediumTurquoise
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumTurquoise_
-  commentId: Overload:SadRogue.Primitives.Color.MediumTurquoise
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumTurquoise
   fullName: SadRogue.Primitives.Color.MediumTurquoise
   nameWithType: Color.MediumTurquoise
 - uid: SadRogue.Primitives.Color.MediumVioletRed
   name: MediumVioletRed
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumVioletRed
-  commentId: P:SadRogue.Primitives.Color.MediumVioletRed
-  fullName: SadRogue.Primitives.Color.MediumVioletRed
-  nameWithType: Color.MediumVioletRed
-- uid: SadRogue.Primitives.Color.MediumVioletRed*
-  name: MediumVioletRed
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MediumVioletRed_
-  commentId: Overload:SadRogue.Primitives.Color.MediumVioletRed
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MediumVioletRed
   fullName: SadRogue.Primitives.Color.MediumVioletRed
   nameWithType: Color.MediumVioletRed
 - uid: SadRogue.Primitives.Color.MidnightBlue
   name: MidnightBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MidnightBlue
-  commentId: P:SadRogue.Primitives.Color.MidnightBlue
-  fullName: SadRogue.Primitives.Color.MidnightBlue
-  nameWithType: Color.MidnightBlue
-- uid: SadRogue.Primitives.Color.MidnightBlue*
-  name: MidnightBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MidnightBlue_
-  commentId: Overload:SadRogue.Primitives.Color.MidnightBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MidnightBlue
   fullName: SadRogue.Primitives.Color.MidnightBlue
   nameWithType: Color.MidnightBlue
 - uid: SadRogue.Primitives.Color.MintCream
   name: MintCream
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MintCream
-  commentId: P:SadRogue.Primitives.Color.MintCream
-  fullName: SadRogue.Primitives.Color.MintCream
-  nameWithType: Color.MintCream
-- uid: SadRogue.Primitives.Color.MintCream*
-  name: MintCream
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MintCream_
-  commentId: Overload:SadRogue.Primitives.Color.MintCream
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MintCream
   fullName: SadRogue.Primitives.Color.MintCream
   nameWithType: Color.MintCream
 - uid: SadRogue.Primitives.Color.MistyRose
   name: MistyRose
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MistyRose
-  commentId: P:SadRogue.Primitives.Color.MistyRose
-  fullName: SadRogue.Primitives.Color.MistyRose
-  nameWithType: Color.MistyRose
-- uid: SadRogue.Primitives.Color.MistyRose*
-  name: MistyRose
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MistyRose_
-  commentId: Overload:SadRogue.Primitives.Color.MistyRose
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MistyRose
   fullName: SadRogue.Primitives.Color.MistyRose
   nameWithType: Color.MistyRose
 - uid: SadRogue.Primitives.Color.Moccasin
   name: Moccasin
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Moccasin
-  commentId: P:SadRogue.Primitives.Color.Moccasin
-  fullName: SadRogue.Primitives.Color.Moccasin
-  nameWithType: Color.Moccasin
-- uid: SadRogue.Primitives.Color.Moccasin*
-  name: Moccasin
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Moccasin_
-  commentId: Overload:SadRogue.Primitives.Color.Moccasin
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Moccasin
   fullName: SadRogue.Primitives.Color.Moccasin
   nameWithType: Color.Moccasin
 - uid: SadRogue.Primitives.Color.MonoGameOrange
   name: MonoGameOrange
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MonoGameOrange
-  commentId: P:SadRogue.Primitives.Color.MonoGameOrange
-  fullName: SadRogue.Primitives.Color.MonoGameOrange
-  nameWithType: Color.MonoGameOrange
-- uid: SadRogue.Primitives.Color.MonoGameOrange*
-  name: MonoGameOrange
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_MonoGameOrange_
-  commentId: Overload:SadRogue.Primitives.Color.MonoGameOrange
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.MonoGameOrange
   fullName: SadRogue.Primitives.Color.MonoGameOrange
   nameWithType: Color.MonoGameOrange
 - uid: SadRogue.Primitives.Color.Multiply(SadRogue.Primitives.Color,System.Single)
@@ -2271,66 +1650,31 @@ references:
 - uid: SadRogue.Primitives.Color.NavajoWhite
   name: NavajoWhite
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_NavajoWhite
-  commentId: P:SadRogue.Primitives.Color.NavajoWhite
-  fullName: SadRogue.Primitives.Color.NavajoWhite
-  nameWithType: Color.NavajoWhite
-- uid: SadRogue.Primitives.Color.NavajoWhite*
-  name: NavajoWhite
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_NavajoWhite_
-  commentId: Overload:SadRogue.Primitives.Color.NavajoWhite
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.NavajoWhite
   fullName: SadRogue.Primitives.Color.NavajoWhite
   nameWithType: Color.NavajoWhite
 - uid: SadRogue.Primitives.Color.Navy
   name: Navy
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Navy
-  commentId: P:SadRogue.Primitives.Color.Navy
-  fullName: SadRogue.Primitives.Color.Navy
-  nameWithType: Color.Navy
-- uid: SadRogue.Primitives.Color.Navy*
-  name: Navy
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Navy_
-  commentId: Overload:SadRogue.Primitives.Color.Navy
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Navy
   fullName: SadRogue.Primitives.Color.Navy
   nameWithType: Color.Navy
 - uid: SadRogue.Primitives.Color.OldLace
   name: OldLace
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_OldLace
-  commentId: P:SadRogue.Primitives.Color.OldLace
-  fullName: SadRogue.Primitives.Color.OldLace
-  nameWithType: Color.OldLace
-- uid: SadRogue.Primitives.Color.OldLace*
-  name: OldLace
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_OldLace_
-  commentId: Overload:SadRogue.Primitives.Color.OldLace
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.OldLace
   fullName: SadRogue.Primitives.Color.OldLace
   nameWithType: Color.OldLace
 - uid: SadRogue.Primitives.Color.Olive
   name: Olive
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Olive
-  commentId: P:SadRogue.Primitives.Color.Olive
-  fullName: SadRogue.Primitives.Color.Olive
-  nameWithType: Color.Olive
-- uid: SadRogue.Primitives.Color.Olive*
-  name: Olive
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Olive_
-  commentId: Overload:SadRogue.Primitives.Color.Olive
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Olive
   fullName: SadRogue.Primitives.Color.Olive
   nameWithType: Color.Olive
 - uid: SadRogue.Primitives.Color.OliveDrab
   name: OliveDrab
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_OliveDrab
-  commentId: P:SadRogue.Primitives.Color.OliveDrab
-  fullName: SadRogue.Primitives.Color.OliveDrab
-  nameWithType: Color.OliveDrab
-- uid: SadRogue.Primitives.Color.OliveDrab*
-  name: OliveDrab
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_OliveDrab_
-  commentId: Overload:SadRogue.Primitives.Color.OliveDrab
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.OliveDrab
   fullName: SadRogue.Primitives.Color.OliveDrab
   nameWithType: Color.OliveDrab
 - uid: SadRogue.Primitives.Color.op_Equality(SadRogue.Primitives.Color,SadRogue.Primitives.Color)
@@ -2375,40 +1719,19 @@ references:
 - uid: SadRogue.Primitives.Color.Orange
   name: Orange
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Orange
-  commentId: P:SadRogue.Primitives.Color.Orange
-  fullName: SadRogue.Primitives.Color.Orange
-  nameWithType: Color.Orange
-- uid: SadRogue.Primitives.Color.Orange*
-  name: Orange
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Orange_
-  commentId: Overload:SadRogue.Primitives.Color.Orange
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Orange
   fullName: SadRogue.Primitives.Color.Orange
   nameWithType: Color.Orange
 - uid: SadRogue.Primitives.Color.OrangeRed
   name: OrangeRed
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_OrangeRed
-  commentId: P:SadRogue.Primitives.Color.OrangeRed
-  fullName: SadRogue.Primitives.Color.OrangeRed
-  nameWithType: Color.OrangeRed
-- uid: SadRogue.Primitives.Color.OrangeRed*
-  name: OrangeRed
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_OrangeRed_
-  commentId: Overload:SadRogue.Primitives.Color.OrangeRed
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.OrangeRed
   fullName: SadRogue.Primitives.Color.OrangeRed
   nameWithType: Color.OrangeRed
 - uid: SadRogue.Primitives.Color.Orchid
   name: Orchid
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Orchid
-  commentId: P:SadRogue.Primitives.Color.Orchid
-  fullName: SadRogue.Primitives.Color.Orchid
-  nameWithType: Color.Orchid
-- uid: SadRogue.Primitives.Color.Orchid*
-  name: Orchid
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Orchid_
-  commentId: Overload:SadRogue.Primitives.Color.Orchid
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Orchid
   fullName: SadRogue.Primitives.Color.Orchid
   nameWithType: Color.Orchid
 - uid: SadRogue.Primitives.Color.PackedValue
@@ -2427,144 +1750,67 @@ references:
 - uid: SadRogue.Primitives.Color.PaleGoldenrod
   name: PaleGoldenrod
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleGoldenrod
-  commentId: P:SadRogue.Primitives.Color.PaleGoldenrod
-  fullName: SadRogue.Primitives.Color.PaleGoldenrod
-  nameWithType: Color.PaleGoldenrod
-- uid: SadRogue.Primitives.Color.PaleGoldenrod*
-  name: PaleGoldenrod
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleGoldenrod_
-  commentId: Overload:SadRogue.Primitives.Color.PaleGoldenrod
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PaleGoldenrod
   fullName: SadRogue.Primitives.Color.PaleGoldenrod
   nameWithType: Color.PaleGoldenrod
 - uid: SadRogue.Primitives.Color.PaleGreen
   name: PaleGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleGreen
-  commentId: P:SadRogue.Primitives.Color.PaleGreen
-  fullName: SadRogue.Primitives.Color.PaleGreen
-  nameWithType: Color.PaleGreen
-- uid: SadRogue.Primitives.Color.PaleGreen*
-  name: PaleGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleGreen_
-  commentId: Overload:SadRogue.Primitives.Color.PaleGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PaleGreen
   fullName: SadRogue.Primitives.Color.PaleGreen
   nameWithType: Color.PaleGreen
 - uid: SadRogue.Primitives.Color.PaleTurquoise
   name: PaleTurquoise
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleTurquoise
-  commentId: P:SadRogue.Primitives.Color.PaleTurquoise
-  fullName: SadRogue.Primitives.Color.PaleTurquoise
-  nameWithType: Color.PaleTurquoise
-- uid: SadRogue.Primitives.Color.PaleTurquoise*
-  name: PaleTurquoise
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleTurquoise_
-  commentId: Overload:SadRogue.Primitives.Color.PaleTurquoise
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PaleTurquoise
   fullName: SadRogue.Primitives.Color.PaleTurquoise
   nameWithType: Color.PaleTurquoise
 - uid: SadRogue.Primitives.Color.PaleVioletRed
   name: PaleVioletRed
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleVioletRed
-  commentId: P:SadRogue.Primitives.Color.PaleVioletRed
-  fullName: SadRogue.Primitives.Color.PaleVioletRed
-  nameWithType: Color.PaleVioletRed
-- uid: SadRogue.Primitives.Color.PaleVioletRed*
-  name: PaleVioletRed
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PaleVioletRed_
-  commentId: Overload:SadRogue.Primitives.Color.PaleVioletRed
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PaleVioletRed
   fullName: SadRogue.Primitives.Color.PaleVioletRed
   nameWithType: Color.PaleVioletRed
 - uid: SadRogue.Primitives.Color.PapayaWhip
   name: PapayaWhip
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PapayaWhip
-  commentId: P:SadRogue.Primitives.Color.PapayaWhip
-  fullName: SadRogue.Primitives.Color.PapayaWhip
-  nameWithType: Color.PapayaWhip
-- uid: SadRogue.Primitives.Color.PapayaWhip*
-  name: PapayaWhip
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PapayaWhip_
-  commentId: Overload:SadRogue.Primitives.Color.PapayaWhip
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PapayaWhip
   fullName: SadRogue.Primitives.Color.PapayaWhip
   nameWithType: Color.PapayaWhip
 - uid: SadRogue.Primitives.Color.PeachPuff
   name: PeachPuff
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PeachPuff
-  commentId: P:SadRogue.Primitives.Color.PeachPuff
-  fullName: SadRogue.Primitives.Color.PeachPuff
-  nameWithType: Color.PeachPuff
-- uid: SadRogue.Primitives.Color.PeachPuff*
-  name: PeachPuff
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PeachPuff_
-  commentId: Overload:SadRogue.Primitives.Color.PeachPuff
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PeachPuff
   fullName: SadRogue.Primitives.Color.PeachPuff
   nameWithType: Color.PeachPuff
 - uid: SadRogue.Primitives.Color.Peru
   name: Peru
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Peru
-  commentId: P:SadRogue.Primitives.Color.Peru
-  fullName: SadRogue.Primitives.Color.Peru
-  nameWithType: Color.Peru
-- uid: SadRogue.Primitives.Color.Peru*
-  name: Peru
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Peru_
-  commentId: Overload:SadRogue.Primitives.Color.Peru
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Peru
   fullName: SadRogue.Primitives.Color.Peru
   nameWithType: Color.Peru
 - uid: SadRogue.Primitives.Color.Pink
   name: Pink
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Pink
-  commentId: P:SadRogue.Primitives.Color.Pink
-  fullName: SadRogue.Primitives.Color.Pink
-  nameWithType: Color.Pink
-- uid: SadRogue.Primitives.Color.Pink*
-  name: Pink
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Pink_
-  commentId: Overload:SadRogue.Primitives.Color.Pink
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Pink
   fullName: SadRogue.Primitives.Color.Pink
   nameWithType: Color.Pink
 - uid: SadRogue.Primitives.Color.Plum
   name: Plum
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Plum
-  commentId: P:SadRogue.Primitives.Color.Plum
-  fullName: SadRogue.Primitives.Color.Plum
-  nameWithType: Color.Plum
-- uid: SadRogue.Primitives.Color.Plum*
-  name: Plum
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Plum_
-  commentId: Overload:SadRogue.Primitives.Color.Plum
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Plum
   fullName: SadRogue.Primitives.Color.Plum
   nameWithType: Color.Plum
 - uid: SadRogue.Primitives.Color.PowderBlue
   name: PowderBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PowderBlue
-  commentId: P:SadRogue.Primitives.Color.PowderBlue
-  fullName: SadRogue.Primitives.Color.PowderBlue
-  nameWithType: Color.PowderBlue
-- uid: SadRogue.Primitives.Color.PowderBlue*
-  name: PowderBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_PowderBlue_
-  commentId: Overload:SadRogue.Primitives.Color.PowderBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.PowderBlue
   fullName: SadRogue.Primitives.Color.PowderBlue
   nameWithType: Color.PowderBlue
 - uid: SadRogue.Primitives.Color.Purple
   name: Purple
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Purple
-  commentId: P:SadRogue.Primitives.Color.Purple
-  fullName: SadRogue.Primitives.Color.Purple
-  nameWithType: Color.Purple
-- uid: SadRogue.Primitives.Color.Purple*
-  name: Purple
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Purple_
-  commentId: Overload:SadRogue.Primitives.Color.Purple
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Purple
   fullName: SadRogue.Primitives.Color.Purple
   nameWithType: Color.Purple
 - uid: SadRogue.Primitives.Color.R
@@ -2583,261 +1829,121 @@ references:
 - uid: SadRogue.Primitives.Color.Red
   name: Red
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Red
-  commentId: P:SadRogue.Primitives.Color.Red
-  fullName: SadRogue.Primitives.Color.Red
-  nameWithType: Color.Red
-- uid: SadRogue.Primitives.Color.Red*
-  name: Red
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Red_
-  commentId: Overload:SadRogue.Primitives.Color.Red
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Red
   fullName: SadRogue.Primitives.Color.Red
   nameWithType: Color.Red
 - uid: SadRogue.Primitives.Color.RosyBrown
   name: RosyBrown
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_RosyBrown
-  commentId: P:SadRogue.Primitives.Color.RosyBrown
-  fullName: SadRogue.Primitives.Color.RosyBrown
-  nameWithType: Color.RosyBrown
-- uid: SadRogue.Primitives.Color.RosyBrown*
-  name: RosyBrown
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_RosyBrown_
-  commentId: Overload:SadRogue.Primitives.Color.RosyBrown
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.RosyBrown
   fullName: SadRogue.Primitives.Color.RosyBrown
   nameWithType: Color.RosyBrown
 - uid: SadRogue.Primitives.Color.RoyalBlue
   name: RoyalBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_RoyalBlue
-  commentId: P:SadRogue.Primitives.Color.RoyalBlue
-  fullName: SadRogue.Primitives.Color.RoyalBlue
-  nameWithType: Color.RoyalBlue
-- uid: SadRogue.Primitives.Color.RoyalBlue*
-  name: RoyalBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_RoyalBlue_
-  commentId: Overload:SadRogue.Primitives.Color.RoyalBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.RoyalBlue
   fullName: SadRogue.Primitives.Color.RoyalBlue
   nameWithType: Color.RoyalBlue
 - uid: SadRogue.Primitives.Color.SaddleBrown
   name: SaddleBrown
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SaddleBrown
-  commentId: P:SadRogue.Primitives.Color.SaddleBrown
-  fullName: SadRogue.Primitives.Color.SaddleBrown
-  nameWithType: Color.SaddleBrown
-- uid: SadRogue.Primitives.Color.SaddleBrown*
-  name: SaddleBrown
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SaddleBrown_
-  commentId: Overload:SadRogue.Primitives.Color.SaddleBrown
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SaddleBrown
   fullName: SadRogue.Primitives.Color.SaddleBrown
   nameWithType: Color.SaddleBrown
 - uid: SadRogue.Primitives.Color.Salmon
   name: Salmon
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Salmon
-  commentId: P:SadRogue.Primitives.Color.Salmon
-  fullName: SadRogue.Primitives.Color.Salmon
-  nameWithType: Color.Salmon
-- uid: SadRogue.Primitives.Color.Salmon*
-  name: Salmon
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Salmon_
-  commentId: Overload:SadRogue.Primitives.Color.Salmon
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Salmon
   fullName: SadRogue.Primitives.Color.Salmon
   nameWithType: Color.Salmon
 - uid: SadRogue.Primitives.Color.SandyBrown
   name: SandyBrown
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SandyBrown
-  commentId: P:SadRogue.Primitives.Color.SandyBrown
-  fullName: SadRogue.Primitives.Color.SandyBrown
-  nameWithType: Color.SandyBrown
-- uid: SadRogue.Primitives.Color.SandyBrown*
-  name: SandyBrown
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SandyBrown_
-  commentId: Overload:SadRogue.Primitives.Color.SandyBrown
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SandyBrown
   fullName: SadRogue.Primitives.Color.SandyBrown
   nameWithType: Color.SandyBrown
 - uid: SadRogue.Primitives.Color.SeaGreen
   name: SeaGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SeaGreen
-  commentId: P:SadRogue.Primitives.Color.SeaGreen
-  fullName: SadRogue.Primitives.Color.SeaGreen
-  nameWithType: Color.SeaGreen
-- uid: SadRogue.Primitives.Color.SeaGreen*
-  name: SeaGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SeaGreen_
-  commentId: Overload:SadRogue.Primitives.Color.SeaGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SeaGreen
   fullName: SadRogue.Primitives.Color.SeaGreen
   nameWithType: Color.SeaGreen
 - uid: SadRogue.Primitives.Color.SeaShell
   name: SeaShell
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SeaShell
-  commentId: P:SadRogue.Primitives.Color.SeaShell
-  fullName: SadRogue.Primitives.Color.SeaShell
-  nameWithType: Color.SeaShell
-- uid: SadRogue.Primitives.Color.SeaShell*
-  name: SeaShell
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SeaShell_
-  commentId: Overload:SadRogue.Primitives.Color.SeaShell
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SeaShell
   fullName: SadRogue.Primitives.Color.SeaShell
   nameWithType: Color.SeaShell
 - uid: SadRogue.Primitives.Color.Sienna
   name: Sienna
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Sienna
-  commentId: P:SadRogue.Primitives.Color.Sienna
-  fullName: SadRogue.Primitives.Color.Sienna
-  nameWithType: Color.Sienna
-- uid: SadRogue.Primitives.Color.Sienna*
-  name: Sienna
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Sienna_
-  commentId: Overload:SadRogue.Primitives.Color.Sienna
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Sienna
   fullName: SadRogue.Primitives.Color.Sienna
   nameWithType: Color.Sienna
 - uid: SadRogue.Primitives.Color.Silver
   name: Silver
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Silver
-  commentId: P:SadRogue.Primitives.Color.Silver
-  fullName: SadRogue.Primitives.Color.Silver
-  nameWithType: Color.Silver
-- uid: SadRogue.Primitives.Color.Silver*
-  name: Silver
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Silver_
-  commentId: Overload:SadRogue.Primitives.Color.Silver
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Silver
   fullName: SadRogue.Primitives.Color.Silver
   nameWithType: Color.Silver
 - uid: SadRogue.Primitives.Color.SkyBlue
   name: SkyBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SkyBlue
-  commentId: P:SadRogue.Primitives.Color.SkyBlue
-  fullName: SadRogue.Primitives.Color.SkyBlue
-  nameWithType: Color.SkyBlue
-- uid: SadRogue.Primitives.Color.SkyBlue*
-  name: SkyBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SkyBlue_
-  commentId: Overload:SadRogue.Primitives.Color.SkyBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SkyBlue
   fullName: SadRogue.Primitives.Color.SkyBlue
   nameWithType: Color.SkyBlue
 - uid: SadRogue.Primitives.Color.SlateBlue
   name: SlateBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SlateBlue
-  commentId: P:SadRogue.Primitives.Color.SlateBlue
-  fullName: SadRogue.Primitives.Color.SlateBlue
-  nameWithType: Color.SlateBlue
-- uid: SadRogue.Primitives.Color.SlateBlue*
-  name: SlateBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SlateBlue_
-  commentId: Overload:SadRogue.Primitives.Color.SlateBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SlateBlue
   fullName: SadRogue.Primitives.Color.SlateBlue
   nameWithType: Color.SlateBlue
 - uid: SadRogue.Primitives.Color.SlateGray
   name: SlateGray
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SlateGray
-  commentId: P:SadRogue.Primitives.Color.SlateGray
-  fullName: SadRogue.Primitives.Color.SlateGray
-  nameWithType: Color.SlateGray
-- uid: SadRogue.Primitives.Color.SlateGray*
-  name: SlateGray
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SlateGray_
-  commentId: Overload:SadRogue.Primitives.Color.SlateGray
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SlateGray
   fullName: SadRogue.Primitives.Color.SlateGray
   nameWithType: Color.SlateGray
 - uid: SadRogue.Primitives.Color.Snow
   name: Snow
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Snow
-  commentId: P:SadRogue.Primitives.Color.Snow
-  fullName: SadRogue.Primitives.Color.Snow
-  nameWithType: Color.Snow
-- uid: SadRogue.Primitives.Color.Snow*
-  name: Snow
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Snow_
-  commentId: Overload:SadRogue.Primitives.Color.Snow
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Snow
   fullName: SadRogue.Primitives.Color.Snow
   nameWithType: Color.Snow
 - uid: SadRogue.Primitives.Color.SpringGreen
   name: SpringGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SpringGreen
-  commentId: P:SadRogue.Primitives.Color.SpringGreen
-  fullName: SadRogue.Primitives.Color.SpringGreen
-  nameWithType: Color.SpringGreen
-- uid: SadRogue.Primitives.Color.SpringGreen*
-  name: SpringGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SpringGreen_
-  commentId: Overload:SadRogue.Primitives.Color.SpringGreen
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SpringGreen
   fullName: SadRogue.Primitives.Color.SpringGreen
   nameWithType: Color.SpringGreen
 - uid: SadRogue.Primitives.Color.SteelBlue
   name: SteelBlue
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SteelBlue
-  commentId: P:SadRogue.Primitives.Color.SteelBlue
-  fullName: SadRogue.Primitives.Color.SteelBlue
-  nameWithType: Color.SteelBlue
-- uid: SadRogue.Primitives.Color.SteelBlue*
-  name: SteelBlue
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_SteelBlue_
-  commentId: Overload:SadRogue.Primitives.Color.SteelBlue
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.SteelBlue
   fullName: SadRogue.Primitives.Color.SteelBlue
   nameWithType: Color.SteelBlue
 - uid: SadRogue.Primitives.Color.Tan
   name: Tan
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Tan
-  commentId: P:SadRogue.Primitives.Color.Tan
-  fullName: SadRogue.Primitives.Color.Tan
-  nameWithType: Color.Tan
-- uid: SadRogue.Primitives.Color.Tan*
-  name: Tan
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Tan_
-  commentId: Overload:SadRogue.Primitives.Color.Tan
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Tan
   fullName: SadRogue.Primitives.Color.Tan
   nameWithType: Color.Tan
 - uid: SadRogue.Primitives.Color.Teal
   name: Teal
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Teal
-  commentId: P:SadRogue.Primitives.Color.Teal
-  fullName: SadRogue.Primitives.Color.Teal
-  nameWithType: Color.Teal
-- uid: SadRogue.Primitives.Color.Teal*
-  name: Teal
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Teal_
-  commentId: Overload:SadRogue.Primitives.Color.Teal
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Teal
   fullName: SadRogue.Primitives.Color.Teal
   nameWithType: Color.Teal
 - uid: SadRogue.Primitives.Color.Thistle
   name: Thistle
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Thistle
-  commentId: P:SadRogue.Primitives.Color.Thistle
-  fullName: SadRogue.Primitives.Color.Thistle
-  nameWithType: Color.Thistle
-- uid: SadRogue.Primitives.Color.Thistle*
-  name: Thistle
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Thistle_
-  commentId: Overload:SadRogue.Primitives.Color.Thistle
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Thistle
   fullName: SadRogue.Primitives.Color.Thistle
   nameWithType: Color.Thistle
 - uid: SadRogue.Primitives.Color.Tomato
   name: Tomato
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Tomato
-  commentId: P:SadRogue.Primitives.Color.Tomato
-  fullName: SadRogue.Primitives.Color.Tomato
-  nameWithType: Color.Tomato
-- uid: SadRogue.Primitives.Color.Tomato*
-  name: Tomato
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Tomato_
-  commentId: Overload:SadRogue.Primitives.Color.Tomato
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Tomato
   fullName: SadRogue.Primitives.Color.Tomato
   nameWithType: Color.Tomato
 - uid: SadRogue.Primitives.Color.ToString
@@ -2856,120 +1962,76 @@ references:
 - uid: SadRogue.Primitives.Color.Transparent
   name: Transparent
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Transparent
-  commentId: P:SadRogue.Primitives.Color.Transparent
-  fullName: SadRogue.Primitives.Color.Transparent
-  nameWithType: Color.Transparent
-- uid: SadRogue.Primitives.Color.Transparent*
-  name: Transparent
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Transparent_
-  commentId: Overload:SadRogue.Primitives.Color.Transparent
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Transparent
   fullName: SadRogue.Primitives.Color.Transparent
   nameWithType: Color.Transparent
 - uid: SadRogue.Primitives.Color.TransparentBlack
   name: TransparentBlack
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_TransparentBlack
-  commentId: P:SadRogue.Primitives.Color.TransparentBlack
-  fullName: SadRogue.Primitives.Color.TransparentBlack
-  nameWithType: Color.TransparentBlack
-- uid: SadRogue.Primitives.Color.TransparentBlack*
-  name: TransparentBlack
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_TransparentBlack_
-  commentId: Overload:SadRogue.Primitives.Color.TransparentBlack
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.TransparentBlack
   fullName: SadRogue.Primitives.Color.TransparentBlack
   nameWithType: Color.TransparentBlack
 - uid: SadRogue.Primitives.Color.Turquoise
   name: Turquoise
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Turquoise
-  commentId: P:SadRogue.Primitives.Color.Turquoise
-  fullName: SadRogue.Primitives.Color.Turquoise
-  nameWithType: Color.Turquoise
-- uid: SadRogue.Primitives.Color.Turquoise*
-  name: Turquoise
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Turquoise_
-  commentId: Overload:SadRogue.Primitives.Color.Turquoise
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Turquoise
   fullName: SadRogue.Primitives.Color.Turquoise
   nameWithType: Color.Turquoise
 - uid: SadRogue.Primitives.Color.Violet
   name: Violet
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Violet
-  commentId: P:SadRogue.Primitives.Color.Violet
-  fullName: SadRogue.Primitives.Color.Violet
-  nameWithType: Color.Violet
-- uid: SadRogue.Primitives.Color.Violet*
-  name: Violet
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Violet_
-  commentId: Overload:SadRogue.Primitives.Color.Violet
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Violet
   fullName: SadRogue.Primitives.Color.Violet
   nameWithType: Color.Violet
 - uid: SadRogue.Primitives.Color.Wheat
   name: Wheat
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Wheat
-  commentId: P:SadRogue.Primitives.Color.Wheat
-  fullName: SadRogue.Primitives.Color.Wheat
-  nameWithType: Color.Wheat
-- uid: SadRogue.Primitives.Color.Wheat*
-  name: Wheat
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Wheat_
-  commentId: Overload:SadRogue.Primitives.Color.Wheat
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Wheat
   fullName: SadRogue.Primitives.Color.Wheat
   nameWithType: Color.Wheat
 - uid: SadRogue.Primitives.Color.White
   name: White
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_White
-  commentId: P:SadRogue.Primitives.Color.White
-  fullName: SadRogue.Primitives.Color.White
-  nameWithType: Color.White
-- uid: SadRogue.Primitives.Color.White*
-  name: White
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_White_
-  commentId: Overload:SadRogue.Primitives.Color.White
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.White
   fullName: SadRogue.Primitives.Color.White
   nameWithType: Color.White
 - uid: SadRogue.Primitives.Color.WhiteSmoke
   name: WhiteSmoke
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_WhiteSmoke
-  commentId: P:SadRogue.Primitives.Color.WhiteSmoke
-  fullName: SadRogue.Primitives.Color.WhiteSmoke
-  nameWithType: Color.WhiteSmoke
-- uid: SadRogue.Primitives.Color.WhiteSmoke*
-  name: WhiteSmoke
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_WhiteSmoke_
-  commentId: Overload:SadRogue.Primitives.Color.WhiteSmoke
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.WhiteSmoke
   fullName: SadRogue.Primitives.Color.WhiteSmoke
   nameWithType: Color.WhiteSmoke
 - uid: SadRogue.Primitives.Color.Yellow
   name: Yellow
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Yellow
-  commentId: P:SadRogue.Primitives.Color.Yellow
-  fullName: SadRogue.Primitives.Color.Yellow
-  nameWithType: Color.Yellow
-- uid: SadRogue.Primitives.Color.Yellow*
-  name: Yellow
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_Yellow_
-  commentId: Overload:SadRogue.Primitives.Color.Yellow
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Color.Yellow
   fullName: SadRogue.Primitives.Color.Yellow
   nameWithType: Color.Yellow
 - uid: SadRogue.Primitives.Color.YellowGreen
   name: YellowGreen
   href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_YellowGreen
-  commentId: P:SadRogue.Primitives.Color.YellowGreen
+  commentId: F:SadRogue.Primitives.Color.YellowGreen
   fullName: SadRogue.Primitives.Color.YellowGreen
   nameWithType: Color.YellowGreen
-- uid: SadRogue.Primitives.Color.YellowGreen*
-  name: YellowGreen
-  href: api/SadRogue.Primitives.Color.html#SadRogue_Primitives_Color_YellowGreen_
-  commentId: Overload:SadRogue.Primitives.Color.YellowGreen
+- uid: SadRogue.Primitives.ColorExtensions
+  name: ColorExtensions
+  href: api/SadRogue.Primitives.ColorExtensions.html
+  commentId: T:SadRogue.Primitives.ColorExtensions
+  fullName: SadRogue.Primitives.ColorExtensions
+  nameWithType: ColorExtensions
+- uid: SadRogue.Primitives.ColorExtensions.Matches(SadRogue.Primitives.Color,SadRogue.Primitives.Color)
+  name: Matches(Color, Color)
+  href: api/SadRogue.Primitives.ColorExtensions.html#SadRogue_Primitives_ColorExtensions_Matches_SadRogue_Primitives_Color_SadRogue_Primitives_Color_
+  commentId: M:SadRogue.Primitives.ColorExtensions.Matches(SadRogue.Primitives.Color,SadRogue.Primitives.Color)
+  fullName: SadRogue.Primitives.ColorExtensions.Matches(SadRogue.Primitives.Color, SadRogue.Primitives.Color)
+  nameWithType: ColorExtensions.Matches(Color, Color)
+- uid: SadRogue.Primitives.ColorExtensions.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.ColorExtensions.html#SadRogue_Primitives_ColorExtensions_Matches_
+  commentId: Overload:SadRogue.Primitives.ColorExtensions.Matches
   isSpec: "True"
-  fullName: SadRogue.Primitives.Color.YellowGreen
-  nameWithType: Color.YellowGreen
+  fullName: SadRogue.Primitives.ColorExtensions.Matches
+  nameWithType: ColorExtensions.Matches
 - uid: SadRogue.Primitives.Direction
   name: Direction
   href: api/SadRogue.Primitives.Direction.html
@@ -3051,6 +2113,18 @@ references:
   commentId: M:SadRogue.Primitives.Direction.GetCardinalDirection(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Direction.GetCardinalDirection(SadRogue.Primitives.Point, SadRogue.Primitives.Point)
   nameWithType: Direction.GetCardinalDirection(Point, Point)
+- uid: SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32,System.Int32)
+  name: GetCardinalDirection(Int32, Int32)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetCardinalDirection_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32, System.Int32)
+  nameWithType: Direction.GetCardinalDirection(Int32, Int32)
+- uid: SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32,System.Int32,System.Int32,System.Int32)
+  name: GetCardinalDirection(Int32, Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetCardinalDirection_System_Int32_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32,System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Direction.GetCardinalDirection(System.Int32, System.Int32, System.Int32, System.Int32)
+  nameWithType: Direction.GetCardinalDirection(Int32, Int32, Int32, Int32)
 - uid: SadRogue.Primitives.Direction.GetCardinalDirection*
   name: GetCardinalDirection
   href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetCardinalDirection_
@@ -3070,6 +2144,18 @@ references:
   commentId: M:SadRogue.Primitives.Direction.GetDirection(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Direction.GetDirection(SadRogue.Primitives.Point, SadRogue.Primitives.Point)
   nameWithType: Direction.GetDirection(Point, Point)
+- uid: SadRogue.Primitives.Direction.GetDirection(System.Int32,System.Int32)
+  name: GetDirection(Int32, Int32)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetDirection_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Direction.GetDirection(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Direction.GetDirection(System.Int32, System.Int32)
+  nameWithType: Direction.GetDirection(Int32, Int32)
+- uid: SadRogue.Primitives.Direction.GetDirection(System.Int32,System.Int32,System.Int32,System.Int32)
+  name: GetDirection(Int32, Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetDirection_System_Int32_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Direction.GetDirection(System.Int32,System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Direction.GetDirection(System.Int32, System.Int32, System.Int32, System.Int32)
+  nameWithType: Direction.GetDirection(Int32, Int32, Int32, Int32)
 - uid: SadRogue.Primitives.Direction.GetDirection*
   name: GetDirection
   href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_GetDirection_
@@ -3109,6 +2195,19 @@ references:
   commentId: F:SadRogue.Primitives.Direction.Left
   fullName: SadRogue.Primitives.Direction.Left
   nameWithType: Direction.Left
+- uid: SadRogue.Primitives.Direction.Matches(SadRogue.Primitives.Direction)
+  name: Matches(Direction)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Matches_SadRogue_Primitives_Direction_
+  commentId: M:SadRogue.Primitives.Direction.Matches(SadRogue.Primitives.Direction)
+  fullName: SadRogue.Primitives.Direction.Matches(SadRogue.Primitives.Direction)
+  nameWithType: Direction.Matches(Direction)
+- uid: SadRogue.Primitives.Direction.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_Matches_
+  commentId: Overload:SadRogue.Primitives.Direction.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Direction.Matches
+  nameWithType: Direction.Matches
 - uid: SadRogue.Primitives.Direction.None
   name: None
   href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_None
@@ -3163,6 +2262,34 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Direction.Equality
   nameWithType: Direction.Equality
+- uid: SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction)~SadRogue.Primitives.Direction.Types
+  name: Implicit(Direction to Direction.Types)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_op_Implicit_SadRogue_Primitives_Direction__SadRogue_Primitives_Direction_Types
+  commentId: M:SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction)~SadRogue.Primitives.Direction.Types
+  name.vb: Widening(Direction to Direction.Types)
+  fullName: SadRogue.Primitives.Direction.Implicit(SadRogue.Primitives.Direction to SadRogue.Primitives.Direction.Types)
+  fullName.vb: SadRogue.Primitives.Direction.Widening(SadRogue.Primitives.Direction to SadRogue.Primitives.Direction.Types)
+  nameWithType: Direction.Implicit(Direction to Direction.Types)
+  nameWithType.vb: Direction.Widening(Direction to Direction.Types)
+- uid: SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction.Types)~SadRogue.Primitives.Direction
+  name: Implicit(Direction.Types to Direction)
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_op_Implicit_SadRogue_Primitives_Direction_Types__SadRogue_Primitives_Direction
+  commentId: M:SadRogue.Primitives.Direction.op_Implicit(SadRogue.Primitives.Direction.Types)~SadRogue.Primitives.Direction
+  name.vb: Widening(Direction.Types to Direction)
+  fullName: SadRogue.Primitives.Direction.Implicit(SadRogue.Primitives.Direction.Types to SadRogue.Primitives.Direction)
+  fullName.vb: SadRogue.Primitives.Direction.Widening(SadRogue.Primitives.Direction.Types to SadRogue.Primitives.Direction)
+  nameWithType: Direction.Implicit(Direction.Types to Direction)
+  nameWithType.vb: Direction.Widening(Direction.Types to Direction)
+- uid: SadRogue.Primitives.Direction.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.Direction.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.Direction.Implicit
+  fullName.vb: SadRogue.Primitives.Direction.Widening
+  nameWithType: Direction.Implicit
+  nameWithType.vb: Direction.Widening
 - uid: SadRogue.Primitives.Direction.op_Increment(SadRogue.Primitives.Direction)
   name: Increment(Direction)
   href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_op_Increment_SadRogue_Primitives_Direction_
@@ -3221,19 +2348,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Direction.SetYIncreasesUpwardsUnsafe
   nameWithType: Direction.SetYIncreasesUpwardsUnsafe
-- uid: SadRogue.Primitives.Direction.ToDirection(SadRogue.Primitives.Direction.Types)
-  name: ToDirection(Direction.Types)
-  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_ToDirection_SadRogue_Primitives_Direction_Types_
-  commentId: M:SadRogue.Primitives.Direction.ToDirection(SadRogue.Primitives.Direction.Types)
-  fullName: SadRogue.Primitives.Direction.ToDirection(SadRogue.Primitives.Direction.Types)
-  nameWithType: Direction.ToDirection(Direction.Types)
-- uid: SadRogue.Primitives.Direction.ToDirection*
-  name: ToDirection
-  href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_ToDirection_
-  commentId: Overload:SadRogue.Primitives.Direction.ToDirection
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Direction.ToDirection
-  nameWithType: Direction.ToDirection
 - uid: SadRogue.Primitives.Direction.ToString
   name: ToString()
   href: api/SadRogue.Primitives.Direction.html#SadRogue_Primitives_Direction_ToString
@@ -3431,6 +2545,19 @@ references:
   commentId: F:SadRogue.Primitives.Distance.Manhattan
   fullName: SadRogue.Primitives.Distance.Manhattan
   nameWithType: Distance.Manhattan
+- uid: SadRogue.Primitives.Distance.Matches(SadRogue.Primitives.Distance)
+  name: Matches(Distance)
+  href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_Matches_SadRogue_Primitives_Distance_
+  commentId: M:SadRogue.Primitives.Distance.Matches(SadRogue.Primitives.Distance)
+  fullName: SadRogue.Primitives.Distance.Matches(SadRogue.Primitives.Distance)
+  nameWithType: Distance.Matches(Distance)
+- uid: SadRogue.Primitives.Distance.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_Matches_
+  commentId: Overload:SadRogue.Primitives.Distance.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Distance.Matches
+  nameWithType: Distance.Matches
 - uid: SadRogue.Primitives.Distance.op_Equality(SadRogue.Primitives.Distance,SadRogue.Primitives.Distance)
   name: Equality(Distance, Distance)
   href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_op_Equality_SadRogue_Primitives_Distance_SadRogue_Primitives_Distance_
@@ -3453,6 +2580,15 @@ references:
   fullName.vb: SadRogue.Primitives.Distance.Widening(SadRogue.Primitives.Distance to SadRogue.Primitives.AdjacencyRule)
   nameWithType: Distance.Implicit(Distance to AdjacencyRule)
   nameWithType.vb: Distance.Widening(Distance to AdjacencyRule)
+- uid: SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Distance.Types
+  name: Implicit(Distance to Distance.Types)
+  href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_Distance_Types
+  commentId: M:SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Distance.Types
+  name.vb: Widening(Distance to Distance.Types)
+  fullName: SadRogue.Primitives.Distance.Implicit(SadRogue.Primitives.Distance to SadRogue.Primitives.Distance.Types)
+  fullName.vb: SadRogue.Primitives.Distance.Widening(SadRogue.Primitives.Distance to SadRogue.Primitives.Distance.Types)
+  nameWithType: Distance.Implicit(Distance to Distance.Types)
+  nameWithType.vb: Distance.Widening(Distance to Distance.Types)
 - uid: SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance)~SadRogue.Primitives.Radius
   name: Implicit(Distance to Radius)
   href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance__SadRogue_Primitives_Radius
@@ -3462,6 +2598,15 @@ references:
   fullName.vb: SadRogue.Primitives.Distance.Widening(SadRogue.Primitives.Distance to SadRogue.Primitives.Radius)
   nameWithType: Distance.Implicit(Distance to Radius)
   nameWithType.vb: Distance.Widening(Distance to Radius)
+- uid: SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance.Types)~SadRogue.Primitives.Distance
+  name: Implicit(Distance.Types to Distance)
+  href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_op_Implicit_SadRogue_Primitives_Distance_Types__SadRogue_Primitives_Distance
+  commentId: M:SadRogue.Primitives.Distance.op_Implicit(SadRogue.Primitives.Distance.Types)~SadRogue.Primitives.Distance
+  name.vb: Widening(Distance.Types to Distance)
+  fullName: SadRogue.Primitives.Distance.Implicit(SadRogue.Primitives.Distance.Types to SadRogue.Primitives.Distance)
+  fullName.vb: SadRogue.Primitives.Distance.Widening(SadRogue.Primitives.Distance.Types to SadRogue.Primitives.Distance)
+  nameWithType: Distance.Implicit(Distance.Types to Distance)
+  nameWithType.vb: Distance.Widening(Distance.Types to Distance)
 - uid: SadRogue.Primitives.Distance.op_Implicit*
   name: Implicit
   href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_op_Implicit_
@@ -3485,19 +2630,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Distance.Inequality
   nameWithType: Distance.Inequality
-- uid: SadRogue.Primitives.Distance.ToDistance(SadRogue.Primitives.Distance.Types)
-  name: ToDistance(Distance.Types)
-  href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_ToDistance_SadRogue_Primitives_Distance_Types_
-  commentId: M:SadRogue.Primitives.Distance.ToDistance(SadRogue.Primitives.Distance.Types)
-  fullName: SadRogue.Primitives.Distance.ToDistance(SadRogue.Primitives.Distance.Types)
-  nameWithType: Distance.ToDistance(Distance.Types)
-- uid: SadRogue.Primitives.Distance.ToDistance*
-  name: ToDistance
-  href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_ToDistance_
-  commentId: Overload:SadRogue.Primitives.Distance.ToDistance
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Distance.ToDistance
-  nameWithType: Distance.ToDistance
 - uid: SadRogue.Primitives.Distance.ToString
   name: ToString()
   href: api/SadRogue.Primitives.Distance.html#SadRogue_Primitives_Distance_ToString
@@ -3571,6 +2703,15 @@ references:
   fullName.vb: SadRogue.Primitives.Gradient.Gradient(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.Color), System.Collections.Generic.IEnumerable(Of System.Single))
   nameWithType: Gradient.Gradient(IEnumerable<Color>, IEnumerable<Single>)
   nameWithType.vb: Gradient.Gradient(IEnumerable(Of Color), IEnumerable(Of Single))
+- uid: SadRogue.Primitives.Gradient.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GradientStop})
+  name: Gradient(IEnumerable<GradientStop>)
+  href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GradientStop__
+  commentId: M:SadRogue.Primitives.Gradient.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GradientStop})
+  name.vb: Gradient(IEnumerable(Of GradientStop))
+  fullName: SadRogue.Primitives.Gradient.Gradient(System.Collections.Generic.IEnumerable<SadRogue.Primitives.GradientStop>)
+  fullName.vb: SadRogue.Primitives.Gradient.Gradient(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.GradientStop))
+  nameWithType: Gradient.Gradient(IEnumerable<GradientStop>)
+  nameWithType.vb: Gradient.Gradient(IEnumerable(Of GradientStop))
 - uid: SadRogue.Primitives.Gradient.#ctor*
   name: Gradient
   href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient__ctor_
@@ -3604,6 +2745,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Gradient.Lerp
   nameWithType: Gradient.Lerp
+- uid: SadRogue.Primitives.Gradient.Matches(SadRogue.Primitives.Gradient)
+  name: Matches(Gradient)
+  href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_Matches_SadRogue_Primitives_Gradient_
+  commentId: M:SadRogue.Primitives.Gradient.Matches(SadRogue.Primitives.Gradient)
+  fullName: SadRogue.Primitives.Gradient.Matches(SadRogue.Primitives.Gradient)
+  nameWithType: Gradient.Matches(Gradient)
+- uid: SadRogue.Primitives.Gradient.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_Matches_
+  commentId: Overload:SadRogue.Primitives.Gradient.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Gradient.Matches
+  nameWithType: Gradient.Matches
 - uid: SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.Gradient
   name: Implicit(Color to Gradient)
   href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_op_Implicit_SadRogue_Primitives_Color__SadRogue_Primitives_Gradient
@@ -3613,15 +2767,6 @@ references:
   fullName.vb: SadRogue.Primitives.Gradient.Widening(SadRogue.Primitives.Color to SadRogue.Primitives.Gradient)
   nameWithType: Gradient.Implicit(Color to Gradient)
   nameWithType.vb: Gradient.Widening(Color to Gradient)
-- uid: SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.Color
-  name: Implicit(Gradient to Color)
-  href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_op_Implicit_SadRogue_Primitives_Gradient__SadRogue_Primitives_Color
-  commentId: M:SadRogue.Primitives.Gradient.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.Color
-  name.vb: Widening(Gradient to Color)
-  fullName: SadRogue.Primitives.Gradient.Implicit(SadRogue.Primitives.Gradient to SadRogue.Primitives.Color)
-  fullName.vb: SadRogue.Primitives.Gradient.Widening(SadRogue.Primitives.Gradient to SadRogue.Primitives.Color)
-  nameWithType: Gradient.Implicit(Gradient to Color)
-  nameWithType.vb: Gradient.Widening(Gradient to Color)
 - uid: SadRogue.Primitives.Gradient.op_Implicit*
   name: Implicit
   href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_op_Implicit_
@@ -3635,14 +2780,7 @@ references:
 - uid: SadRogue.Primitives.Gradient.Stops
   name: Stops
   href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_Stops
-  commentId: P:SadRogue.Primitives.Gradient.Stops
-  fullName: SadRogue.Primitives.Gradient.Stops
-  nameWithType: Gradient.Stops
-- uid: SadRogue.Primitives.Gradient.Stops*
-  name: Stops
-  href: api/SadRogue.Primitives.Gradient.html#SadRogue_Primitives_Gradient_Stops_
-  commentId: Overload:SadRogue.Primitives.Gradient.Stops
-  isSpec: "True"
+  commentId: F:SadRogue.Primitives.Gradient.Stops
   fullName: SadRogue.Primitives.Gradient.Stops
   nameWithType: Gradient.Stops
 - uid: SadRogue.Primitives.Gradient.System#Collections#IEnumerable#GetEnumerator
@@ -3732,6 +2870,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.GradientStop.GetHashCode
   nameWithType: GradientStop.GetHashCode
+- uid: SadRogue.Primitives.GradientStop.Matches(SadRogue.Primitives.GradientStop)
+  name: Matches(GradientStop)
+  href: api/SadRogue.Primitives.GradientStop.html#SadRogue_Primitives_GradientStop_Matches_SadRogue_Primitives_GradientStop_
+  commentId: M:SadRogue.Primitives.GradientStop.Matches(SadRogue.Primitives.GradientStop)
+  fullName: SadRogue.Primitives.GradientStop.Matches(SadRogue.Primitives.GradientStop)
+  nameWithType: GradientStop.Matches(GradientStop)
+- uid: SadRogue.Primitives.GradientStop.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.GradientStop.html#SadRogue_Primitives_GradientStop_Matches_
+  commentId: Overload:SadRogue.Primitives.GradientStop.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GradientStop.Matches
+  nameWithType: GradientStop.Matches
 - uid: SadRogue.Primitives.GradientStop.op_Equality(SadRogue.Primitives.GradientStop,SadRogue.Primitives.GradientStop)
   name: Equality(GradientStop, GradientStop)
   href: api/SadRogue.Primitives.GradientStop.html#SadRogue_Primitives_GradientStop_op_Equality_SadRogue_Primitives_GradientStop_SadRogue_Primitives_GradientStop_
@@ -3764,6 +2915,2722 @@ references:
   commentId: F:SadRogue.Primitives.GradientStop.Stop
   fullName: SadRogue.Primitives.GradientStop.Stop
   nameWithType: GradientStop.Stop
+- uid: SadRogue.Primitives.GridViews
+  name: SadRogue.Primitives.GridViews
+  href: api/SadRogue.Primitives.GridViews.html
+  commentId: N:SadRogue.Primitives.GridViews
+  fullName: SadRogue.Primitives.GridViews
+  nameWithType: SadRogue.Primitives.GridViews
+- uid: SadRogue.Primitives.GridViews.ArrayView`1
+  name: ArrayView<T>
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html
+  commentId: T:SadRogue.Primitives.GridViews.ArrayView`1
+  name.vb: ArrayView(Of T)
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T)
+  nameWithType: ArrayView<T>
+  nameWithType.vb: ArrayView(Of T)
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.#ctor(`0[],System.Int32)
+  name: ArrayView(T[], Int32)
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1__ctor__0___System_Int32_
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.#ctor(`0[],System.Int32)
+  name.vb: ArrayView(T(), Int32)
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ArrayView(T[], System.Int32)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ArrayView(T(), System.Int32)
+  nameWithType: ArrayView<T>.ArrayView(T[], Int32)
+  nameWithType.vb: ArrayView(Of T).ArrayView(T(), Int32)
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.#ctor(System.Int32,System.Int32)
+  name: ArrayView(Int32, Int32)
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1__ctor_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.#ctor(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ArrayView(System.Int32, System.Int32)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ArrayView(System.Int32, System.Int32)
+  nameWithType: ArrayView<T>.ArrayView(Int32, Int32)
+  nameWithType.vb: ArrayView(Of T).ArrayView(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.#ctor*
+  name: ArrayView
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ArrayView
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ArrayView
+  nameWithType: ArrayView<T>.ArrayView
+  nameWithType.vb: ArrayView(Of T).ArrayView
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Clear
+  name: Clear()
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Clear
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.Clear
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Clear()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Clear()
+  nameWithType: ArrayView<T>.Clear()
+  nameWithType.vb: ArrayView(Of T).Clear()
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Clear*
+  name: Clear
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Clear_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.Clear
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Clear
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Clear
+  nameWithType: ArrayView<T>.Clear
+  nameWithType.vb: ArrayView(Of T).Clear
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Clone
+  name: Clone()
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Clone
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.Clone
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Clone()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Clone()
+  nameWithType: ArrayView<T>.Clone()
+  nameWithType.vb: ArrayView(Of T).Clone()
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Clone*
+  name: Clone
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Clone_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.Clone
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Clone
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Clone
+  nameWithType: ArrayView<T>.Clone
+  nameWithType.vb: ArrayView(Of T).Clone
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.ArrayView`1.Height
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Height
+  nameWithType: ArrayView<T>.Height
+  nameWithType.vb: ArrayView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Height
+  nameWithType: ArrayView<T>.Height
+  nameWithType.vb: ArrayView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.ArrayView`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: ArrayView<T>.Item[Point]
+  nameWithType.vb: ArrayView(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Item
+  nameWithType: ArrayView<T>.Item
+  nameWithType.vb: ArrayView(Of T).Item
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Matches(SadRogue.Primitives.GridViews.ArrayView{`0})
+  name: Matches(ArrayView<T>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Matches_SadRogue_Primitives_GridViews_ArrayView__0__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.Matches(SadRogue.Primitives.GridViews.ArrayView{`0})
+  name.vb: Matches(ArrayView(Of T))
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Matches(SadRogue.Primitives.GridViews.ArrayView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Matches(SadRogue.Primitives.GridViews.ArrayView(Of T))
+  nameWithType: ArrayView<T>.Matches(ArrayView<T>)
+  nameWithType.vb: ArrayView(Of T).Matches(ArrayView(Of T))
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Matches_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Matches
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Matches
+  nameWithType: ArrayView<T>.Matches
+  nameWithType.vb: ArrayView(Of T).Matches
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView{`0})~`0[]
+  name: Implicit(ArrayView<T> to T[])
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView__0____0__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView{`0})~`0[]
+  name.vb: Widening(ArrayView(Of T) to T())
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Implicit(SadRogue.Primitives.GridViews.ArrayView<T> to T[])
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Widening(SadRogue.Primitives.GridViews.ArrayView(Of T) to T())
+  nameWithType: ArrayView<T>.Implicit(ArrayView<T> to T[])
+  nameWithType.vb: ArrayView(Of T).Widening(ArrayView(Of T) to T())
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Implicit
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Widening
+  nameWithType: ArrayView<T>.Implicit
+  nameWithType.vb: ArrayView(Of T).Widening
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.ToArray
+  name: ToArray()
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_ToArray
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.ToArray
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ToArray()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ToArray()
+  nameWithType: ArrayView<T>.ToArray()
+  nameWithType.vb: ArrayView(Of T).ToArray()
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.ToArray*
+  name: ToArray
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_ToArray_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.ToArray
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ToArray
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ToArray
+  nameWithType: ArrayView<T>.ToArray
+  nameWithType.vb: ArrayView(Of T).ToArray
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.ToString
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ToString()
+  nameWithType: ArrayView<T>.ToString()
+  nameWithType.vb: ArrayView(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.ToString(System.Func{`0,System.String})
+  name: ToString(Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.ToString(System.Func{`0,System.String})
+  name.vb: ToString(Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ToString(System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ToString(System.Func(Of T, System.String))
+  nameWithType: ArrayView<T>.ToString(Func<T, String>)
+  nameWithType.vb: ArrayView(Of T).ToString(Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.ToString(System.Int32,System.Func{`0,System.String})
+  name: ToString(Int32, Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_ToString_System_Int32_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView`1.ToString(System.Int32,System.Func{`0,System.String})
+  name.vb: ToString(Int32, Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ToString(System.Int32, System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ToString(System.Int32, System.Func(Of T, System.String))
+  nameWithType: ArrayView<T>.ToString(Int32, Func<T, String>)
+  nameWithType.vb: ArrayView(Of T).ToString(Int32, Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).ToString
+  nameWithType: ArrayView<T>.ToString
+  nameWithType.vb: ArrayView(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.ArrayView`1.Width
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Width
+  nameWithType: ArrayView<T>.Width
+  nameWithType.vb: ArrayView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.ArrayView`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.ArrayView-1.html#SadRogue_Primitives_GridViews_ArrayView_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView(Of T).Width
+  nameWithType: ArrayView<T>.Width
+  nameWithType.vb: ArrayView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1
+  name: ArrayView2D<T>
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html
+  commentId: T:SadRogue.Primitives.GridViews.ArrayView2D`1
+  name.vb: ArrayView2D(Of T)
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T)
+  nameWithType: ArrayView2D<T>
+  nameWithType.vb: ArrayView2D(Of T)
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor(`0[0:,0:])
+  name: ArrayView2D(T[,])
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1__ctor__0_0__0___
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor(`0[0:,0:])
+  name.vb: ArrayView2D(T(,))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ArrayView2D(T[,])
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ArrayView2D(T(,))
+  nameWithType: ArrayView2D<T>.ArrayView2D(T[,])
+  nameWithType.vb: ArrayView2D(Of T).ArrayView2D(T(,))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor(System.Int32,System.Int32)
+  name: ArrayView2D(Int32, Int32)
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1__ctor_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ArrayView2D(System.Int32, System.Int32)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ArrayView2D(System.Int32, System.Int32)
+  nameWithType: ArrayView2D<T>.ArrayView2D(Int32, Int32)
+  nameWithType.vb: ArrayView2D(Of T).ArrayView2D(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor*
+  name: ArrayView2D
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ArrayView2D
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ArrayView2D
+  nameWithType: ArrayView2D<T>.ArrayView2D
+  nameWithType.vb: ArrayView2D(Of T).ArrayView2D
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Clear
+  name: Clear()
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Clear
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.Clear
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Clear()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Clear()
+  nameWithType: ArrayView2D<T>.Clear()
+  nameWithType.vb: ArrayView2D(Of T).Clear()
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Clear*
+  name: Clear
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Clear_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.Clear
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Clear
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Clear
+  nameWithType: ArrayView2D<T>.Clear
+  nameWithType.vb: ArrayView2D(Of T).Clear
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Clone
+  name: Clone()
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Clone
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.Clone
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Clone()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Clone()
+  nameWithType: ArrayView2D<T>.Clone()
+  nameWithType.vb: ArrayView2D(Of T).Clone()
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Clone*
+  name: Clone
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Clone_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.Clone
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Clone
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Clone
+  nameWithType: ArrayView2D<T>.Clone
+  nameWithType.vb: ArrayView2D(Of T).Clone
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.FromMultidimensionalArray(`0[0:,0:])
+  name: FromMultidimensionalArray(T[,])
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_FromMultidimensionalArray__0_0__0___
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.FromMultidimensionalArray(`0[0:,0:])
+  name.vb: FromMultidimensionalArray(T(,))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.FromMultidimensionalArray(T[,])
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).FromMultidimensionalArray(T(,))
+  nameWithType: ArrayView2D<T>.FromMultidimensionalArray(T[,])
+  nameWithType.vb: ArrayView2D(Of T).FromMultidimensionalArray(T(,))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.FromMultidimensionalArray*
+  name: FromMultidimensionalArray
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_FromMultidimensionalArray_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.FromMultidimensionalArray
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.FromMultidimensionalArray
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).FromMultidimensionalArray
+  nameWithType: ArrayView2D<T>.FromMultidimensionalArray
+  nameWithType.vb: ArrayView2D(Of T).FromMultidimensionalArray
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.ArrayView2D`1.Height
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Height
+  nameWithType: ArrayView2D<T>.Height
+  nameWithType.vb: ArrayView2D(Of T).Height
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Height
+  nameWithType: ArrayView2D<T>.Height
+  nameWithType.vb: ArrayView2D(Of T).Height
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.ArrayView2D`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: ArrayView2D<T>.Item[Point]
+  nameWithType.vb: ArrayView2D(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Item
+  nameWithType: ArrayView2D<T>.Item
+  nameWithType.vb: ArrayView2D(Of T).Item
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Matches(SadRogue.Primitives.GridViews.ArrayView2D{`0})
+  name: Matches(ArrayView2D<T>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Matches_SadRogue_Primitives_GridViews_ArrayView2D__0__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.Matches(SadRogue.Primitives.GridViews.ArrayView2D{`0})
+  name.vb: Matches(ArrayView2D(Of T))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Matches(SadRogue.Primitives.GridViews.ArrayView2D<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Matches(SadRogue.Primitives.GridViews.ArrayView2D(Of T))
+  nameWithType: ArrayView2D<T>.Matches(ArrayView2D<T>)
+  nameWithType.vb: ArrayView2D(Of T).Matches(ArrayView2D(Of T))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Matches_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Matches
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Matches
+  nameWithType: ArrayView2D<T>.Matches
+  nameWithType.vb: ArrayView2D(Of T).Matches
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit(`0[0:,0:])~SadRogue.Primitives.GridViews.ArrayView2D{`0}
+  name: Implicit(T[,] to ArrayView2D<T>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit__0_0__0____SadRogue_Primitives_GridViews_ArrayView2D__0_
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit(`0[0:,0:])~SadRogue.Primitives.GridViews.ArrayView2D{`0}
+  name.vb: Widening(T(,) to ArrayView2D(Of T))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Implicit(T[,] to SadRogue.Primitives.GridViews.ArrayView2D<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Widening(T(,) to SadRogue.Primitives.GridViews.ArrayView2D(Of T))
+  nameWithType: ArrayView2D<T>.Implicit(T[,] to ArrayView2D<T>)
+  nameWithType.vb: ArrayView2D(Of T).Widening(T(,) to ArrayView2D(Of T))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView2D{`0})~`0[0:,0:]
+  name: Implicit(ArrayView2D<T> to T[,])
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView2D__0____0_0__0__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView2D{`0})~`0[0:,0:]
+  name.vb: Widening(ArrayView2D(Of T) to T(,))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Implicit(SadRogue.Primitives.GridViews.ArrayView2D<T> to T[,])
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Widening(SadRogue.Primitives.GridViews.ArrayView2D(Of T) to T(,))
+  nameWithType: ArrayView2D<T>.Implicit(ArrayView2D<T> to T[,])
+  nameWithType.vb: ArrayView2D(Of T).Widening(ArrayView2D(Of T) to T(,))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Implicit
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Widening
+  nameWithType: ArrayView2D<T>.Implicit
+  nameWithType.vb: ArrayView2D(Of T).Widening
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.ToMultidimensionalArray
+  name: ToMultidimensionalArray()
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_ToMultidimensionalArray
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.ToMultidimensionalArray
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ToMultidimensionalArray()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ToMultidimensionalArray()
+  nameWithType: ArrayView2D<T>.ToMultidimensionalArray()
+  nameWithType.vb: ArrayView2D(Of T).ToMultidimensionalArray()
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.ToMultidimensionalArray*
+  name: ToMultidimensionalArray
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_ToMultidimensionalArray_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.ToMultidimensionalArray
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ToMultidimensionalArray
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ToMultidimensionalArray
+  nameWithType: ArrayView2D<T>.ToMultidimensionalArray
+  nameWithType.vb: ArrayView2D(Of T).ToMultidimensionalArray
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.ToString
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ToString()
+  nameWithType: ArrayView2D<T>.ToString()
+  nameWithType.vb: ArrayView2D(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.ToString(System.Func{`0,System.String})
+  name: ToString(Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.ToString(System.Func{`0,System.String})
+  name.vb: ToString(Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ToString(System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ToString(System.Func(Of T, System.String))
+  nameWithType: ArrayView2D<T>.ToString(Func<T, String>)
+  nameWithType.vb: ArrayView2D(Of T).ToString(Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.ToString(System.Int32,System.Func{`0,System.String})
+  name: ToString(Int32, Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_System_Int32_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.ArrayView2D`1.ToString(System.Int32,System.Func{`0,System.String})
+  name.vb: ToString(Int32, Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ToString(System.Int32, System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ToString(System.Int32, System.Func(Of T, System.String))
+  nameWithType: ArrayView2D<T>.ToString(Int32, Func<T, String>)
+  nameWithType.vb: ArrayView2D(Of T).ToString(Int32, Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).ToString
+  nameWithType: ArrayView2D<T>.ToString
+  nameWithType.vb: ArrayView2D(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.ArrayView2D`1.Width
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Width
+  nameWithType: ArrayView2D<T>.Width
+  nameWithType.vb: ArrayView2D(Of T).Width
+- uid: SadRogue.Primitives.GridViews.ArrayView2D`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.ArrayView2D-1.html#SadRogue_Primitives_GridViews_ArrayView2D_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.ArrayView2D`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ArrayView2D<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.ArrayView2D(Of T).Width
+  nameWithType: ArrayView2D<T>.Width
+  nameWithType.vb: ArrayView2D(Of T).Width
+- uid: SadRogue.Primitives.GridViews.Diff`1
+  name: Diff<T>
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html
+  commentId: T:SadRogue.Primitives.GridViews.Diff`1
+  name.vb: Diff(Of T)
+  fullName: SadRogue.Primitives.GridViews.Diff<T>
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T)
+  nameWithType: Diff<T>
+  nameWithType.vb: Diff(Of T)
+- uid: SadRogue.Primitives.GridViews.Diff`1.#ctor
+  name: Diff()
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1__ctor
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.#ctor
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Diff()
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Diff()
+  nameWithType: Diff<T>.Diff()
+  nameWithType.vb: Diff(Of T).Diff()
+- uid: SadRogue.Primitives.GridViews.Diff`1.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.ValueChange{`0}})
+  name: Diff(IEnumerable<ValueChange<T>>)
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1__ctor_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_ValueChange__0___
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.#ctor(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.ValueChange{`0}})
+  name.vb: Diff(IEnumerable(Of ValueChange(Of T)))
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Diff(System.Collections.Generic.IEnumerable<SadRogue.Primitives.GridViews.ValueChange<T>>)
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Diff(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.GridViews.ValueChange(Of T)))
+  nameWithType: Diff<T>.Diff(IEnumerable<ValueChange<T>>)
+  nameWithType.vb: Diff(Of T).Diff(IEnumerable(Of ValueChange(Of T)))
+- uid: SadRogue.Primitives.GridViews.Diff`1.#ctor*
+  name: Diff
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Diff
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Diff
+  nameWithType: Diff<T>.Diff
+  nameWithType.vb: Diff(Of T).Diff
+- uid: SadRogue.Primitives.GridViews.Diff`1.Add(SadRogue.Primitives.GridViews.ValueChange{`0})
+  name: Add(ValueChange<T>)
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_Add_SadRogue_Primitives_GridViews_ValueChange__0__
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.Add(SadRogue.Primitives.GridViews.ValueChange{`0})
+  name.vb: Add(ValueChange(Of T))
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Add(SadRogue.Primitives.GridViews.ValueChange<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Add(SadRogue.Primitives.GridViews.ValueChange(Of T))
+  nameWithType: Diff<T>.Add(ValueChange<T>)
+  nameWithType.vb: Diff(Of T).Add(ValueChange(Of T))
+- uid: SadRogue.Primitives.GridViews.Diff`1.Add*
+  name: Add
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_Add_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.Add
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Add
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Add
+  nameWithType: Diff<T>.Add
+  nameWithType.vb: Diff(Of T).Add
+- uid: SadRogue.Primitives.GridViews.Diff`1.Changes
+  name: Changes
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_Changes
+  commentId: P:SadRogue.Primitives.GridViews.Diff`1.Changes
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Changes
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Changes
+  nameWithType: Diff<T>.Changes
+  nameWithType.vb: Diff(Of T).Changes
+- uid: SadRogue.Primitives.GridViews.Diff`1.Changes*
+  name: Changes
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_Changes_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.Changes
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Changes
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Changes
+  nameWithType: Diff<T>.Changes
+  nameWithType.vb: Diff(Of T).Changes
+- uid: SadRogue.Primitives.GridViews.Diff`1.Compress
+  name: Compress()
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_Compress
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.Compress
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Compress()
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Compress()
+  nameWithType: Diff<T>.Compress()
+  nameWithType.vb: Diff(Of T).Compress()
+- uid: SadRogue.Primitives.GridViews.Diff`1.Compress*
+  name: Compress
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_Compress_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.Compress
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.Compress
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).Compress
+  nameWithType: Diff<T>.Compress
+  nameWithType.vb: Diff(Of T).Compress
+- uid: SadRogue.Primitives.GridViews.Diff`1.FinalizeChanges
+  name: FinalizeChanges()
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_FinalizeChanges
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.FinalizeChanges
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.FinalizeChanges()
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).FinalizeChanges()
+  nameWithType: Diff<T>.FinalizeChanges()
+  nameWithType.vb: Diff(Of T).FinalizeChanges()
+- uid: SadRogue.Primitives.GridViews.Diff`1.FinalizeChanges*
+  name: FinalizeChanges
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_FinalizeChanges_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.FinalizeChanges
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.FinalizeChanges
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).FinalizeChanges
+  nameWithType: Diff<T>.FinalizeChanges
+  nameWithType.vb: Diff(Of T).FinalizeChanges
+- uid: SadRogue.Primitives.GridViews.Diff`1.GetEnumerator
+  name: GetEnumerator()
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_GetEnumerator
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.GetEnumerator
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.GetEnumerator()
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).GetEnumerator()
+  nameWithType: Diff<T>.GetEnumerator()
+  nameWithType.vb: Diff(Of T).GetEnumerator()
+- uid: SadRogue.Primitives.GridViews.Diff`1.GetEnumerator*
+  name: GetEnumerator
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_GetEnumerator_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.GetEnumerator
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.GetEnumerator
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).GetEnumerator
+  nameWithType: Diff<T>.GetEnumerator
+  nameWithType.vb: Diff(Of T).GetEnumerator
+- uid: SadRogue.Primitives.GridViews.Diff`1.IsCompressed
+  name: IsCompressed
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_IsCompressed
+  commentId: P:SadRogue.Primitives.GridViews.Diff`1.IsCompressed
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.IsCompressed
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).IsCompressed
+  nameWithType: Diff<T>.IsCompressed
+  nameWithType.vb: Diff(Of T).IsCompressed
+- uid: SadRogue.Primitives.GridViews.Diff`1.IsCompressed*
+  name: IsCompressed
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_IsCompressed_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.IsCompressed
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.IsCompressed
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).IsCompressed
+  nameWithType: Diff<T>.IsCompressed
+  nameWithType.vb: Diff(Of T).IsCompressed
+- uid: SadRogue.Primitives.GridViews.Diff`1.IsFinalized
+  name: IsFinalized
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_IsFinalized
+  commentId: P:SadRogue.Primitives.GridViews.Diff`1.IsFinalized
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.IsFinalized
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).IsFinalized
+  nameWithType: Diff<T>.IsFinalized
+  nameWithType.vb: Diff(Of T).IsFinalized
+- uid: SadRogue.Primitives.GridViews.Diff`1.IsFinalized*
+  name: IsFinalized
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_IsFinalized_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.IsFinalized
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.IsFinalized
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).IsFinalized
+  nameWithType: Diff<T>.IsFinalized
+  nameWithType.vb: Diff(Of T).IsFinalized
+- uid: SadRogue.Primitives.GridViews.Diff`1.System#Collections#IEnumerable#GetEnumerator
+  name: IEnumerable.GetEnumerator()
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_System_Collections_IEnumerable_GetEnumerator
+  commentId: M:SadRogue.Primitives.GridViews.Diff`1.System#Collections#IEnumerable#GetEnumerator
+  name.vb: System.Collections.IEnumerable.GetEnumerator()
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.System.Collections.IEnumerable.GetEnumerator()
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).System.Collections.IEnumerable.GetEnumerator()
+  nameWithType: Diff<T>.IEnumerable.GetEnumerator()
+  nameWithType.vb: Diff(Of T).System.Collections.IEnumerable.GetEnumerator()
+- uid: SadRogue.Primitives.GridViews.Diff`1.System#Collections#IEnumerable#GetEnumerator*
+  name: IEnumerable.GetEnumerator
+  href: api/SadRogue.Primitives.GridViews.Diff-1.html#SadRogue_Primitives_GridViews_Diff_1_System_Collections_IEnumerable_GetEnumerator_
+  commentId: Overload:SadRogue.Primitives.GridViews.Diff`1.System#Collections#IEnumerable#GetEnumerator
+  isSpec: "True"
+  name.vb: System.Collections.IEnumerable.GetEnumerator
+  fullName: SadRogue.Primitives.GridViews.Diff<T>.System.Collections.IEnumerable.GetEnumerator
+  fullName.vb: SadRogue.Primitives.GridViews.Diff(Of T).System.Collections.IEnumerable.GetEnumerator
+  nameWithType: Diff<T>.IEnumerable.GetEnumerator
+  nameWithType.vb: Diff(Of T).System.Collections.IEnumerable.GetEnumerator
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1
+  name: DiffAwareGridView<T>
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html
+  commentId: T:SadRogue.Primitives.GridViews.DiffAwareGridView`1
+  name.vb: DiffAwareGridView(Of T)
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T)
+  nameWithType: DiffAwareGridView<T>
+  nameWithType.vb: DiffAwareGridView(Of T)
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Boolean)
+  name: DiffAwareGridView(ISettableGridView<T>, Boolean)
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Boolean_
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Boolean)
+  name.vb: DiffAwareGridView(ISettableGridView(Of T), Boolean)
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.DiffAwareGridView(SadRogue.Primitives.GridViews.ISettableGridView<T>, System.Boolean)
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).DiffAwareGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T), System.Boolean)
+  nameWithType: DiffAwareGridView<T>.DiffAwareGridView(ISettableGridView<T>, Boolean)
+  nameWithType.vb: DiffAwareGridView(Of T).DiffAwareGridView(ISettableGridView(Of T), Boolean)
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor(System.Int32,System.Int32,System.Boolean)
+  name: DiffAwareGridView(Int32, Int32, Boolean)
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_System_Int32_System_Int32_System_Boolean_
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor(System.Int32,System.Int32,System.Boolean)
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.DiffAwareGridView(System.Int32, System.Int32, System.Boolean)
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).DiffAwareGridView(System.Int32, System.Int32, System.Boolean)
+  nameWithType: DiffAwareGridView<T>.DiffAwareGridView(Int32, Int32, Boolean)
+  nameWithType.vb: DiffAwareGridView(Of T).DiffAwareGridView(Int32, Int32, Boolean)
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor*
+  name: DiffAwareGridView
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.DiffAwareGridView
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).DiffAwareGridView
+  nameWithType: DiffAwareGridView<T>.DiffAwareGridView
+  nameWithType.vb: DiffAwareGridView(Of T).DiffAwareGridView
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiff
+  name: ApplyNextDiff()
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiff
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiff
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.ApplyNextDiff()
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).ApplyNextDiff()
+  nameWithType: DiffAwareGridView<T>.ApplyNextDiff()
+  nameWithType.vb: DiffAwareGridView(Of T).ApplyNextDiff()
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiff*
+  name: ApplyNextDiff
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiff_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiff
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.ApplyNextDiff
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).ApplyNextDiff
+  nameWithType: DiffAwareGridView<T>.ApplyNextDiff
+  nameWithType.vb: DiffAwareGridView(Of T).ApplyNextDiff
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiffOrFinalize
+  name: ApplyNextDiffOrFinalize()
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiffOrFinalize
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiffOrFinalize
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.ApplyNextDiffOrFinalize()
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).ApplyNextDiffOrFinalize()
+  nameWithType: DiffAwareGridView<T>.ApplyNextDiffOrFinalize()
+  nameWithType.vb: DiffAwareGridView(Of T).ApplyNextDiffOrFinalize()
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiffOrFinalize*
+  name: ApplyNextDiffOrFinalize
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ApplyNextDiffOrFinalize_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.ApplyNextDiffOrFinalize
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.ApplyNextDiffOrFinalize
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).ApplyNextDiffOrFinalize
+  nameWithType: DiffAwareGridView<T>.ApplyNextDiffOrFinalize
+  nameWithType.vb: DiffAwareGridView(Of T).ApplyNextDiffOrFinalize
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.AutoCompress
+  name: AutoCompress
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_AutoCompress
+  commentId: F:SadRogue.Primitives.GridViews.DiffAwareGridView`1.AutoCompress
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.AutoCompress
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).AutoCompress
+  nameWithType: DiffAwareGridView<T>.AutoCompress
+  nameWithType.vb: DiffAwareGridView(Of T).AutoCompress
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.BaseGrid
+  name: BaseGrid
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid
+  commentId: P:SadRogue.Primitives.GridViews.DiffAwareGridView`1.BaseGrid
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.BaseGrid
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).BaseGrid
+  nameWithType: DiffAwareGridView<T>.BaseGrid
+  nameWithType.vb: DiffAwareGridView(Of T).BaseGrid
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.BaseGrid*
+  name: BaseGrid
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_BaseGrid_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.BaseGrid
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.BaseGrid
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).BaseGrid
+  nameWithType: DiffAwareGridView<T>.BaseGrid
+  nameWithType.vb: DiffAwareGridView(Of T).BaseGrid
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.ClearHistory
+  name: ClearHistory()
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ClearHistory
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.ClearHistory
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.ClearHistory()
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).ClearHistory()
+  nameWithType: DiffAwareGridView<T>.ClearHistory()
+  nameWithType.vb: DiffAwareGridView(Of T).ClearHistory()
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.ClearHistory*
+  name: ClearHistory
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_ClearHistory_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.ClearHistory
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.ClearHistory
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).ClearHistory
+  nameWithType: DiffAwareGridView<T>.ClearHistory
+  nameWithType.vb: DiffAwareGridView(Of T).ClearHistory
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.CurrentDiffIndex
+  name: CurrentDiffIndex
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_CurrentDiffIndex
+  commentId: P:SadRogue.Primitives.GridViews.DiffAwareGridView`1.CurrentDiffIndex
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.CurrentDiffIndex
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).CurrentDiffIndex
+  nameWithType: DiffAwareGridView<T>.CurrentDiffIndex
+  nameWithType.vb: DiffAwareGridView(Of T).CurrentDiffIndex
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.CurrentDiffIndex*
+  name: CurrentDiffIndex
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_CurrentDiffIndex_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.CurrentDiffIndex
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.CurrentDiffIndex
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).CurrentDiffIndex
+  nameWithType: DiffAwareGridView<T>.CurrentDiffIndex
+  nameWithType.vb: DiffAwareGridView(Of T).CurrentDiffIndex
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Diffs
+  name: Diffs
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Diffs
+  commentId: P:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Diffs
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Diffs
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Diffs
+  nameWithType: DiffAwareGridView<T>.Diffs
+  nameWithType.vb: DiffAwareGridView(Of T).Diffs
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Diffs*
+  name: Diffs
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Diffs_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Diffs
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Diffs
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Diffs
+  nameWithType: DiffAwareGridView<T>.Diffs
+  nameWithType.vb: DiffAwareGridView(Of T).Diffs
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.FinalizeCurrentDiff
+  name: FinalizeCurrentDiff()
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_FinalizeCurrentDiff
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.FinalizeCurrentDiff
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.FinalizeCurrentDiff()
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).FinalizeCurrentDiff()
+  nameWithType: DiffAwareGridView<T>.FinalizeCurrentDiff()
+  nameWithType.vb: DiffAwareGridView(Of T).FinalizeCurrentDiff()
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.FinalizeCurrentDiff*
+  name: FinalizeCurrentDiff
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_FinalizeCurrentDiff_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.FinalizeCurrentDiff
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.FinalizeCurrentDiff
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).FinalizeCurrentDiff
+  nameWithType: DiffAwareGridView<T>.FinalizeCurrentDiff
+  nameWithType.vb: DiffAwareGridView(Of T).FinalizeCurrentDiff
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Height
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Height
+  nameWithType: DiffAwareGridView<T>.Height
+  nameWithType.vb: DiffAwareGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Height
+  nameWithType: DiffAwareGridView<T>.Height
+  nameWithType.vb: DiffAwareGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: DiffAwareGridView<T>.Item[Point]
+  nameWithType.vb: DiffAwareGridView(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Item
+  nameWithType: DiffAwareGridView<T>.Item
+  nameWithType.vb: DiffAwareGridView(Of T).Item
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.RevertToPreviousDiff
+  name: RevertToPreviousDiff()
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_RevertToPreviousDiff
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.RevertToPreviousDiff
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.RevertToPreviousDiff()
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).RevertToPreviousDiff()
+  nameWithType: DiffAwareGridView<T>.RevertToPreviousDiff()
+  nameWithType.vb: DiffAwareGridView(Of T).RevertToPreviousDiff()
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.RevertToPreviousDiff*
+  name: RevertToPreviousDiff
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_RevertToPreviousDiff_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.RevertToPreviousDiff
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.RevertToPreviousDiff
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).RevertToPreviousDiff
+  nameWithType: DiffAwareGridView<T>.RevertToPreviousDiff
+  nameWithType.vb: DiffAwareGridView(Of T).RevertToPreviousDiff
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetBaseline(SadRogue.Primitives.GridViews.IGridView{`0})
+  name: SetBaseline(IGridView<T>)
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetBaseline_SadRogue_Primitives_GridViews_IGridView__0__
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetBaseline(SadRogue.Primitives.GridViews.IGridView{`0})
+  name.vb: SetBaseline(IGridView(Of T))
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.SetBaseline(SadRogue.Primitives.GridViews.IGridView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).SetBaseline(SadRogue.Primitives.GridViews.IGridView(Of T))
+  nameWithType: DiffAwareGridView<T>.SetBaseline(IGridView<T>)
+  nameWithType.vb: DiffAwareGridView(Of T).SetBaseline(IGridView(Of T))
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetBaseline*
+  name: SetBaseline
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetBaseline_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetBaseline
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.SetBaseline
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).SetBaseline
+  nameWithType: DiffAwareGridView<T>.SetBaseline
+  nameWithType.vb: DiffAwareGridView(Of T).SetBaseline
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.Diff{`0}})
+  name: SetHistory(IEnumerable<Diff<T>>)
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.Diff{`0}})
+  name.vb: SetHistory(IEnumerable(Of Diff(Of T)))
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.SetHistory(System.Collections.Generic.IEnumerable<SadRogue.Primitives.GridViews.Diff<T>>)
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).SetHistory(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.GridViews.Diff(Of T)))
+  nameWithType: DiffAwareGridView<T>.SetHistory(IEnumerable<Diff<T>>)
+  nameWithType.vb: DiffAwareGridView(Of T).SetHistory(IEnumerable(Of Diff(Of T)))
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.Diff{`0}},System.Int32)
+  name: SetHistory(IEnumerable<Diff<T>>, Int32)
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_System_Collections_Generic_IEnumerable_SadRogue_Primitives_GridViews_Diff__0___System_Int32_
+  commentId: M:SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory(System.Collections.Generic.IEnumerable{SadRogue.Primitives.GridViews.Diff{`0}},System.Int32)
+  name.vb: SetHistory(IEnumerable(Of Diff(Of T)), Int32)
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.SetHistory(System.Collections.Generic.IEnumerable<SadRogue.Primitives.GridViews.Diff<T>>, System.Int32)
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).SetHistory(System.Collections.Generic.IEnumerable(Of SadRogue.Primitives.GridViews.Diff(Of T)), System.Int32)
+  nameWithType: DiffAwareGridView<T>.SetHistory(IEnumerable<Diff<T>>, Int32)
+  nameWithType.vb: DiffAwareGridView(Of T).SetHistory(IEnumerable(Of Diff(Of T)), Int32)
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory*
+  name: SetHistory
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_SetHistory_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.SetHistory
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.SetHistory
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).SetHistory
+  nameWithType: DiffAwareGridView<T>.SetHistory
+  nameWithType.vb: DiffAwareGridView(Of T).SetHistory
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Width
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Width
+  nameWithType: DiffAwareGridView<T>.Width
+  nameWithType.vb: DiffAwareGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.DiffAwareGridView`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.DiffAwareGridView-1.html#SadRogue_Primitives_GridViews_DiffAwareGridView_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.DiffAwareGridView`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.DiffAwareGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.DiffAwareGridView(Of T).Width
+  nameWithType: DiffAwareGridView<T>.Width
+  nameWithType.vb: DiffAwareGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1
+  name: GridViewBase<T>
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html
+  commentId: T:SadRogue.Primitives.GridViews.GridViewBase`1
+  name.vb: GridViewBase(Of T)
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T)
+  nameWithType: GridViewBase<T>
+  nameWithType.vb: GridViewBase(Of T)
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Count
+  name: Count
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count
+  commentId: P:SadRogue.Primitives.GridViews.GridViewBase`1.Count
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Count
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Count
+  nameWithType: GridViewBase<T>.Count
+  nameWithType.vb: GridViewBase(Of T).Count
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Count*
+  name: Count
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Count_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewBase`1.Count
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Count
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Count
+  nameWithType: GridViewBase<T>.Count
+  nameWithType.vb: GridViewBase(Of T).Count
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.GridViewBase`1.Height
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Height
+  nameWithType: GridViewBase<T>.Height
+  nameWithType.vb: GridViewBase(Of T).Height
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewBase`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Height
+  nameWithType: GridViewBase<T>.Height
+  nameWithType.vb: GridViewBase(Of T).Height
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.GridViewBase`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: GridViewBase<T>.Item[Point]
+  nameWithType.vb: GridViewBase(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.GridViewBase`1.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Item(System.Int32)
+  nameWithType: GridViewBase<T>.Item[Int32]
+  nameWithType.vb: GridViewBase(Of T).Item(Int32)
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Item(System.Int32,System.Int32)
+  name: Item[Int32, Int32]
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_System_Int32_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.GridViewBase`1.Item(System.Int32,System.Int32)
+  name.vb: Item(Int32, Int32)
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Item[System.Int32, System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Item(System.Int32, System.Int32)
+  nameWithType: GridViewBase<T>.Item[Int32, Int32]
+  nameWithType.vb: GridViewBase(Of T).Item(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewBase`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Item
+  nameWithType: GridViewBase<T>.Item
+  nameWithType.vb: GridViewBase(Of T).Item
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.GridViewBase`1.Width
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Width
+  nameWithType: GridViewBase<T>.Width
+  nameWithType.vb: GridViewBase(Of T).Width
+- uid: SadRogue.Primitives.GridViews.GridViewBase`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.GridViewBase-1.html#SadRogue_Primitives_GridViews_GridViewBase_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewBase`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewBase<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewBase(Of T).Width
+  nameWithType: GridViewBase<T>.Width
+  nameWithType.vb: GridViewBase(Of T).Width
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions
+  name: GridViewExtensions
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html
+  commentId: T:SadRogue.Primitives.GridViews.GridViewExtensions
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions
+  nameWithType: GridViewExtensions
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay*
+  name: ApplyOverlay
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay
+  nameWithType: GridViewExtensions.ApplyOverlay
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},SadRogue.Primitives.GridViews.IGridView{``0})
+  name: ApplyOverlay<T>(ISettableGridView<T>, IGridView<T>)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__SadRogue_Primitives_GridViews_IGridView___0__
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},SadRogue.Primitives.GridViews.IGridView{``0})
+  name.vb: ApplyOverlay(Of T)(ISettableGridView(Of T), IGridView(Of T))
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay<T>(SadRogue.Primitives.GridViews.ISettableGridView<T>, SadRogue.Primitives.GridViews.IGridView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay(Of T)(SadRogue.Primitives.GridViews.ISettableGridView(Of T), SadRogue.Primitives.GridViews.IGridView(Of T))
+  nameWithType: GridViewExtensions.ApplyOverlay<T>(ISettableGridView<T>, IGridView<T>)
+  nameWithType.vb: GridViewExtensions.ApplyOverlay(Of T)(ISettableGridView(Of T), IGridView(Of T))
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},System.Func{SadRogue.Primitives.Point,``0})
+  name: ApplyOverlay<T>(ISettableGridView<T>, Func<Point, T>)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ApplyOverlay__1_SadRogue_Primitives_GridViews_ISettableGridView___0__System_Func_SadRogue_Primitives_Point___0__
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},System.Func{SadRogue.Primitives.Point,``0})
+  name.vb: ApplyOverlay(Of T)(ISettableGridView(Of T), Func(Of Point, T))
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay<T>(SadRogue.Primitives.GridViews.ISettableGridView<T>, System.Func<SadRogue.Primitives.Point, T>)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.ApplyOverlay(Of T)(SadRogue.Primitives.GridViews.ISettableGridView(Of T), System.Func(Of SadRogue.Primitives.Point, T))
+  nameWithType: GridViewExtensions.ApplyOverlay<T>(ISettableGridView<T>, Func<Point, T>)
+  nameWithType.vb: GridViewExtensions.ApplyOverlay(Of T)(ISettableGridView(Of T), Func(Of Point, T))
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Bounds*
+  name: Bounds
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewExtensions.Bounds
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Bounds
+  nameWithType: GridViewExtensions.Bounds
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Bounds``1(SadRogue.Primitives.GridViews.IGridView{``0})
+  name: Bounds<T>(IGridView<T>)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Bounds__1_SadRogue_Primitives_GridViews_IGridView___0__
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.Bounds``1(SadRogue.Primitives.GridViews.IGridView{``0})
+  name.vb: Bounds(Of T)(IGridView(Of T))
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Bounds<T>(SadRogue.Primitives.GridViews.IGridView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.Bounds(Of T)(SadRogue.Primitives.GridViews.IGridView(Of T))
+  nameWithType: GridViewExtensions.Bounds<T>(IGridView<T>)
+  nameWithType.vb: GridViewExtensions.Bounds(Of T)(IGridView(Of T))
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Contains*
+  name: Contains
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewExtensions.Contains
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Contains
+  nameWithType: GridViewExtensions.Contains
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Contains``1(SadRogue.Primitives.GridViews.IGridView{``0},SadRogue.Primitives.Point)
+  name: Contains<T>(IGridView<T>, Point)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__SadRogue_Primitives_Point_
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.Contains``1(SadRogue.Primitives.GridViews.IGridView{``0},SadRogue.Primitives.Point)
+  name.vb: Contains(Of T)(IGridView(Of T), Point)
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Contains<T>(SadRogue.Primitives.GridViews.IGridView<T>, SadRogue.Primitives.Point)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.Contains(Of T)(SadRogue.Primitives.GridViews.IGridView(Of T), SadRogue.Primitives.Point)
+  nameWithType: GridViewExtensions.Contains<T>(IGridView<T>, Point)
+  nameWithType.vb: GridViewExtensions.Contains(Of T)(IGridView(Of T), Point)
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Contains``1(SadRogue.Primitives.GridViews.IGridView{``0},System.Int32,System.Int32)
+  name: Contains<T>(IGridView<T>, Int32, Int32)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Contains__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.Contains``1(SadRogue.Primitives.GridViews.IGridView{``0},System.Int32,System.Int32)
+  name.vb: Contains(Of T)(IGridView(Of T), Int32, Int32)
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Contains<T>(SadRogue.Primitives.GridViews.IGridView<T>, System.Int32, System.Int32)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.Contains(Of T)(SadRogue.Primitives.GridViews.IGridView(Of T), System.Int32, System.Int32)
+  nameWithType: GridViewExtensions.Contains<T>(IGridView<T>, Int32, Int32)
+  nameWithType.vb: GridViewExtensions.Contains(Of T)(IGridView(Of T), Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString*
+  name: ExtendToString
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString
+  nameWithType: GridViewExtensions.ExtendToString
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString``1(SadRogue.Primitives.GridViews.IGridView{``0},System.Int32,System.String,System.String,System.Func{``0,System.String},System.String,System.String,System.String,System.String)
+  name: ExtendToString<T>(IGridView<T>, Int32, String, String, Func<T, String>, String, String, String, String)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_Int32_System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString``1(SadRogue.Primitives.GridViews.IGridView{``0},System.Int32,System.String,System.String,System.Func{``0,System.String},System.String,System.String,System.String,System.String)
+  name.vb: ExtendToString(Of T)(IGridView(Of T), Int32, String, String, Func(Of T, String), String, String, String, String)
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString<T>(SadRogue.Primitives.GridViews.IGridView<T>, System.Int32, System.String, System.String, System.Func<T, System.String>, System.String, System.String, System.String, System.String)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString(Of T)(SadRogue.Primitives.GridViews.IGridView(Of T), System.Int32, System.String, System.String, System.Func(Of T, System.String), System.String, System.String, System.String, System.String)
+  nameWithType: GridViewExtensions.ExtendToString<T>(IGridView<T>, Int32, String, String, Func<T, String>, String, String, String, String)
+  nameWithType.vb: GridViewExtensions.ExtendToString(Of T)(IGridView(Of T), Int32, String, String, Func(Of T, String), String, String, String, String)
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString``1(SadRogue.Primitives.GridViews.IGridView{``0},System.String,System.String,System.Func{``0,System.String},System.String,System.String,System.String,System.String)
+  name: ExtendToString<T>(IGridView<T>, String, String, Func<T, String>, String, String, String, String)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_ExtendToString__1_SadRogue_Primitives_GridViews_IGridView___0__System_String_System_String_System_Func___0_System_String__System_String_System_String_System_String_System_String_
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString``1(SadRogue.Primitives.GridViews.IGridView{``0},System.String,System.String,System.Func{``0,System.String},System.String,System.String,System.String,System.String)
+  name.vb: ExtendToString(Of T)(IGridView(Of T), String, String, Func(Of T, String), String, String, String, String)
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString<T>(SadRogue.Primitives.GridViews.IGridView<T>, System.String, System.String, System.Func<T, System.String>, System.String, System.String, System.String, System.String)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.ExtendToString(Of T)(SadRogue.Primitives.GridViews.IGridView(Of T), System.String, System.String, System.Func(Of T, System.String), System.String, System.String, System.String, System.String)
+  nameWithType: GridViewExtensions.ExtendToString<T>(IGridView<T>, String, String, Func<T, String>, String, String, String, String)
+  nameWithType.vb: GridViewExtensions.ExtendToString(Of T)(IGridView(Of T), String, String, Func(Of T, String), String, String, String, String)
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Fill*
+  name: Fill
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewExtensions.Fill
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Fill
+  nameWithType: GridViewExtensions.Fill
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Fill``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},``0)
+  name: Fill<T>(ISettableGridView<T>, T)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Fill__1_SadRogue_Primitives_GridViews_ISettableGridView___0____0_
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.Fill``1(SadRogue.Primitives.GridViews.ISettableGridView{``0},``0)
+  name.vb: Fill(Of T)(ISettableGridView(Of T), T)
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Fill<T>(SadRogue.Primitives.GridViews.ISettableGridView<T>, T)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.Fill(Of T)(SadRogue.Primitives.GridViews.ISettableGridView(Of T), T)
+  nameWithType: GridViewExtensions.Fill<T>(ISettableGridView<T>, T)
+  nameWithType.vb: GridViewExtensions.Fill(Of T)(ISettableGridView(Of T), T)
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Positions*
+  name: Positions
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions_
+  commentId: Overload:SadRogue.Primitives.GridViews.GridViewExtensions.Positions
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Positions
+  nameWithType: GridViewExtensions.Positions
+- uid: SadRogue.Primitives.GridViews.GridViewExtensions.Positions``1(SadRogue.Primitives.GridViews.IGridView{``0})
+  name: Positions<T>(IGridView<T>)
+  href: api/SadRogue.Primitives.GridViews.GridViewExtensions.html#SadRogue_Primitives_GridViews_GridViewExtensions_Positions__1_SadRogue_Primitives_GridViews_IGridView___0__
+  commentId: M:SadRogue.Primitives.GridViews.GridViewExtensions.Positions``1(SadRogue.Primitives.GridViews.IGridView{``0})
+  name.vb: Positions(Of T)(IGridView(Of T))
+  fullName: SadRogue.Primitives.GridViews.GridViewExtensions.Positions<T>(SadRogue.Primitives.GridViews.IGridView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.GridViewExtensions.Positions(Of T)(SadRogue.Primitives.GridViews.IGridView(Of T))
+  nameWithType: GridViewExtensions.Positions<T>(IGridView<T>)
+  nameWithType.vb: GridViewExtensions.Positions(Of T)(IGridView(Of T))
+- uid: SadRogue.Primitives.GridViews.IGridView`1
+  name: IGridView<T>
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html
+  commentId: T:SadRogue.Primitives.GridViews.IGridView`1
+  name.vb: IGridView(Of T)
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T)
+  nameWithType: IGridView<T>
+  nameWithType.vb: IGridView(Of T)
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Count
+  name: Count
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Count
+  commentId: P:SadRogue.Primitives.GridViews.IGridView`1.Count
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Count
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Count
+  nameWithType: IGridView<T>.Count
+  nameWithType.vb: IGridView(Of T).Count
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Count*
+  name: Count
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Count_
+  commentId: Overload:SadRogue.Primitives.GridViews.IGridView`1.Count
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Count
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Count
+  nameWithType: IGridView<T>.Count
+  nameWithType.vb: IGridView(Of T).Count
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.IGridView`1.Height
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Height
+  nameWithType: IGridView<T>.Height
+  nameWithType.vb: IGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.IGridView`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Height
+  nameWithType: IGridView<T>.Height
+  nameWithType.vb: IGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.IGridView`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: IGridView<T>.Item[Point]
+  nameWithType.vb: IGridView(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.IGridView`1.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Item(System.Int32)
+  nameWithType: IGridView<T>.Item[Int32]
+  nameWithType.vb: IGridView(Of T).Item(Int32)
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Item(System.Int32,System.Int32)
+  name: Item[Int32, Int32]
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_System_Int32_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.IGridView`1.Item(System.Int32,System.Int32)
+  name.vb: Item(Int32, Int32)
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Item[System.Int32, System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Item(System.Int32, System.Int32)
+  nameWithType: IGridView<T>.Item[Int32, Int32]
+  nameWithType.vb: IGridView(Of T).Item(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.IGridView`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Item
+  nameWithType: IGridView<T>.Item
+  nameWithType.vb: IGridView(Of T).Item
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.IGridView`1.Width
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Width
+  nameWithType: IGridView<T>.Width
+  nameWithType.vb: IGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.IGridView`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.IGridView-1.html#SadRogue_Primitives_GridViews_IGridView_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.IGridView`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.IGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.IGridView(Of T).Width
+  nameWithType: IGridView<T>.Width
+  nameWithType.vb: IGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.ISettableGridView`1
+  name: ISettableGridView<T>
+  href: api/SadRogue.Primitives.GridViews.ISettableGridView-1.html
+  commentId: T:SadRogue.Primitives.GridViews.ISettableGridView`1
+  name.vb: ISettableGridView(Of T)
+  fullName: SadRogue.Primitives.GridViews.ISettableGridView<T>
+  fullName.vb: SadRogue.Primitives.GridViews.ISettableGridView(Of T)
+  nameWithType: ISettableGridView<T>
+  nameWithType.vb: ISettableGridView(Of T)
+- uid: SadRogue.Primitives.GridViews.ISettableGridView`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.ISettableGridView`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.ISettableGridView<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.ISettableGridView(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: ISettableGridView<T>.Item[Point]
+  nameWithType.vb: ISettableGridView(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.ISettableGridView`1.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.ISettableGridView`1.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.GridViews.ISettableGridView<T>.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.ISettableGridView(Of T).Item(System.Int32)
+  nameWithType: ISettableGridView<T>.Item[Int32]
+  nameWithType.vb: ISettableGridView(Of T).Item(Int32)
+- uid: SadRogue.Primitives.GridViews.ISettableGridView`1.Item(System.Int32,System.Int32)
+  name: Item[Int32, Int32]
+  href: api/SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_System_Int32_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.ISettableGridView`1.Item(System.Int32,System.Int32)
+  name.vb: Item(Int32, Int32)
+  fullName: SadRogue.Primitives.GridViews.ISettableGridView<T>.Item[System.Int32, System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.ISettableGridView(Of T).Item(System.Int32, System.Int32)
+  nameWithType: ISettableGridView<T>.Item[Int32, Int32]
+  nameWithType.vb: ISettableGridView(Of T).Item(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.ISettableGridView`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.ISettableGridView-1.html#SadRogue_Primitives_GridViews_ISettableGridView_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.ISettableGridView`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ISettableGridView<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.ISettableGridView(Of T).Item
+  nameWithType: ISettableGridView<T>.Item
+  nameWithType.vb: ISettableGridView(Of T).Item
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1
+  name: LambdaGridView<T>
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html
+  commentId: T:SadRogue.Primitives.GridViews.LambdaGridView`1
+  name.vb: LambdaGridView(Of T)
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T)
+  nameWithType: LambdaGridView<T>
+  nameWithType.vb: LambdaGridView(Of T)
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor(System.Func{System.Int32},System.Func{System.Int32},System.Func{SadRogue.Primitives.Point,`0})
+  name: LambdaGridView(Func<Int32>, Func<Int32>, Func<Point, T>)
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor(System.Func{System.Int32},System.Func{System.Int32},System.Func{SadRogue.Primitives.Point,`0})
+  name.vb: LambdaGridView(Func(Of Int32), Func(Of Int32), Func(Of Point, T))
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.LambdaGridView(System.Func<System.Int32>, System.Func<System.Int32>, System.Func<SadRogue.Primitives.Point, T>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).LambdaGridView(System.Func(Of System.Int32), System.Func(Of System.Int32), System.Func(Of SadRogue.Primitives.Point, T))
+  nameWithType: LambdaGridView<T>.LambdaGridView(Func<Int32>, Func<Int32>, Func<Point, T>)
+  nameWithType.vb: LambdaGridView(Of T).LambdaGridView(Func(Of Int32), Func(Of Int32), Func(Of Point, T))
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor(System.Int32,System.Int32,System.Func{SadRogue.Primitives.Point,`0})
+  name: LambdaGridView(Int32, Int32, Func<Point, T>)
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor(System.Int32,System.Int32,System.Func{SadRogue.Primitives.Point,`0})
+  name.vb: LambdaGridView(Int32, Int32, Func(Of Point, T))
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.LambdaGridView(System.Int32, System.Int32, System.Func<SadRogue.Primitives.Point, T>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).LambdaGridView(System.Int32, System.Int32, System.Func(Of SadRogue.Primitives.Point, T))
+  nameWithType: LambdaGridView<T>.LambdaGridView(Int32, Int32, Func<Point, T>)
+  nameWithType.vb: LambdaGridView(Of T).LambdaGridView(Int32, Int32, Func(Of Point, T))
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor*
+  name: LambdaGridView
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaGridView`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.LambdaGridView
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).LambdaGridView
+  nameWithType: LambdaGridView<T>.LambdaGridView
+  nameWithType.vb: LambdaGridView(Of T).LambdaGridView
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.LambdaGridView`1.Height
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).Height
+  nameWithType: LambdaGridView<T>.Height
+  nameWithType.vb: LambdaGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaGridView`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).Height
+  nameWithType: LambdaGridView<T>.Height
+  nameWithType.vb: LambdaGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.LambdaGridView`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: LambdaGridView<T>.Item[Point]
+  nameWithType.vb: LambdaGridView(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaGridView`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).Item
+  nameWithType: LambdaGridView<T>.Item
+  nameWithType.vb: LambdaGridView(Of T).Item
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.LambdaGridView`1.ToString
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).ToString()
+  nameWithType: LambdaGridView<T>.ToString()
+  nameWithType.vb: LambdaGridView(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.ToString(System.Func{`0,System.String})
+  name: ToString(Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaGridView`1.ToString(System.Func{`0,System.String})
+  name.vb: ToString(Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.ToString(System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).ToString(System.Func(Of T, System.String))
+  nameWithType: LambdaGridView<T>.ToString(Func<T, String>)
+  nameWithType.vb: LambdaGridView(Of T).ToString(Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.ToString(System.Int32,System.Func{`0,System.String})
+  name: ToString(Int32, Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_System_Int32_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaGridView`1.ToString(System.Int32,System.Func{`0,System.String})
+  name.vb: ToString(Int32, Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.ToString(System.Int32, System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).ToString(System.Int32, System.Func(Of T, System.String))
+  nameWithType: LambdaGridView<T>.ToString(Int32, Func<T, String>)
+  nameWithType.vb: LambdaGridView(Of T).ToString(Int32, Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaGridView`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).ToString
+  nameWithType: LambdaGridView<T>.ToString
+  nameWithType.vb: LambdaGridView(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.LambdaGridView`1.Width
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).Width
+  nameWithType: LambdaGridView<T>.Width
+  nameWithType.vb: LambdaGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.LambdaGridView`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.LambdaGridView-1.html#SadRogue_Primitives_GridViews_LambdaGridView_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaGridView`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaGridView(Of T).Width
+  nameWithType: LambdaGridView<T>.Width
+  nameWithType.vb: LambdaGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1
+  name: LambdaSettableGridView<T>
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html
+  commentId: T:SadRogue.Primitives.GridViews.LambdaSettableGridView`1
+  name.vb: LambdaSettableGridView(Of T)
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T)
+  nameWithType: LambdaSettableGridView<T>
+  nameWithType.vb: LambdaSettableGridView(Of T)
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor(System.Func{System.Int32},System.Func{System.Int32},System.Func{SadRogue.Primitives.Point,`0},System.Action{SadRogue.Primitives.Point,`0})
+  name: LambdaSettableGridView(Func<Int32>, Func<Int32>, Func<Point, T>, Action<Point, T>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Func_System_Int32__System_Func_System_Int32__System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor(System.Func{System.Int32},System.Func{System.Int32},System.Func{SadRogue.Primitives.Point,`0},System.Action{SadRogue.Primitives.Point,`0})
+  name.vb: LambdaSettableGridView(Func(Of Int32), Func(Of Int32), Func(Of Point, T), Action(Of Point, T))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.LambdaSettableGridView(System.Func<System.Int32>, System.Func<System.Int32>, System.Func<SadRogue.Primitives.Point, T>, System.Action<SadRogue.Primitives.Point, T>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).LambdaSettableGridView(System.Func(Of System.Int32), System.Func(Of System.Int32), System.Func(Of SadRogue.Primitives.Point, T), System.Action(Of SadRogue.Primitives.Point, T))
+  nameWithType: LambdaSettableGridView<T>.LambdaSettableGridView(Func<Int32>, Func<Int32>, Func<Point, T>, Action<Point, T>)
+  nameWithType.vb: LambdaSettableGridView(Of T).LambdaSettableGridView(Func(Of Int32), Func(Of Int32), Func(Of Point, T), Action(Of Point, T))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor(System.Int32,System.Int32,System.Func{SadRogue.Primitives.Point,`0},System.Action{SadRogue.Primitives.Point,`0})
+  name: LambdaSettableGridView(Int32, Int32, Func<Point, T>, Action<Point, T>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_System_Int32_System_Int32_System_Func_SadRogue_Primitives_Point__0__System_Action_SadRogue_Primitives_Point__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor(System.Int32,System.Int32,System.Func{SadRogue.Primitives.Point,`0},System.Action{SadRogue.Primitives.Point,`0})
+  name.vb: LambdaSettableGridView(Int32, Int32, Func(Of Point, T), Action(Of Point, T))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.LambdaSettableGridView(System.Int32, System.Int32, System.Func<SadRogue.Primitives.Point, T>, System.Action<SadRogue.Primitives.Point, T>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).LambdaSettableGridView(System.Int32, System.Int32, System.Func(Of SadRogue.Primitives.Point, T), System.Action(Of SadRogue.Primitives.Point, T))
+  nameWithType: LambdaSettableGridView<T>.LambdaSettableGridView(Int32, Int32, Func<Point, T>, Action<Point, T>)
+  nameWithType.vb: LambdaSettableGridView(Of T).LambdaSettableGridView(Int32, Int32, Func(Of Point, T), Action(Of Point, T))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor*
+  name: LambdaSettableGridView
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.LambdaSettableGridView
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).LambdaSettableGridView
+  nameWithType: LambdaSettableGridView<T>.LambdaSettableGridView
+  nameWithType.vb: LambdaSettableGridView(Of T).LambdaSettableGridView
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Height
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).Height
+  nameWithType: LambdaSettableGridView<T>.Height
+  nameWithType.vb: LambdaSettableGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).Height
+  nameWithType: LambdaSettableGridView<T>.Height
+  nameWithType.vb: LambdaSettableGridView(Of T).Height
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: LambdaSettableGridView<T>.Item[Point]
+  nameWithType.vb: LambdaSettableGridView(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).Item
+  nameWithType: LambdaSettableGridView<T>.Item
+  nameWithType.vb: LambdaSettableGridView(Of T).Item
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).ToString()
+  nameWithType: LambdaSettableGridView<T>.ToString()
+  nameWithType.vb: LambdaSettableGridView(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString(System.Func{`0,System.String})
+  name: ToString(Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString(System.Func{`0,System.String})
+  name.vb: ToString(Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.ToString(System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).ToString(System.Func(Of T, System.String))
+  nameWithType: LambdaSettableGridView<T>.ToString(Func<T, String>)
+  nameWithType.vb: LambdaSettableGridView(Of T).ToString(Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString(System.Int32,System.Func{`0,System.String})
+  name: ToString(Int32, Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_System_Int32_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString(System.Int32,System.Func{`0,System.String})
+  name.vb: ToString(Int32, Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.ToString(System.Int32, System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).ToString(System.Int32, System.Func(Of T, System.String))
+  nameWithType: LambdaSettableGridView<T>.ToString(Int32, Func<T, String>)
+  nameWithType.vb: LambdaSettableGridView(Of T).ToString(Int32, Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).ToString
+  nameWithType: LambdaSettableGridView<T>.ToString
+  nameWithType.vb: LambdaSettableGridView(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Width
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).Width
+  nameWithType: LambdaSettableGridView<T>.Width
+  nameWithType.vb: LambdaSettableGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableGridView-1.html#SadRogue_Primitives_GridViews_LambdaSettableGridView_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableGridView`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableGridView<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableGridView(Of T).Width
+  nameWithType: LambdaSettableGridView<T>.Width
+  nameWithType.vb: LambdaSettableGridView(Of T).Width
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2
+  name: LambdaSettableTranslationGridView<T1, T2>
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html
+  commentId: T:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2
+  name.vb: LambdaSettableTranslationGridView(Of T1, T2)
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2)
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2)
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1},System.Func{`0,`1},System.Func{`1,`0})
+  name: LambdaSettableTranslationGridView(ISettableGridView<T1>, ISettableGridView<T2>, Func<T1, T2>, Func<T2, T1>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__System_Func__0__1__System_Func__1__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1},System.Func{`0,`1},System.Func{`1,`0})
+  name.vb: LambdaSettableTranslationGridView(ISettableGridView(Of T1), ISettableGridView(Of T2), Func(Of T1, T2), Func(Of T2, T1))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView<T1>, SadRogue.Primitives.GridViews.ISettableGridView<T2>, System.Func<T1, T2>, System.Func<T2, T1>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T1), SadRogue.Primitives.GridViews.ISettableGridView(Of T2), System.Func(Of T1, T2), System.Func(Of T2, T1))
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(ISettableGridView<T1>, ISettableGridView<T2>, Func<T1, T2>, Func<T2, T1>)
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(ISettableGridView(Of T1), ISettableGridView(Of T2), Func(Of T1, T2), Func(Of T2, T1))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1},System.Func{SadRogue.Primitives.Point,`0,`1},System.Func{SadRogue.Primitives.Point,`1,`0})
+  name: LambdaSettableTranslationGridView(ISettableGridView<T1>, ISettableGridView<T2>, Func<Point, T1, T2>, Func<Point, T2, T1>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__System_Func_SadRogue_Primitives_Point__0__1__System_Func_SadRogue_Primitives_Point__1__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1},System.Func{SadRogue.Primitives.Point,`0,`1},System.Func{SadRogue.Primitives.Point,`1,`0})
+  name.vb: LambdaSettableTranslationGridView(ISettableGridView(Of T1), ISettableGridView(Of T2), Func(Of Point, T1, T2), Func(Of Point, T2, T1))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView<T1>, SadRogue.Primitives.GridViews.ISettableGridView<T2>, System.Func<SadRogue.Primitives.Point, T1, T2>, System.Func<SadRogue.Primitives.Point, T2, T1>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T1), SadRogue.Primitives.GridViews.ISettableGridView(Of T2), System.Func(Of SadRogue.Primitives.Point, T1, T2), System.Func(Of SadRogue.Primitives.Point, T2, T1))
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(ISettableGridView<T1>, ISettableGridView<T2>, Func<Point, T1, T2>, Func<Point, T2, T1>)
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(ISettableGridView(Of T1), ISettableGridView(Of T2), Func(Of Point, T1, T2), Func(Of Point, T2, T1))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Func{`0,`1},System.Func{`1,`0})
+  name: LambdaSettableTranslationGridView(ISettableGridView<T1>, Func<T1, T2>, Func<T2, T1>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func__0__1__System_Func__1__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Func{`0,`1},System.Func{`1,`0})
+  name.vb: LambdaSettableTranslationGridView(ISettableGridView(Of T1), Func(Of T1, T2), Func(Of T2, T1))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView<T1>, System.Func<T1, T2>, System.Func<T2, T1>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T1), System.Func(Of T1, T2), System.Func(Of T2, T1))
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(ISettableGridView<T1>, Func<T1, T2>, Func<T2, T1>)
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(ISettableGridView(Of T1), Func(Of T1, T2), Func(Of T2, T1))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Func{SadRogue.Primitives.Point,`0,`1},System.Func{SadRogue.Primitives.Point,`1,`0})
+  name: LambdaSettableTranslationGridView(ISettableGridView<T1>, Func<Point, T1, T2>, Func<Point, T2, T1>)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__System_Func_SadRogue_Primitives_Point__0__1__System_Func_SadRogue_Primitives_Point__1__0__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},System.Func{SadRogue.Primitives.Point,`0,`1},System.Func{SadRogue.Primitives.Point,`1,`0})
+  name.vb: LambdaSettableTranslationGridView(ISettableGridView(Of T1), Func(Of Point, T1, T2), Func(Of Point, T2, T1))
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView<T1>, System.Func<SadRogue.Primitives.Point, T1, T2>, System.Func<SadRogue.Primitives.Point, T2, T1>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T1), System.Func(Of SadRogue.Primitives.Point, T1, T2), System.Func(Of SadRogue.Primitives.Point, T2, T1))
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView(ISettableGridView<T1>, Func<Point, T1, T2>, Func<Point, T2, T1>)
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView(ISettableGridView(Of T1), Func(Of Point, T1, T2), Func(Of Point, T2, T1))
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor*
+  name: LambdaSettableTranslationGridView
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.LambdaSettableTranslationGridView
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).LambdaSettableTranslationGridView
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  name: TranslateGet(Point, T1)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.TranslateGet(SadRogue.Primitives.Point, T1)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).TranslateGet(SadRogue.Primitives.Point, T1)
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.TranslateGet(Point, T1)
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).TranslateGet(Point, T1)
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateGet*
+  name: TranslateGet
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateGet_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateGet
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.TranslateGet
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).TranslateGet
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.TranslateGet
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).TranslateGet
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateSet(SadRogue.Primitives.Point,`1)
+  name: TranslateSet(Point, T2)
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_
+  commentId: M:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateSet(SadRogue.Primitives.Point,`1)
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.TranslateSet(SadRogue.Primitives.Point, T2)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).TranslateSet(SadRogue.Primitives.Point, T2)
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.TranslateSet(Point, T2)
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).TranslateSet(Point, T2)
+- uid: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateSet*
+  name: TranslateSet
+  href: api/SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaSettableTranslationGridView_2_TranslateSet_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView`2.TranslateSet
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView<T1, T2>.TranslateSet
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaSettableTranslationGridView(Of T1, T2).TranslateSet
+  nameWithType: LambdaSettableTranslationGridView<T1, T2>.TranslateSet
+  nameWithType.vb: LambdaSettableTranslationGridView(Of T1, T2).TranslateSet
+- uid: SadRogue.Primitives.GridViews.LambdaTranslationGridView`2
+  name: LambdaTranslationGridView<T1, T2>
+  href: api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html
+  commentId: T:SadRogue.Primitives.GridViews.LambdaTranslationGridView`2
+  name.vb: LambdaTranslationGridView(Of T1, T2)
+  fullName: SadRogue.Primitives.GridViews.LambdaTranslationGridView<T1, T2>
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaTranslationGridView(Of T1, T2)
+  nameWithType: LambdaTranslationGridView<T1, T2>
+  nameWithType.vb: LambdaTranslationGridView(Of T1, T2)
+- uid: SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},System.Func{`0,`1})
+  name: LambdaTranslationGridView(IGridView<T1>, Func<T1, T2>)
+  href: api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func__0__1__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},System.Func{`0,`1})
+  name.vb: LambdaTranslationGridView(IGridView(Of T1), Func(Of T1, T2))
+  fullName: SadRogue.Primitives.GridViews.LambdaTranslationGridView<T1, T2>.LambdaTranslationGridView(SadRogue.Primitives.GridViews.IGridView<T1>, System.Func<T1, T2>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaTranslationGridView(Of T1, T2).LambdaTranslationGridView(SadRogue.Primitives.GridViews.IGridView(Of T1), System.Func(Of T1, T2))
+  nameWithType: LambdaTranslationGridView<T1, T2>.LambdaTranslationGridView(IGridView<T1>, Func<T1, T2>)
+  nameWithType.vb: LambdaTranslationGridView(Of T1, T2).LambdaTranslationGridView(IGridView(Of T1), Func(Of T1, T2))
+- uid: SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},System.Func{SadRogue.Primitives.Point,`0,`1})
+  name: LambdaTranslationGridView(IGridView<T1>, Func<Point, T1, T2>)
+  href: api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__System_Func_SadRogue_Primitives_Point__0__1__
+  commentId: M:SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},System.Func{SadRogue.Primitives.Point,`0,`1})
+  name.vb: LambdaTranslationGridView(IGridView(Of T1), Func(Of Point, T1, T2))
+  fullName: SadRogue.Primitives.GridViews.LambdaTranslationGridView<T1, T2>.LambdaTranslationGridView(SadRogue.Primitives.GridViews.IGridView<T1>, System.Func<SadRogue.Primitives.Point, T1, T2>)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaTranslationGridView(Of T1, T2).LambdaTranslationGridView(SadRogue.Primitives.GridViews.IGridView(Of T1), System.Func(Of SadRogue.Primitives.Point, T1, T2))
+  nameWithType: LambdaTranslationGridView<T1, T2>.LambdaTranslationGridView(IGridView<T1>, Func<Point, T1, T2>)
+  nameWithType.vb: LambdaTranslationGridView(Of T1, T2).LambdaTranslationGridView(IGridView(Of T1), Func(Of Point, T1, T2))
+- uid: SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor*
+  name: LambdaTranslationGridView
+  href: api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaTranslationGridView_2__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaTranslationGridView<T1, T2>.LambdaTranslationGridView
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaTranslationGridView(Of T1, T2).LambdaTranslationGridView
+  nameWithType: LambdaTranslationGridView<T1, T2>.LambdaTranslationGridView
+  nameWithType.vb: LambdaTranslationGridView(Of T1, T2).LambdaTranslationGridView
+- uid: SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  name: TranslateGet(Point, T1)
+  href: api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_
+  commentId: M:SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  fullName: SadRogue.Primitives.GridViews.LambdaTranslationGridView<T1, T2>.TranslateGet(SadRogue.Primitives.Point, T1)
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaTranslationGridView(Of T1, T2).TranslateGet(SadRogue.Primitives.Point, T1)
+  nameWithType: LambdaTranslationGridView<T1, T2>.TranslateGet(Point, T1)
+  nameWithType.vb: LambdaTranslationGridView(Of T1, T2).TranslateGet(Point, T1)
+- uid: SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.TranslateGet*
+  name: TranslateGet
+  href: api/SadRogue.Primitives.GridViews.LambdaTranslationGridView-2.html#SadRogue_Primitives_GridViews_LambdaTranslationGridView_2_TranslateGet_
+  commentId: Overload:SadRogue.Primitives.GridViews.LambdaTranslationGridView`2.TranslateGet
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.LambdaTranslationGridView<T1, T2>.TranslateGet
+  fullName.vb: SadRogue.Primitives.GridViews.LambdaTranslationGridView(Of T1, T2).TranslateGet
+  nameWithType: LambdaTranslationGridView<T1, T2>.TranslateGet
+  nameWithType.vb: LambdaTranslationGridView(Of T1, T2).TranslateGet
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1
+  name: SettableGridViewBase<T>
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html
+  commentId: T:SadRogue.Primitives.GridViews.SettableGridViewBase`1
+  name.vb: SettableGridViewBase(Of T)
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T)
+  nameWithType: SettableGridViewBase<T>
+  nameWithType.vb: SettableGridViewBase(Of T)
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Count
+  name: Count
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count
+  commentId: P:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Count
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Count
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Count
+  nameWithType: SettableGridViewBase<T>.Count
+  nameWithType.vb: SettableGridViewBase(Of T).Count
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Count*
+  name: Count
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Count_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Count
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Count
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Count
+  nameWithType: SettableGridViewBase<T>.Count
+  nameWithType.vb: SettableGridViewBase(Of T).Count
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Height
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Height
+  nameWithType: SettableGridViewBase<T>.Height
+  nameWithType.vb: SettableGridViewBase(Of T).Height
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Height
+  nameWithType: SettableGridViewBase<T>.Height
+  nameWithType.vb: SettableGridViewBase(Of T).Height
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: SettableGridViewBase<T>.Item[Point]
+  nameWithType.vb: SettableGridViewBase(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Item(System.Int32)
+  nameWithType: SettableGridViewBase<T>.Item[Int32]
+  nameWithType.vb: SettableGridViewBase(Of T).Item(Int32)
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(System.Int32,System.Int32)
+  name: Item[Int32, Int32]
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_System_Int32_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item(System.Int32,System.Int32)
+  name.vb: Item(Int32, Int32)
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Item[System.Int32, System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Item(System.Int32, System.Int32)
+  nameWithType: SettableGridViewBase<T>.Item[Int32, Int32]
+  nameWithType.vb: SettableGridViewBase(Of T).Item(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Item
+  nameWithType: SettableGridViewBase<T>.Item
+  nameWithType.vb: SettableGridViewBase(Of T).Item
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Width
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Width
+  nameWithType: SettableGridViewBase<T>.Width
+  nameWithType.vb: SettableGridViewBase(Of T).Width
+- uid: SadRogue.Primitives.GridViews.SettableGridViewBase`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.SettableGridViewBase-1.html#SadRogue_Primitives_GridViews_SettableGridViewBase_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableGridViewBase`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableGridViewBase<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.SettableGridViewBase(Of T).Width
+  nameWithType: SettableGridViewBase<T>.Width
+  nameWithType.vb: SettableGridViewBase(Of T).Width
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2
+  name: SettableTranslationGridView<T1, T2>
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html
+  commentId: T:SadRogue.Primitives.GridViews.SettableTranslationGridView`2
+  name.vb: SettableTranslationGridView(Of T1, T2)
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2)
+  nameWithType: SettableTranslationGridView<T1, T2>
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2)
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0})
+  name: SettableTranslationGridView(ISettableGridView<T1>)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0})
+  name.vb: SettableTranslationGridView(ISettableGridView(Of T1))
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.SettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView<T1>)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).SettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T1))
+  nameWithType: SettableTranslationGridView<T1, T2>.SettableTranslationGridView(ISettableGridView<T1>)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).SettableTranslationGridView(ISettableGridView(Of T1))
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1})
+  name: SettableTranslationGridView(ISettableGridView<T1>, ISettableGridView<T2>)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_GridViews_ISettableGridView__1__
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.GridViews.ISettableGridView{`1})
+  name.vb: SettableTranslationGridView(ISettableGridView(Of T1), ISettableGridView(Of T2))
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.SettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView<T1>, SadRogue.Primitives.GridViews.ISettableGridView<T2>)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).SettableTranslationGridView(SadRogue.Primitives.GridViews.ISettableGridView(Of T1), SadRogue.Primitives.GridViews.ISettableGridView(Of T2))
+  nameWithType: SettableTranslationGridView<T1, T2>.SettableTranslationGridView(ISettableGridView<T1>, ISettableGridView<T2>)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).SettableTranslationGridView(ISettableGridView(Of T1), ISettableGridView(Of T2))
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor*
+  name: SettableTranslationGridView
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.SettableTranslationGridView
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).SettableTranslationGridView
+  nameWithType: SettableTranslationGridView<T1, T2>.SettableTranslationGridView
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).SettableTranslationGridView
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.BaseGrid
+  name: BaseGrid
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_BaseGrid
+  commentId: P:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.BaseGrid
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.BaseGrid
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).BaseGrid
+  nameWithType: SettableTranslationGridView<T1, T2>.BaseGrid
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).BaseGrid
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.BaseGrid*
+  name: BaseGrid
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_BaseGrid_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.BaseGrid
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.BaseGrid
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).BaseGrid
+  nameWithType: SettableTranslationGridView<T1, T2>.BaseGrid
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).BaseGrid
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Height
+  commentId: P:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Height
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).Height
+  nameWithType: SettableTranslationGridView<T1, T2>.Height
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).Height
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).Height
+  nameWithType: SettableTranslationGridView<T1, T2>.Height
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).Height
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).Item(SadRogue.Primitives.Point)
+  nameWithType: SettableTranslationGridView<T1, T2>.Item[Point]
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).Item(Point)
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).Item
+  nameWithType: SettableTranslationGridView<T1, T2>.Item
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).Item
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).ToString()
+  nameWithType: SettableTranslationGridView<T1, T2>.ToString()
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).ToString()
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString(System.Func{`1,System.String})
+  name: ToString(Func<T2, String>)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Func__1_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString(System.Func{`1,System.String})
+  name.vb: ToString(Func(Of T2, String))
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.ToString(System.Func<T2, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).ToString(System.Func(Of T2, System.String))
+  nameWithType: SettableTranslationGridView<T1, T2>.ToString(Func<T2, String>)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).ToString(Func(Of T2, String))
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString(System.Int32,System.Func{`1,System.String})
+  name: ToString(Int32, Func<T2, String>)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString(System.Int32,System.Func{`1,System.String})
+  name.vb: ToString(Int32, Func(Of T2, String))
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.ToString(System.Int32, System.Func<T2, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).ToString(System.Int32, System.Func(Of T2, System.String))
+  nameWithType: SettableTranslationGridView<T1, T2>.ToString(Int32, Func<T2, String>)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).ToString(Int32, Func(Of T2, String))
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).ToString
+  nameWithType: SettableTranslationGridView<T1, T2>.ToString
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).ToString
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet(`0)
+  name: TranslateGet(T1)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet__0_
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet(`0)
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.TranslateGet(T1)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).TranslateGet(T1)
+  nameWithType: SettableTranslationGridView<T1, T2>.TranslateGet(T1)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).TranslateGet(T1)
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  name: TranslateGet(Point, T1)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.TranslateGet(SadRogue.Primitives.Point, T1)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).TranslateGet(SadRogue.Primitives.Point, T1)
+  nameWithType: SettableTranslationGridView<T1, T2>.TranslateGet(Point, T1)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).TranslateGet(Point, T1)
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet*
+  name: TranslateGet
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateGet_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateGet
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.TranslateGet
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).TranslateGet
+  nameWithType: SettableTranslationGridView<T1, T2>.TranslateGet
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).TranslateGet
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet(`1)
+  name: TranslateSet(T2)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet__1_
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet(`1)
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.TranslateSet(T2)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).TranslateSet(T2)
+  nameWithType: SettableTranslationGridView<T1, T2>.TranslateSet(T2)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).TranslateSet(T2)
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet(SadRogue.Primitives.Point,`1)
+  name: TranslateSet(Point, T2)
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_SadRogue_Primitives_Point__1_
+  commentId: M:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet(SadRogue.Primitives.Point,`1)
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.TranslateSet(SadRogue.Primitives.Point, T2)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).TranslateSet(SadRogue.Primitives.Point, T2)
+  nameWithType: SettableTranslationGridView<T1, T2>.TranslateSet(Point, T2)
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).TranslateSet(Point, T2)
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet*
+  name: TranslateSet
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_TranslateSet_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.TranslateSet
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.TranslateSet
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).TranslateSet
+  nameWithType: SettableTranslationGridView<T1, T2>.TranslateSet
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).TranslateSet
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Width
+  commentId: P:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Width
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).Width
+  nameWithType: SettableTranslationGridView<T1, T2>.Width
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).Width
+- uid: SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.SettableTranslationGridView-2.html#SadRogue_Primitives_GridViews_SettableTranslationGridView_2_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableTranslationGridView`2.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableTranslationGridView<T1, T2>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.SettableTranslationGridView(Of T1, T2).Width
+  nameWithType: SettableTranslationGridView<T1, T2>.Width
+  nameWithType.vb: SettableTranslationGridView(Of T1, T2).Width
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1
+  name: SettableViewport<T>
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html
+  commentId: T:SadRogue.Primitives.GridViews.SettableViewport`1
+  name.vb: SettableViewport(Of T)
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T)
+  nameWithType: SettableViewport<T>
+  nameWithType.vb: SettableViewport(Of T)
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0})
+  name: SettableViewport(ISettableGridView<T>)
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__
+  commentId: M:SadRogue.Primitives.GridViews.SettableViewport`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0})
+  name.vb: SettableViewport(ISettableGridView(Of T))
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.SettableViewport(SadRogue.Primitives.GridViews.ISettableGridView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).SettableViewport(SadRogue.Primitives.GridViews.ISettableGridView(Of T))
+  nameWithType: SettableViewport<T>.SettableViewport(ISettableGridView<T>)
+  nameWithType.vb: SettableViewport(Of T).SettableViewport(ISettableGridView(Of T))
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.Rectangle)
+  name: SettableViewport(ISettableGridView<T>, Rectangle)
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1__ctor_SadRogue_Primitives_GridViews_ISettableGridView__0__SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.GridViews.SettableViewport`1.#ctor(SadRogue.Primitives.GridViews.ISettableGridView{`0},SadRogue.Primitives.Rectangle)
+  name.vb: SettableViewport(ISettableGridView(Of T), Rectangle)
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.SettableViewport(SadRogue.Primitives.GridViews.ISettableGridView<T>, SadRogue.Primitives.Rectangle)
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).SettableViewport(SadRogue.Primitives.GridViews.ISettableGridView(Of T), SadRogue.Primitives.Rectangle)
+  nameWithType: SettableViewport<T>.SettableViewport(ISettableGridView<T>, Rectangle)
+  nameWithType.vb: SettableViewport(Of T).SettableViewport(ISettableGridView(Of T), Rectangle)
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.#ctor*
+  name: SettableViewport
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableViewport`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.SettableViewport
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).SettableViewport
+  nameWithType: SettableViewport<T>.SettableViewport
+  nameWithType.vb: SettableViewport(Of T).SettableViewport
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.GridView
+  name: GridView
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1_GridView
+  commentId: P:SadRogue.Primitives.GridViews.SettableViewport`1.GridView
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.GridView
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).GridView
+  nameWithType: SettableViewport<T>.GridView
+  nameWithType.vb: SettableViewport(Of T).GridView
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.GridView*
+  name: GridView
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1_GridView_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableViewport`1.GridView
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.GridView
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).GridView
+  nameWithType: SettableViewport<T>.GridView
+  nameWithType.vb: SettableViewport(Of T).GridView
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.SettableViewport`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: SettableViewport<T>.Item[Point]
+  nameWithType.vb: SettableViewport(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.SettableViewport`1.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).Item(System.Int32)
+  nameWithType: SettableViewport<T>.Item[Int32]
+  nameWithType.vb: SettableViewport(Of T).Item(Int32)
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.Item(System.Int32,System.Int32)
+  name: Item[Int32, Int32]
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1_Item_System_Int32_System_Int32_
+  commentId: P:SadRogue.Primitives.GridViews.SettableViewport`1.Item(System.Int32,System.Int32)
+  name.vb: Item(Int32, Int32)
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.Item[System.Int32, System.Int32]
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).Item(System.Int32, System.Int32)
+  nameWithType: SettableViewport<T>.Item[Int32, Int32]
+  nameWithType.vb: SettableViewport(Of T).Item(Int32, Int32)
+- uid: SadRogue.Primitives.GridViews.SettableViewport`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.SettableViewport-1.html#SadRogue_Primitives_GridViews_SettableViewport_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.SettableViewport`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.SettableViewport<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.SettableViewport(Of T).Item
+  nameWithType: SettableViewport<T>.Item
+  nameWithType.vb: SettableViewport(Of T).Item
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2
+  name: TranslationGridView<T1, T2>
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html
+  commentId: T:SadRogue.Primitives.GridViews.TranslationGridView`2
+  name.vb: TranslationGridView(Of T1, T2)
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2)
+  nameWithType: TranslationGridView<T1, T2>
+  nameWithType.vb: TranslationGridView(Of T1, T2)
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0})
+  name: TranslationGridView(IGridView<T1>)
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2__ctor_SadRogue_Primitives_GridViews_IGridView__0__
+  commentId: M:SadRogue.Primitives.GridViews.TranslationGridView`2.#ctor(SadRogue.Primitives.GridViews.IGridView{`0})
+  name.vb: TranslationGridView(IGridView(Of T1))
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.TranslationGridView(SadRogue.Primitives.GridViews.IGridView<T1>)
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).TranslationGridView(SadRogue.Primitives.GridViews.IGridView(Of T1))
+  nameWithType: TranslationGridView<T1, T2>.TranslationGridView(IGridView<T1>)
+  nameWithType.vb: TranslationGridView(Of T1, T2).TranslationGridView(IGridView(Of T1))
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.#ctor*
+  name: TranslationGridView
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.TranslationGridView
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).TranslationGridView
+  nameWithType: TranslationGridView<T1, T2>.TranslationGridView
+  nameWithType.vb: TranslationGridView(Of T1, T2).TranslationGridView
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.BaseGrid
+  name: BaseGrid
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_BaseGrid
+  commentId: P:SadRogue.Primitives.GridViews.TranslationGridView`2.BaseGrid
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.BaseGrid
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).BaseGrid
+  nameWithType: TranslationGridView<T1, T2>.BaseGrid
+  nameWithType.vb: TranslationGridView(Of T1, T2).BaseGrid
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.BaseGrid*
+  name: BaseGrid
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_BaseGrid_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.BaseGrid
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.BaseGrid
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).BaseGrid
+  nameWithType: TranslationGridView<T1, T2>.BaseGrid
+  nameWithType.vb: TranslationGridView(Of T1, T2).BaseGrid
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Height
+  commentId: P:SadRogue.Primitives.GridViews.TranslationGridView`2.Height
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).Height
+  nameWithType: TranslationGridView<T1, T2>.Height
+  nameWithType.vb: TranslationGridView(Of T1, T2).Height
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).Height
+  nameWithType: TranslationGridView<T1, T2>.Height
+  nameWithType.vb: TranslationGridView(Of T1, T2).Height
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.TranslationGridView`2.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).Item(SadRogue.Primitives.Point)
+  nameWithType: TranslationGridView<T1, T2>.Item[Point]
+  nameWithType.vb: TranslationGridView(Of T1, T2).Item(Point)
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).Item
+  nameWithType: TranslationGridView<T1, T2>.Item
+  nameWithType.vb: TranslationGridView(Of T1, T2).Item
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString
+  commentId: M:SadRogue.Primitives.GridViews.TranslationGridView`2.ToString
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).ToString()
+  nameWithType: TranslationGridView<T1, T2>.ToString()
+  nameWithType.vb: TranslationGridView(Of T1, T2).ToString()
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.ToString(System.Func{`1,System.String})
+  name: ToString(Func<T2, String>)
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Func__1_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.TranslationGridView`2.ToString(System.Func{`1,System.String})
+  name.vb: ToString(Func(Of T2, String))
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.ToString(System.Func<T2, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).ToString(System.Func(Of T2, System.String))
+  nameWithType: TranslationGridView<T1, T2>.ToString(Func<T2, String>)
+  nameWithType.vb: TranslationGridView(Of T1, T2).ToString(Func(Of T2, String))
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.ToString(System.Int32,System.Func{`1,System.String})
+  name: ToString(Int32, Func<T2, String>)
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_System_Int32_System_Func__1_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.TranslationGridView`2.ToString(System.Int32,System.Func{`1,System.String})
+  name.vb: ToString(Int32, Func(Of T2, String))
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.ToString(System.Int32, System.Func<T2, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).ToString(System.Int32, System.Func(Of T2, System.String))
+  nameWithType: TranslationGridView<T1, T2>.ToString(Int32, Func<T2, String>)
+  nameWithType.vb: TranslationGridView(Of T1, T2).ToString(Int32, Func(Of T2, String))
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).ToString
+  nameWithType: TranslationGridView<T1, T2>.ToString
+  nameWithType.vb: TranslationGridView(Of T1, T2).ToString
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet(`0)
+  name: TranslateGet(T1)
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet__0_
+  commentId: M:SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet(`0)
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.TranslateGet(T1)
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).TranslateGet(T1)
+  nameWithType: TranslationGridView<T1, T2>.TranslateGet(T1)
+  nameWithType.vb: TranslationGridView(Of T1, T2).TranslateGet(T1)
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  name: TranslateGet(Point, T1)
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_SadRogue_Primitives_Point__0_
+  commentId: M:SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet(SadRogue.Primitives.Point,`0)
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.TranslateGet(SadRogue.Primitives.Point, T1)
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).TranslateGet(SadRogue.Primitives.Point, T1)
+  nameWithType: TranslationGridView<T1, T2>.TranslateGet(Point, T1)
+  nameWithType.vb: TranslationGridView(Of T1, T2).TranslateGet(Point, T1)
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet*
+  name: TranslateGet
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_TranslateGet_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.TranslateGet
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.TranslateGet
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).TranslateGet
+  nameWithType: TranslationGridView<T1, T2>.TranslateGet
+  nameWithType.vb: TranslationGridView(Of T1, T2).TranslateGet
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Width
+  commentId: P:SadRogue.Primitives.GridViews.TranslationGridView`2.Width
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).Width
+  nameWithType: TranslationGridView<T1, T2>.Width
+  nameWithType.vb: TranslationGridView(Of T1, T2).Width
+- uid: SadRogue.Primitives.GridViews.TranslationGridView`2.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.TranslationGridView-2.html#SadRogue_Primitives_GridViews_TranslationGridView_2_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.TranslationGridView`2.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.TranslationGridView<T1, T2>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.TranslationGridView(Of T1, T2).Width
+  nameWithType: TranslationGridView<T1, T2>.Width
+  nameWithType.vb: TranslationGridView(Of T1, T2).Width
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1
+  name: UnboundedViewport<T>
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html
+  commentId: T:SadRogue.Primitives.GridViews.UnboundedViewport`1
+  name.vb: UnboundedViewport(Of T)
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T)
+  nameWithType: UnboundedViewport<T>
+  nameWithType.vb: UnboundedViewport(Of T)
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},`0)
+  name: UnboundedViewport(IGridView<T>, T)
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0___0_
+  commentId: M:SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},`0)
+  name.vb: UnboundedViewport(IGridView(Of T), T)
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.UnboundedViewport(SadRogue.Primitives.GridViews.IGridView<T>, T)
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).UnboundedViewport(SadRogue.Primitives.GridViews.IGridView(Of T), T)
+  nameWithType: UnboundedViewport<T>.UnboundedViewport(IGridView<T>, T)
+  nameWithType.vb: UnboundedViewport(Of T).UnboundedViewport(IGridView(Of T), T)
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},SadRogue.Primitives.Rectangle,`0)
+  name: UnboundedViewport(IGridView<T>, Rectangle, T)
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__SadRogue_Primitives_Rectangle__0_
+  commentId: M:SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},SadRogue.Primitives.Rectangle,`0)
+  name.vb: UnboundedViewport(IGridView(Of T), Rectangle, T)
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.UnboundedViewport(SadRogue.Primitives.GridViews.IGridView<T>, SadRogue.Primitives.Rectangle, T)
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).UnboundedViewport(SadRogue.Primitives.GridViews.IGridView(Of T), SadRogue.Primitives.Rectangle, T)
+  nameWithType: UnboundedViewport<T>.UnboundedViewport(IGridView<T>, Rectangle, T)
+  nameWithType.vb: UnboundedViewport(Of T).UnboundedViewport(IGridView(Of T), Rectangle, T)
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor*
+  name: UnboundedViewport
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.UnboundedViewport
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).UnboundedViewport
+  nameWithType: UnboundedViewport<T>.UnboundedViewport
+  nameWithType.vb: UnboundedViewport(Of T).UnboundedViewport
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.DefaultValue
+  name: DefaultValue
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_DefaultValue
+  commentId: F:SadRogue.Primitives.GridViews.UnboundedViewport`1.DefaultValue
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.DefaultValue
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).DefaultValue
+  nameWithType: UnboundedViewport<T>.DefaultValue
+  nameWithType.vb: UnboundedViewport(Of T).DefaultValue
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.GridView
+  name: GridView
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_GridView
+  commentId: P:SadRogue.Primitives.GridViews.UnboundedViewport`1.GridView
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.GridView
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).GridView
+  nameWithType: UnboundedViewport<T>.GridView
+  nameWithType.vb: UnboundedViewport(Of T).GridView
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.GridView*
+  name: GridView
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_GridView_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.GridView
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.GridView
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).GridView
+  nameWithType: UnboundedViewport<T>.GridView
+  nameWithType.vb: UnboundedViewport(Of T).GridView
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.UnboundedViewport`1.Height
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).Height
+  nameWithType: UnboundedViewport<T>.Height
+  nameWithType.vb: UnboundedViewport(Of T).Height
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).Height
+  nameWithType: UnboundedViewport<T>.Height
+  nameWithType.vb: UnboundedViewport(Of T).Height
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.UnboundedViewport`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: UnboundedViewport<T>.Item[Point]
+  nameWithType.vb: UnboundedViewport(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).Item
+  nameWithType: UnboundedViewport<T>.Item
+  nameWithType.vb: UnboundedViewport(Of T).Item
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).ToString()
+  nameWithType: UnboundedViewport<T>.ToString()
+  nameWithType.vb: UnboundedViewport(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString(System.Func{`0,System.String})
+  name: ToString(Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString(System.Func{`0,System.String})
+  name.vb: ToString(Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.ToString(System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).ToString(System.Func(Of T, System.String))
+  nameWithType: UnboundedViewport<T>.ToString(Func<T, String>)
+  nameWithType.vb: UnboundedViewport(Of T).ToString(Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString(System.Int32,System.Func{`0,System.String})
+  name: ToString(Int32, Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_System_Int32_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString(System.Int32,System.Func{`0,System.String})
+  name.vb: ToString(Int32, Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.ToString(System.Int32, System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).ToString(System.Int32, System.Func(Of T, System.String))
+  nameWithType: UnboundedViewport<T>.ToString(Int32, Func<T, String>)
+  nameWithType.vb: UnboundedViewport(Of T).ToString(Int32, Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).ToString
+  nameWithType: UnboundedViewport<T>.ToString
+  nameWithType.vb: UnboundedViewport(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.ViewArea
+  name: ViewArea
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_ViewArea
+  commentId: P:SadRogue.Primitives.GridViews.UnboundedViewport`1.ViewArea
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.ViewArea
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).ViewArea
+  nameWithType: UnboundedViewport<T>.ViewArea
+  nameWithType.vb: UnboundedViewport(Of T).ViewArea
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.ViewArea*
+  name: ViewArea
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_ViewArea_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.ViewArea
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.ViewArea
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).ViewArea
+  nameWithType: UnboundedViewport<T>.ViewArea
+  nameWithType.vb: UnboundedViewport(Of T).ViewArea
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.UnboundedViewport`1.Width
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).Width
+  nameWithType: UnboundedViewport<T>.Width
+  nameWithType.vb: UnboundedViewport(Of T).Width
+- uid: SadRogue.Primitives.GridViews.UnboundedViewport`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.UnboundedViewport-1.html#SadRogue_Primitives_GridViews_UnboundedViewport_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.UnboundedViewport`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.UnboundedViewport<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.UnboundedViewport(Of T).Width
+  nameWithType: UnboundedViewport<T>.Width
+  nameWithType.vb: UnboundedViewport(Of T).Width
+- uid: SadRogue.Primitives.GridViews.ValueChange`1
+  name: ValueChange<T>
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html
+  commentId: T:SadRogue.Primitives.GridViews.ValueChange`1
+  name.vb: ValueChange(Of T)
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T)
+  nameWithType: ValueChange<T>
+  nameWithType.vb: ValueChange(Of T)
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.#ctor(SadRogue.Primitives.Point,`0,`0)
+  name: ValueChange(Point, T, T)
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1__ctor_SadRogue_Primitives_Point__0__0_
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.#ctor(SadRogue.Primitives.Point,`0,`0)
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.ValueChange(SadRogue.Primitives.Point, T, T)
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).ValueChange(SadRogue.Primitives.Point, T, T)
+  nameWithType: ValueChange<T>.ValueChange(Point, T, T)
+  nameWithType.vb: ValueChange(Of T).ValueChange(Point, T, T)
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.#ctor*
+  name: ValueChange
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.ValueChange
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).ValueChange
+  nameWithType: ValueChange<T>.ValueChange
+  nameWithType.vb: ValueChange(Of T).ValueChange
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.Equals(SadRogue.Primitives.GridViews.ValueChange{`0})
+  name: Equals(ValueChange<T>)
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_Equals_SadRogue_Primitives_GridViews_ValueChange__0__
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.Equals(SadRogue.Primitives.GridViews.ValueChange{`0})
+  name.vb: Equals(ValueChange(Of T))
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Equals(SadRogue.Primitives.GridViews.ValueChange<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Equals(SadRogue.Primitives.GridViews.ValueChange(Of T))
+  nameWithType: ValueChange<T>.Equals(ValueChange<T>)
+  nameWithType.vb: ValueChange(Of T).Equals(ValueChange(Of T))
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.Equals(System.Object)
+  name: Equals(Object)
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_Equals_System_Object_
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.Equals(System.Object)
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Equals(System.Object)
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Equals(System.Object)
+  nameWithType: ValueChange<T>.Equals(Object)
+  nameWithType.vb: ValueChange(Of T).Equals(Object)
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.Equals*
+  name: Equals
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_Equals_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.Equals
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Equals
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Equals
+  nameWithType: ValueChange<T>.Equals
+  nameWithType.vb: ValueChange(Of T).Equals
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.GetHashCode
+  name: GetHashCode()
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_GetHashCode
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.GetHashCode
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.GetHashCode()
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).GetHashCode()
+  nameWithType: ValueChange<T>.GetHashCode()
+  nameWithType.vb: ValueChange(Of T).GetHashCode()
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.GetHashCode*
+  name: GetHashCode
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_GetHashCode_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.GetHashCode
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.GetHashCode
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).GetHashCode
+  nameWithType: ValueChange<T>.GetHashCode
+  nameWithType.vb: ValueChange(Of T).GetHashCode
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.Matches(SadRogue.Primitives.GridViews.ValueChange{`0})
+  name: Matches(ValueChange<T>)
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_Matches_SadRogue_Primitives_GridViews_ValueChange__0__
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.Matches(SadRogue.Primitives.GridViews.ValueChange{`0})
+  name.vb: Matches(ValueChange(Of T))
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Matches(SadRogue.Primitives.GridViews.ValueChange<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Matches(SadRogue.Primitives.GridViews.ValueChange(Of T))
+  nameWithType: ValueChange<T>.Matches(ValueChange<T>)
+  nameWithType.vb: ValueChange(Of T).Matches(ValueChange(Of T))
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_Matches_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Matches
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Matches
+  nameWithType: ValueChange<T>.Matches
+  nameWithType.vb: ValueChange(Of T).Matches
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.NewValue
+  name: NewValue
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_NewValue
+  commentId: F:SadRogue.Primitives.GridViews.ValueChange`1.NewValue
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.NewValue
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).NewValue
+  nameWithType: ValueChange<T>.NewValue
+  nameWithType.vb: ValueChange(Of T).NewValue
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.OldValue
+  name: OldValue
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_OldValue
+  commentId: F:SadRogue.Primitives.GridViews.ValueChange`1.OldValue
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.OldValue
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).OldValue
+  nameWithType: ValueChange<T>.OldValue
+  nameWithType.vb: ValueChange(Of T).OldValue
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.op_Equality(SadRogue.Primitives.GridViews.ValueChange{`0},SadRogue.Primitives.GridViews.ValueChange{`0})
+  name: Equality(ValueChange<T>, ValueChange<T>)
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_op_Equality_SadRogue_Primitives_GridViews_ValueChange__0__SadRogue_Primitives_GridViews_ValueChange__0__
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.op_Equality(SadRogue.Primitives.GridViews.ValueChange{`0},SadRogue.Primitives.GridViews.ValueChange{`0})
+  name.vb: Equality(ValueChange(Of T), ValueChange(Of T))
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Equality(SadRogue.Primitives.GridViews.ValueChange<T>, SadRogue.Primitives.GridViews.ValueChange<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Equality(SadRogue.Primitives.GridViews.ValueChange(Of T), SadRogue.Primitives.GridViews.ValueChange(Of T))
+  nameWithType: ValueChange<T>.Equality(ValueChange<T>, ValueChange<T>)
+  nameWithType.vb: ValueChange(Of T).Equality(ValueChange(Of T), ValueChange(Of T))
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.op_Equality*
+  name: Equality
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_op_Equality_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.op_Equality
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Equality
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Equality
+  nameWithType: ValueChange<T>.Equality
+  nameWithType.vb: ValueChange(Of T).Equality
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.op_Inequality(SadRogue.Primitives.GridViews.ValueChange{`0},SadRogue.Primitives.GridViews.ValueChange{`0})
+  name: Inequality(ValueChange<T>, ValueChange<T>)
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_op_Inequality_SadRogue_Primitives_GridViews_ValueChange__0__SadRogue_Primitives_GridViews_ValueChange__0__
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.op_Inequality(SadRogue.Primitives.GridViews.ValueChange{`0},SadRogue.Primitives.GridViews.ValueChange{`0})
+  name.vb: Inequality(ValueChange(Of T), ValueChange(Of T))
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Inequality(SadRogue.Primitives.GridViews.ValueChange<T>, SadRogue.Primitives.GridViews.ValueChange<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Inequality(SadRogue.Primitives.GridViews.ValueChange(Of T), SadRogue.Primitives.GridViews.ValueChange(Of T))
+  nameWithType: ValueChange<T>.Inequality(ValueChange<T>, ValueChange<T>)
+  nameWithType.vb: ValueChange(Of T).Inequality(ValueChange(Of T), ValueChange(Of T))
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.op_Inequality*
+  name: Inequality
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_op_Inequality_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.op_Inequality
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Inequality
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Inequality
+  nameWithType: ValueChange<T>.Inequality
+  nameWithType.vb: ValueChange(Of T).Inequality
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.Position
+  name: Position
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_Position
+  commentId: F:SadRogue.Primitives.GridViews.ValueChange`1.Position
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.Position
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).Position
+  nameWithType: ValueChange<T>.Position
+  nameWithType.vb: ValueChange(Of T).Position
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.ValueChange`1.ToString
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).ToString()
+  nameWithType: ValueChange<T>.ToString()
+  nameWithType.vb: ValueChange(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.ValueChange`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.ValueChange-1.html#SadRogue_Primitives_GridViews_ValueChange_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.ValueChange`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.ValueChange<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.ValueChange(Of T).ToString
+  nameWithType: ValueChange<T>.ToString
+  nameWithType.vb: ValueChange(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.Viewport`1
+  name: Viewport<T>
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html
+  commentId: T:SadRogue.Primitives.GridViews.Viewport`1
+  name.vb: Viewport(Of T)
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T)
+  nameWithType: Viewport<T>
+  nameWithType.vb: Viewport(Of T)
+- uid: SadRogue.Primitives.GridViews.Viewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0})
+  name: Viewport(IGridView<T>)
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__
+  commentId: M:SadRogue.Primitives.GridViews.Viewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0})
+  name.vb: Viewport(IGridView(Of T))
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Viewport(SadRogue.Primitives.GridViews.IGridView<T>)
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Viewport(SadRogue.Primitives.GridViews.IGridView(Of T))
+  nameWithType: Viewport<T>.Viewport(IGridView<T>)
+  nameWithType.vb: Viewport(Of T).Viewport(IGridView(Of T))
+- uid: SadRogue.Primitives.GridViews.Viewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},SadRogue.Primitives.Rectangle)
+  name: Viewport(IGridView<T>, Rectangle)
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1__ctor_SadRogue_Primitives_GridViews_IGridView__0__SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.GridViews.Viewport`1.#ctor(SadRogue.Primitives.GridViews.IGridView{`0},SadRogue.Primitives.Rectangle)
+  name.vb: Viewport(IGridView(Of T), Rectangle)
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Viewport(SadRogue.Primitives.GridViews.IGridView<T>, SadRogue.Primitives.Rectangle)
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Viewport(SadRogue.Primitives.GridViews.IGridView(Of T), SadRogue.Primitives.Rectangle)
+  nameWithType: Viewport<T>.Viewport(IGridView<T>, Rectangle)
+  nameWithType.vb: Viewport(Of T).Viewport(IGridView(Of T), Rectangle)
+- uid: SadRogue.Primitives.GridViews.Viewport`1.#ctor*
+  name: Viewport
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1__ctor_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Viewport
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Viewport
+  nameWithType: Viewport<T>.Viewport
+  nameWithType.vb: Viewport(Of T).Viewport
+- uid: SadRogue.Primitives.GridViews.Viewport`1.GridView
+  name: GridView
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_GridView
+  commentId: P:SadRogue.Primitives.GridViews.Viewport`1.GridView
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.GridView
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).GridView
+  nameWithType: Viewport<T>.GridView
+  nameWithType.vb: Viewport(Of T).GridView
+- uid: SadRogue.Primitives.GridViews.Viewport`1.GridView*
+  name: GridView
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_GridView_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.GridView
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.GridView
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).GridView
+  nameWithType: Viewport<T>.GridView
+  nameWithType.vb: Viewport(Of T).GridView
+- uid: SadRogue.Primitives.GridViews.Viewport`1.Height
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Height
+  commentId: P:SadRogue.Primitives.GridViews.Viewport`1.Height
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Height
+  nameWithType: Viewport<T>.Height
+  nameWithType.vb: Viewport(Of T).Height
+- uid: SadRogue.Primitives.GridViews.Viewport`1.Height*
+  name: Height
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Height_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.Height
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Height
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Height
+  nameWithType: Viewport<T>.Height
+  nameWithType.vb: Viewport(Of T).Height
+- uid: SadRogue.Primitives.GridViews.Viewport`1.Item(SadRogue.Primitives.Point)
+  name: Item[Point]
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Item_SadRogue_Primitives_Point_
+  commentId: P:SadRogue.Primitives.GridViews.Viewport`1.Item(SadRogue.Primitives.Point)
+  name.vb: Item(Point)
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Item[SadRogue.Primitives.Point]
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Item(SadRogue.Primitives.Point)
+  nameWithType: Viewport<T>.Item[Point]
+  nameWithType.vb: Viewport(Of T).Item(Point)
+- uid: SadRogue.Primitives.GridViews.Viewport`1.Item*
+  name: Item
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Item_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.Item
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Item
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Item
+  nameWithType: Viewport<T>.Item
+  nameWithType.vb: Viewport(Of T).Item
+- uid: SadRogue.Primitives.GridViews.Viewport`1.SetViewArea(SadRogue.Primitives.Rectangle)
+  name: SetViewArea(Rectangle)
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.GridViews.Viewport`1.SetViewArea(SadRogue.Primitives.Rectangle)
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.SetViewArea(SadRogue.Primitives.Rectangle)
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).SetViewArea(SadRogue.Primitives.Rectangle)
+  nameWithType: Viewport<T>.SetViewArea(Rectangle)
+  nameWithType.vb: Viewport(Of T).SetViewArea(Rectangle)
+- uid: SadRogue.Primitives.GridViews.Viewport`1.SetViewArea*
+  name: SetViewArea
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_SetViewArea_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.SetViewArea
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.SetViewArea
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).SetViewArea
+  nameWithType: Viewport<T>.SetViewArea
+  nameWithType.vb: Viewport(Of T).SetViewArea
+- uid: SadRogue.Primitives.GridViews.Viewport`1.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString
+  commentId: M:SadRogue.Primitives.GridViews.Viewport`1.ToString
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.ToString()
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).ToString()
+  nameWithType: Viewport<T>.ToString()
+  nameWithType.vb: Viewport(Of T).ToString()
+- uid: SadRogue.Primitives.GridViews.Viewport`1.ToString(System.Func{`0,System.String})
+  name: ToString(Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.Viewport`1.ToString(System.Func{`0,System.String})
+  name.vb: ToString(Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.ToString(System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).ToString(System.Func(Of T, System.String))
+  nameWithType: Viewport<T>.ToString(Func<T, String>)
+  nameWithType.vb: Viewport(Of T).ToString(Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.Viewport`1.ToString(System.Int32,System.Func{`0,System.String})
+  name: ToString(Int32, Func<T, String>)
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString_System_Int32_System_Func__0_System_String__
+  commentId: M:SadRogue.Primitives.GridViews.Viewport`1.ToString(System.Int32,System.Func{`0,System.String})
+  name.vb: ToString(Int32, Func(Of T, String))
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.ToString(System.Int32, System.Func<T, System.String>)
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).ToString(System.Int32, System.Func(Of T, System.String))
+  nameWithType: Viewport<T>.ToString(Int32, Func<T, String>)
+  nameWithType.vb: Viewport(Of T).ToString(Int32, Func(Of T, String))
+- uid: SadRogue.Primitives.GridViews.Viewport`1.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ToString_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.ToString
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).ToString
+  nameWithType: Viewport<T>.ToString
+  nameWithType.vb: Viewport(Of T).ToString
+- uid: SadRogue.Primitives.GridViews.Viewport`1.ViewArea
+  name: ViewArea
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ViewArea
+  commentId: P:SadRogue.Primitives.GridViews.Viewport`1.ViewArea
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.ViewArea
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).ViewArea
+  nameWithType: Viewport<T>.ViewArea
+  nameWithType.vb: Viewport(Of T).ViewArea
+- uid: SadRogue.Primitives.GridViews.Viewport`1.ViewArea*
+  name: ViewArea
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_ViewArea_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.ViewArea
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.ViewArea
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).ViewArea
+  nameWithType: Viewport<T>.ViewArea
+  nameWithType.vb: Viewport(Of T).ViewArea
+- uid: SadRogue.Primitives.GridViews.Viewport`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Width
+  commentId: P:SadRogue.Primitives.GridViews.Viewport`1.Width
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Width
+  nameWithType: Viewport<T>.Width
+  nameWithType.vb: Viewport(Of T).Width
+- uid: SadRogue.Primitives.GridViews.Viewport`1.Width*
+  name: Width
+  href: api/SadRogue.Primitives.GridViews.Viewport-1.html#SadRogue_Primitives_GridViews_Viewport_1_Width_
+  commentId: Overload:SadRogue.Primitives.GridViews.Viewport`1.Width
+  isSpec: "True"
+  fullName: SadRogue.Primitives.GridViews.Viewport<T>.Width
+  fullName.vb: SadRogue.Primitives.GridViews.Viewport(Of T).Width
+  nameWithType: Viewport<T>.Width
+  nameWithType.vb: Viewport(Of T).Width
+- uid: SadRogue.Primitives.IMatchable`1
+  name: IMatchable<T>
+  href: api/SadRogue.Primitives.IMatchable-1.html
+  commentId: T:SadRogue.Primitives.IMatchable`1
+  name.vb: IMatchable(Of T)
+  fullName: SadRogue.Primitives.IMatchable<T>
+  fullName.vb: SadRogue.Primitives.IMatchable(Of T)
+  nameWithType: IMatchable<T>
+  nameWithType.vb: IMatchable(Of T)
+- uid: SadRogue.Primitives.IMatchable`1.Matches(`0)
+  name: Matches(T)
+  href: api/SadRogue.Primitives.IMatchable-1.html#SadRogue_Primitives_IMatchable_1_Matches__0_
+  commentId: M:SadRogue.Primitives.IMatchable`1.Matches(`0)
+  fullName: SadRogue.Primitives.IMatchable<T>.Matches(T)
+  fullName.vb: SadRogue.Primitives.IMatchable(Of T).Matches(T)
+  nameWithType: IMatchable<T>.Matches(T)
+  nameWithType.vb: IMatchable(Of T).Matches(T)
+- uid: SadRogue.Primitives.IMatchable`1.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.IMatchable-1.html#SadRogue_Primitives_IMatchable_1_Matches_
+  commentId: Overload:SadRogue.Primitives.IMatchable`1.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.IMatchable<T>.Matches
+  fullName.vb: SadRogue.Primitives.IMatchable(Of T).Matches
+  nameWithType: IMatchable<T>.Matches
+  nameWithType.vb: IMatchable(Of T).Matches
 - uid: SadRogue.Primitives.IReadOnlyArea
   name: IReadOnlyArea
   href: api/SadRogue.Primitives.IReadOnlyArea.html
@@ -3795,6 +5662,12 @@ references:
   commentId: M:SadRogue.Primitives.IReadOnlyArea.Contains(SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.IReadOnlyArea.Contains(SadRogue.Primitives.Point)
   nameWithType: IReadOnlyArea.Contains(Point)
+- uid: SadRogue.Primitives.IReadOnlyArea.Contains(System.Int32,System.Int32)
+  name: Contains(Int32, Int32)
+  href: api/SadRogue.Primitives.IReadOnlyArea.html#SadRogue_Primitives_IReadOnlyArea_Contains_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.IReadOnlyArea.Contains(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.IReadOnlyArea.Contains(System.Int32, System.Int32)
+  nameWithType: IReadOnlyArea.Contains(Int32, Int32)
 - uid: SadRogue.Primitives.IReadOnlyArea.Contains*
   name: Contains
   href: api/SadRogue.Primitives.IReadOnlyArea.html#SadRogue_Primitives_IReadOnlyArea_Contains_
@@ -3828,19 +5701,22 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.IReadOnlyArea.Intersects
   nameWithType: IReadOnlyArea.Intersects
-- uid: SadRogue.Primitives.IReadOnlyArea.Positions
-  name: Positions
-  href: api/SadRogue.Primitives.IReadOnlyArea.html#SadRogue_Primitives_IReadOnlyArea_Positions
-  commentId: P:SadRogue.Primitives.IReadOnlyArea.Positions
-  fullName: SadRogue.Primitives.IReadOnlyArea.Positions
-  nameWithType: IReadOnlyArea.Positions
-- uid: SadRogue.Primitives.IReadOnlyArea.Positions*
-  name: Positions
-  href: api/SadRogue.Primitives.IReadOnlyArea.html#SadRogue_Primitives_IReadOnlyArea_Positions_
-  commentId: Overload:SadRogue.Primitives.IReadOnlyArea.Positions
+- uid: SadRogue.Primitives.IReadOnlyArea.Item(System.Int32)
+  name: Item[Int32]
+  href: api/SadRogue.Primitives.IReadOnlyArea.html#SadRogue_Primitives_IReadOnlyArea_Item_System_Int32_
+  commentId: P:SadRogue.Primitives.IReadOnlyArea.Item(System.Int32)
+  name.vb: Item(Int32)
+  fullName: SadRogue.Primitives.IReadOnlyArea.Item[System.Int32]
+  fullName.vb: SadRogue.Primitives.IReadOnlyArea.Item(System.Int32)
+  nameWithType: IReadOnlyArea.Item[Int32]
+  nameWithType.vb: IReadOnlyArea.Item(Int32)
+- uid: SadRogue.Primitives.IReadOnlyArea.Item*
+  name: Item
+  href: api/SadRogue.Primitives.IReadOnlyArea.html#SadRogue_Primitives_IReadOnlyArea_Item_
+  commentId: Overload:SadRogue.Primitives.IReadOnlyArea.Item
   isSpec: "True"
-  fullName: SadRogue.Primitives.IReadOnlyArea.Positions
-  nameWithType: IReadOnlyArea.Positions
+  fullName: SadRogue.Primitives.IReadOnlyArea.Item
+  nameWithType: IReadOnlyArea.Item
 - uid: SadRogue.Primitives.MathHelpers
   name: MathHelpers
   href: api/SadRogue.Primitives.MathHelpers.html
@@ -3878,6 +5754,12 @@ references:
   commentId: F:SadRogue.Primitives.MathHelpers.DegreePctOfCircle
   fullName: SadRogue.Primitives.MathHelpers.DegreePctOfCircle
   nameWithType: MathHelpers.DegreePctOfCircle
+- uid: SadRogue.Primitives.MathHelpers.DegreesToRadiansConstant
+  name: DegreesToRadiansConstant
+  href: api/SadRogue.Primitives.MathHelpers.html#SadRogue_Primitives_MathHelpers_DegreesToRadiansConstant
+  commentId: F:SadRogue.Primitives.MathHelpers.DegreesToRadiansConstant
+  fullName: SadRogue.Primitives.MathHelpers.DegreesToRadiansConstant
+  nameWithType: MathHelpers.DegreesToRadiansConstant
 - uid: SadRogue.Primitives.MathHelpers.Lerp(System.Double,System.Double,System.Double)
   name: Lerp(Double, Double, Double)
   href: api/SadRogue.Primitives.MathHelpers.html#SadRogue_Primitives_MathHelpers_Lerp_System_Double_System_Double_System_Double_
@@ -3897,6 +5779,12 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.MathHelpers.Lerp
   nameWithType: MathHelpers.Lerp
+- uid: SadRogue.Primitives.MathHelpers.RadiansToDegreesConstant
+  name: RadiansToDegreesConstant
+  href: api/SadRogue.Primitives.MathHelpers.html#SadRogue_Primitives_MathHelpers_RadiansToDegreesConstant
+  commentId: F:SadRogue.Primitives.MathHelpers.RadiansToDegreesConstant
+  fullName: SadRogue.Primitives.MathHelpers.RadiansToDegreesConstant
+  nameWithType: MathHelpers.RadiansToDegreesConstant
 - uid: SadRogue.Primitives.MathHelpers.ToDegree(System.Double)
   name: ToDegree(Double)
   href: api/SadRogue.Primitives.MathHelpers.html#SadRogue_Primitives_MathHelpers_ToDegree_System_Double_
@@ -4032,6 +5920,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Palette.Length
   nameWithType: Palette.Length
+- uid: SadRogue.Primitives.Palette.Matches(SadRogue.Primitives.Palette)
+  name: Matches(Palette)
+  href: api/SadRogue.Primitives.Palette.html#SadRogue_Primitives_Palette_Matches_SadRogue_Primitives_Palette_
+  commentId: M:SadRogue.Primitives.Palette.Matches(SadRogue.Primitives.Palette)
+  fullName: SadRogue.Primitives.Palette.Matches(SadRogue.Primitives.Palette)
+  nameWithType: Palette.Matches(Palette)
+- uid: SadRogue.Primitives.Palette.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Palette.html#SadRogue_Primitives_Palette_Matches_
+  commentId: Overload:SadRogue.Primitives.Palette.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Palette.Matches
+  nameWithType: Palette.Matches
 - uid: SadRogue.Primitives.Palette.ShiftLeft
   name: ShiftLeft()
   href: api/SadRogue.Primitives.Palette.html#SadRogue_Primitives_Palette_ShiftLeft
@@ -4118,6 +6019,18 @@ references:
   commentId: M:SadRogue.Primitives.Point.BearingOfLine(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Point.BearingOfLine(SadRogue.Primitives.Point, SadRogue.Primitives.Point)
   nameWithType: Point.BearingOfLine(Point, Point)
+- uid: SadRogue.Primitives.Point.BearingOfLine(System.Int32,System.Int32)
+  name: BearingOfLine(Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_BearingOfLine_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.BearingOfLine(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.BearingOfLine(System.Int32, System.Int32)
+  nameWithType: Point.BearingOfLine(Int32, Int32)
+- uid: SadRogue.Primitives.Point.BearingOfLine(System.Int32,System.Int32,System.Int32,System.Int32)
+  name: BearingOfLine(Int32, Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_BearingOfLine_System_Int32_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.BearingOfLine(System.Int32,System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.BearingOfLine(System.Int32, System.Int32, System.Int32, System.Int32)
+  nameWithType: Point.BearingOfLine(Int32, Int32, Int32, Int32)
 - uid: SadRogue.Primitives.Point.BearingOfLine*
   name: BearingOfLine
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_BearingOfLine_
@@ -4181,6 +6094,18 @@ references:
   commentId: M:SadRogue.Primitives.Point.EuclideanDistanceMagnitude(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Point.EuclideanDistanceMagnitude(SadRogue.Primitives.Point, SadRogue.Primitives.Point)
   nameWithType: Point.EuclideanDistanceMagnitude(Point, Point)
+- uid: SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32,System.Int32)
+  name: EuclideanDistanceMagnitude(Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_EuclideanDistanceMagnitude_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32, System.Int32)
+  nameWithType: Point.EuclideanDistanceMagnitude(Int32, Int32)
+- uid: SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32,System.Int32,System.Int32,System.Int32)
+  name: EuclideanDistanceMagnitude(Int32, Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_EuclideanDistanceMagnitude_System_Int32_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32,System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.EuclideanDistanceMagnitude(System.Int32, System.Int32, System.Int32, System.Int32)
+  nameWithType: Point.EuclideanDistanceMagnitude(Int32, Int32, Int32, Int32)
 - uid: SadRogue.Primitives.Point.EuclideanDistanceMagnitude*
   name: EuclideanDistanceMagnitude
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_EuclideanDistanceMagnitude_
@@ -4214,12 +6139,40 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Point.GetHashCode
   nameWithType: Point.GetHashCode
+- uid: SadRogue.Primitives.Point.Matches(SadRogue.Primitives.Point)
+  name: Matches(Point)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Matches_SadRogue_Primitives_Point_
+  commentId: M:SadRogue.Primitives.Point.Matches(SadRogue.Primitives.Point)
+  fullName: SadRogue.Primitives.Point.Matches(SadRogue.Primitives.Point)
+  nameWithType: Point.Matches(Point)
+- uid: SadRogue.Primitives.Point.Matches(System.ValueTuple{System.Int32,System.Int32})
+  name: Matches((Int32 x, Int32 y))
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Matches_System_ValueTuple_System_Int32_System_Int32__
+  commentId: M:SadRogue.Primitives.Point.Matches(System.ValueTuple{System.Int32,System.Int32})
+  name.vb: Matches((x As Int32, y As Int32))
+  fullName: SadRogue.Primitives.Point.Matches(System.ValueTuple<System.Int32, System.Int32>)
+  fullName.vb: SadRogue.Primitives.Point.Matches(System.ValueTuple(Of System.Int32, System.Int32))
+  nameWithType: Point.Matches((Int32 x, Int32 y))
+  nameWithType.vb: Point.Matches((x As Int32, y As Int32))
+- uid: SadRogue.Primitives.Point.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Matches_
+  commentId: Overload:SadRogue.Primitives.Point.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Point.Matches
+  nameWithType: Point.Matches
 - uid: SadRogue.Primitives.Point.Midpoint(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   name: Midpoint(Point, Point)
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Midpoint_SadRogue_Primitives_Point_SadRogue_Primitives_Point_
   commentId: M:SadRogue.Primitives.Point.Midpoint(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Point.Midpoint(SadRogue.Primitives.Point, SadRogue.Primitives.Point)
   nameWithType: Point.Midpoint(Point, Point)
+- uid: SadRogue.Primitives.Point.Midpoint(System.Int32,System.Int32,System.Int32,System.Int32)
+  name: Midpoint(Int32, Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Midpoint_System_Int32_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.Midpoint(System.Int32,System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.Midpoint(System.Int32, System.Int32, System.Int32, System.Int32)
+  nameWithType: Point.Midpoint(Int32, Int32, Int32, Int32)
 - uid: SadRogue.Primitives.Point.Midpoint*
   name: Midpoint
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Midpoint_
@@ -4344,6 +6297,15 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Point.Equality
   nameWithType: Point.Equality
+- uid: SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.PolarCoordinate
+  name: Implicit(Point to PolarCoordinate)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_op_Implicit_SadRogue_Primitives_Point__SadRogue_Primitives_PolarCoordinate
+  commentId: M:SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.PolarCoordinate
+  name.vb: Widening(Point to PolarCoordinate)
+  fullName: SadRogue.Primitives.Point.Implicit(SadRogue.Primitives.Point to SadRogue.Primitives.PolarCoordinate)
+  fullName.vb: SadRogue.Primitives.Point.Widening(SadRogue.Primitives.Point to SadRogue.Primitives.PolarCoordinate)
+  nameWithType: Point.Implicit(Point to PolarCoordinate)
+  nameWithType.vb: Point.Widening(Point to PolarCoordinate)
 - uid: SadRogue.Primitives.Point.op_Implicit(SadRogue.Primitives.Point)~System.ValueTuple{System.Int32,System.Int32}
   name: Implicit(Point to (Int32 x, Int32 y))
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_op_Implicit_SadRogue_Primitives_Point__System_ValueTuple_System_Int32_System_Int32_
@@ -4489,6 +6451,31 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Point.Subtraction
   nameWithType: Point.Subtraction
+- uid: SadRogue.Primitives.Point.Rotate(System.Double)
+  name: Rotate(Double)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Rotate_System_Double_
+  commentId: M:SadRogue.Primitives.Point.Rotate(System.Double)
+  fullName: SadRogue.Primitives.Point.Rotate(System.Double)
+  nameWithType: Point.Rotate(Double)
+- uid: SadRogue.Primitives.Point.Rotate(System.Double,SadRogue.Primitives.Point)
+  name: Rotate(Double, Point)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Rotate_System_Double_SadRogue_Primitives_Point_
+  commentId: M:SadRogue.Primitives.Point.Rotate(System.Double,SadRogue.Primitives.Point)
+  fullName: SadRogue.Primitives.Point.Rotate(System.Double, SadRogue.Primitives.Point)
+  nameWithType: Point.Rotate(Double, Point)
+- uid: SadRogue.Primitives.Point.Rotate(System.Double,System.Int32,System.Int32)
+  name: Rotate(Double, Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Rotate_System_Double_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.Rotate(System.Double,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.Rotate(System.Double, System.Int32, System.Int32)
+  nameWithType: Point.Rotate(Double, Int32, Int32)
+- uid: SadRogue.Primitives.Point.Rotate*
+  name: Rotate
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Rotate_
+  commentId: Overload:SadRogue.Primitives.Point.Rotate
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Point.Rotate
+  nameWithType: Point.Rotate
 - uid: SadRogue.Primitives.Point.ToIndex(System.Int32)
   name: ToIndex(Int32)
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_ToIndex_System_Int32_
@@ -4508,6 +6495,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Point.ToIndex
   nameWithType: Point.ToIndex
+- uid: SadRogue.Primitives.Point.ToPolarCoordinate
+  name: ToPolarCoordinate()
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_ToPolarCoordinate
+  commentId: M:SadRogue.Primitives.Point.ToPolarCoordinate
+  fullName: SadRogue.Primitives.Point.ToPolarCoordinate()
+  nameWithType: Point.ToPolarCoordinate()
+- uid: SadRogue.Primitives.Point.ToPolarCoordinate*
+  name: ToPolarCoordinate
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_ToPolarCoordinate_
+  commentId: Overload:SadRogue.Primitives.Point.ToPolarCoordinate
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Point.ToPolarCoordinate
+  nameWithType: Point.ToPolarCoordinate
 - uid: SadRogue.Primitives.Point.ToString
   name: ToString()
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_ToString
@@ -4553,6 +6553,12 @@ references:
   commentId: M:SadRogue.Primitives.Point.Translate(SadRogue.Primitives.Point)
   fullName: SadRogue.Primitives.Point.Translate(SadRogue.Primitives.Point)
   nameWithType: Point.Translate(Point)
+- uid: SadRogue.Primitives.Point.Translate(System.Int32,System.Int32)
+  name: Translate(Int32, Int32)
+  href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Translate_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Point.Translate(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Point.Translate(System.Int32, System.Int32)
+  nameWithType: Point.Translate(Int32, Int32)
 - uid: SadRogue.Primitives.Point.Translate*
   name: Translate
   href: api/SadRogue.Primitives.Point.html#SadRogue_Primitives_Point_Translate_
@@ -4654,6 +6660,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.PointExtensions.Divide
   nameWithType: PointExtensions.Divide
+- uid: SadRogue.Primitives.PointExtensions.Matches(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
+  name: Matches(Point, Point)
+  href: api/SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Matches_SadRogue_Primitives_Point_SadRogue_Primitives_Point_
+  commentId: M:SadRogue.Primitives.PointExtensions.Matches(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
+  fullName: SadRogue.Primitives.PointExtensions.Matches(SadRogue.Primitives.Point, SadRogue.Primitives.Point)
+  nameWithType: PointExtensions.Matches(Point, Point)
+- uid: SadRogue.Primitives.PointExtensions.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Matches_
+  commentId: Overload:SadRogue.Primitives.PointExtensions.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PointExtensions.Matches
+  nameWithType: PointExtensions.Matches
 - uid: SadRogue.Primitives.PointExtensions.Multiply(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   name: Multiply(Point, Point)
   href: api/SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Multiply_SadRogue_Primitives_Point_SadRogue_Primitives_Point_
@@ -4679,6 +6698,12 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.PointExtensions.Multiply
   nameWithType: PointExtensions.Multiply
+- uid: SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)
+  name: Subtract(Point, Direction)
+  href: api/SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_
+  commentId: M:SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)
+  fullName: SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point, SadRogue.Primitives.Direction)
+  nameWithType: PointExtensions.Subtract(Point, Direction)
 - uid: SadRogue.Primitives.PointExtensions.Subtract(SadRogue.Primitives.Point,SadRogue.Primitives.Point)
   name: Subtract(Point, Point)
   href: api/SadRogue.Primitives.PointExtensions.html#SadRogue_Primitives_PointExtensions_Subtract_SadRogue_Primitives_Point_SadRogue_Primitives_Point_
@@ -4698,6 +6723,273 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.PointExtensions.Subtract
   nameWithType: PointExtensions.Subtract
+- uid: SadRogue.Primitives.PolarCoordinate
+  name: PolarCoordinate
+  href: api/SadRogue.Primitives.PolarCoordinate.html
+  commentId: T:SadRogue.Primitives.PolarCoordinate
+  fullName: SadRogue.Primitives.PolarCoordinate
+  nameWithType: PolarCoordinate
+- uid: SadRogue.Primitives.PolarCoordinate.#ctor(System.Double,System.Double)
+  name: PolarCoordinate(Double, Double)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate__ctor_System_Double_System_Double_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.#ctor(System.Double,System.Double)
+  fullName: SadRogue.Primitives.PolarCoordinate.PolarCoordinate(System.Double, System.Double)
+  nameWithType: PolarCoordinate.PolarCoordinate(Double, Double)
+- uid: SadRogue.Primitives.PolarCoordinate.#ctor*
+  name: PolarCoordinate
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate__ctor_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.#ctor
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.PolarCoordinate
+  nameWithType: PolarCoordinate.PolarCoordinate
+- uid: SadRogue.Primitives.PolarCoordinate.Deconstruct(System.Double@,System.Double@)
+  name: Deconstruct(out Double, out Double)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Deconstruct_System_Double__System_Double__
+  commentId: M:SadRogue.Primitives.PolarCoordinate.Deconstruct(System.Double@,System.Double@)
+  name.vb: Deconstruct(ByRef Double, ByRef Double)
+  fullName: SadRogue.Primitives.PolarCoordinate.Deconstruct(out System.Double, out System.Double)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Deconstruct(ByRef System.Double, ByRef System.Double)
+  nameWithType: PolarCoordinate.Deconstruct(out Double, out Double)
+  nameWithType.vb: PolarCoordinate.Deconstruct(ByRef Double, ByRef Double)
+- uid: SadRogue.Primitives.PolarCoordinate.Deconstruct*
+  name: Deconstruct
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Deconstruct_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.Deconstruct
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.Deconstruct
+  nameWithType: PolarCoordinate.Deconstruct
+- uid: SadRogue.Primitives.PolarCoordinate.Equals(SadRogue.Primitives.PolarCoordinate)
+  name: Equals(PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Equals_SadRogue_Primitives_PolarCoordinate_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.Equals(SadRogue.Primitives.PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Equals(SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Equals(PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.Equals(System.Object)
+  name: Equals(Object)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Equals_System_Object_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.Equals(System.Object)
+  fullName: SadRogue.Primitives.PolarCoordinate.Equals(System.Object)
+  nameWithType: PolarCoordinate.Equals(Object)
+- uid: SadRogue.Primitives.PolarCoordinate.Equals(System.ValueTuple{System.Double,System.Double})
+  name: Equals((Double radius, Double theta))
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Equals_System_ValueTuple_System_Double_System_Double__
+  commentId: M:SadRogue.Primitives.PolarCoordinate.Equals(System.ValueTuple{System.Double,System.Double})
+  name.vb: Equals((radius As Double, theta As Double))
+  fullName: SadRogue.Primitives.PolarCoordinate.Equals(System.ValueTuple<System.Double, System.Double>)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Equals(System.ValueTuple(Of System.Double, System.Double))
+  nameWithType: PolarCoordinate.Equals((Double radius, Double theta))
+  nameWithType.vb: PolarCoordinate.Equals((radius As Double, theta As Double))
+- uid: SadRogue.Primitives.PolarCoordinate.Equals*
+  name: Equals
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Equals_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.Equals
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.Equals
+  nameWithType: PolarCoordinate.Equals
+- uid: SadRogue.Primitives.PolarCoordinate.FromCartesian(SadRogue.Primitives.Point)
+  name: FromCartesian(Point)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_FromCartesian_SadRogue_Primitives_Point_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.FromCartesian(SadRogue.Primitives.Point)
+  fullName: SadRogue.Primitives.PolarCoordinate.FromCartesian(SadRogue.Primitives.Point)
+  nameWithType: PolarCoordinate.FromCartesian(Point)
+- uid: SadRogue.Primitives.PolarCoordinate.FromCartesian(System.Int32,System.Int32)
+  name: FromCartesian(Int32, Int32)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_FromCartesian_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.FromCartesian(System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.PolarCoordinate.FromCartesian(System.Int32, System.Int32)
+  nameWithType: PolarCoordinate.FromCartesian(Int32, Int32)
+- uid: SadRogue.Primitives.PolarCoordinate.FromCartesian*
+  name: FromCartesian
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_FromCartesian_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.FromCartesian
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.FromCartesian
+  nameWithType: PolarCoordinate.FromCartesian
+- uid: SadRogue.Primitives.PolarCoordinate.Functions
+  name: Functions
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Functions
+  commentId: P:SadRogue.Primitives.PolarCoordinate.Functions
+  fullName: SadRogue.Primitives.PolarCoordinate.Functions
+  nameWithType: PolarCoordinate.Functions
+- uid: SadRogue.Primitives.PolarCoordinate.Functions*
+  name: Functions
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Functions_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.Functions
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.Functions
+  nameWithType: PolarCoordinate.Functions
+- uid: SadRogue.Primitives.PolarCoordinate.GetHashCode
+  name: GetHashCode()
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_GetHashCode
+  commentId: M:SadRogue.Primitives.PolarCoordinate.GetHashCode
+  fullName: SadRogue.Primitives.PolarCoordinate.GetHashCode()
+  nameWithType: PolarCoordinate.GetHashCode()
+- uid: SadRogue.Primitives.PolarCoordinate.GetHashCode*
+  name: GetHashCode
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_GetHashCode_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.GetHashCode
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.GetHashCode
+  nameWithType: PolarCoordinate.GetHashCode
+- uid: SadRogue.Primitives.PolarCoordinate.Matches(SadRogue.Primitives.PolarCoordinate)
+  name: Matches(PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Matches_SadRogue_Primitives_PolarCoordinate_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.Matches(SadRogue.Primitives.PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Matches(SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Matches(PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.Matches(System.ValueTuple{System.Double,System.Double})
+  name: Matches((Double radius, Double theta))
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Matches_System_ValueTuple_System_Double_System_Double__
+  commentId: M:SadRogue.Primitives.PolarCoordinate.Matches(System.ValueTuple{System.Double,System.Double})
+  name.vb: Matches((radius As Double, theta As Double))
+  fullName: SadRogue.Primitives.PolarCoordinate.Matches(System.ValueTuple<System.Double, System.Double>)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Matches(System.ValueTuple(Of System.Double, System.Double))
+  nameWithType: PolarCoordinate.Matches((Double radius, Double theta))
+  nameWithType.vb: PolarCoordinate.Matches((radius As Double, theta As Double))
+- uid: SadRogue.Primitives.PolarCoordinate.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Matches_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.Matches
+  nameWithType: PolarCoordinate.Matches
+- uid: SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate,SadRogue.Primitives.PolarCoordinate)
+  name: Equality(PolarCoordinate, PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Equality_SadRogue_Primitives_PolarCoordinate_SadRogue_Primitives_PolarCoordinate_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate,SadRogue.Primitives.PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Equality(SadRogue.Primitives.PolarCoordinate, SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Equality(PolarCoordinate, PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate,System.ValueTuple{System.Double,System.Double})
+  name: Equality(PolarCoordinate, (Double radius, Double theta))
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Equality_SadRogue_Primitives_PolarCoordinate_System_ValueTuple_System_Double_System_Double__
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Equality(SadRogue.Primitives.PolarCoordinate,System.ValueTuple{System.Double,System.Double})
+  name.vb: Equality(PolarCoordinate, (radius As Double, theta As Double))
+  fullName: SadRogue.Primitives.PolarCoordinate.Equality(SadRogue.Primitives.PolarCoordinate, System.ValueTuple<System.Double, System.Double>)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Equality(SadRogue.Primitives.PolarCoordinate, System.ValueTuple(Of System.Double, System.Double))
+  nameWithType: PolarCoordinate.Equality(PolarCoordinate, (Double radius, Double theta))
+  nameWithType.vb: PolarCoordinate.Equality(PolarCoordinate, (radius As Double, theta As Double))
+- uid: SadRogue.Primitives.PolarCoordinate.op_Equality(System.ValueTuple{System.Double,System.Double},SadRogue.Primitives.PolarCoordinate)
+  name: Equality((Double radius, Double theta), PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Equality_System_ValueTuple_System_Double_System_Double__SadRogue_Primitives_PolarCoordinate_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Equality(System.ValueTuple{System.Double,System.Double},SadRogue.Primitives.PolarCoordinate)
+  name.vb: Equality((radius As Double, theta As Double), PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Equality(System.ValueTuple<System.Double, System.Double>, SadRogue.Primitives.PolarCoordinate)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Equality(System.ValueTuple(Of System.Double, System.Double), SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Equality((Double radius, Double theta), PolarCoordinate)
+  nameWithType.vb: PolarCoordinate.Equality((radius As Double, theta As Double), PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.op_Equality*
+  name: Equality
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Equality_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.op_Equality
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.Equality
+  nameWithType: PolarCoordinate.Equality
+- uid: SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.Point
+  name: Implicit(PolarCoordinate to Point)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Implicit_SadRogue_Primitives_PolarCoordinate__SadRogue_Primitives_Point
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.Point
+  name.vb: Widening(PolarCoordinate to Point)
+  fullName: SadRogue.Primitives.PolarCoordinate.Implicit(SadRogue.Primitives.PolarCoordinate to SadRogue.Primitives.Point)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Widening(SadRogue.Primitives.PolarCoordinate to SadRogue.Primitives.Point)
+  nameWithType: PolarCoordinate.Implicit(PolarCoordinate to Point)
+  nameWithType.vb: PolarCoordinate.Widening(PolarCoordinate to Point)
+- uid: SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~System.ValueTuple{System.Double,System.Double}
+  name: Implicit(PolarCoordinate to (Double radius, Double theta))
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Implicit_SadRogue_Primitives_PolarCoordinate__System_ValueTuple_System_Double_System_Double_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Implicit(SadRogue.Primitives.PolarCoordinate)~System.ValueTuple{System.Double,System.Double}
+  name.vb: Widening(PolarCoordinate to (radius As Double, theta As Double))
+  fullName: SadRogue.Primitives.PolarCoordinate.Implicit(SadRogue.Primitives.PolarCoordinate to System.ValueTuple<System.Double, System.Double>)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Widening(SadRogue.Primitives.PolarCoordinate to System.ValueTuple(Of System.Double, System.Double))
+  nameWithType: PolarCoordinate.Implicit(PolarCoordinate to (Double radius, Double theta))
+  nameWithType.vb: PolarCoordinate.Widening(PolarCoordinate to (radius As Double, theta As Double))
+- uid: SadRogue.Primitives.PolarCoordinate.op_Implicit(System.ValueTuple{System.Double,System.Double})~SadRogue.Primitives.PolarCoordinate
+  name: Implicit((Double radius, Double theta) to PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Implicit_System_ValueTuple_System_Double_System_Double___SadRogue_Primitives_PolarCoordinate
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Implicit(System.ValueTuple{System.Double,System.Double})~SadRogue.Primitives.PolarCoordinate
+  name.vb: Widening((radius As Double, theta As Double) to PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Implicit(System.ValueTuple<System.Double, System.Double> to SadRogue.Primitives.PolarCoordinate)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Widening(System.ValueTuple(Of System.Double, System.Double) to SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Implicit((Double radius, Double theta) to PolarCoordinate)
+  nameWithType.vb: PolarCoordinate.Widening((radius As Double, theta As Double) to PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.PolarCoordinate.Implicit
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Widening
+  nameWithType: PolarCoordinate.Implicit
+  nameWithType.vb: PolarCoordinate.Widening
+- uid: SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate,SadRogue.Primitives.PolarCoordinate)
+  name: Inequality(PolarCoordinate, PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Inequality_SadRogue_Primitives_PolarCoordinate_SadRogue_Primitives_PolarCoordinate_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate,SadRogue.Primitives.PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Inequality(SadRogue.Primitives.PolarCoordinate, SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Inequality(PolarCoordinate, PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate,System.ValueTuple{System.Double,System.Double})
+  name: Inequality(PolarCoordinate, (Double radius, Double theta))
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Inequality_SadRogue_Primitives_PolarCoordinate_System_ValueTuple_System_Double_System_Double__
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Inequality(SadRogue.Primitives.PolarCoordinate,System.ValueTuple{System.Double,System.Double})
+  name.vb: Inequality(PolarCoordinate, (radius As Double, theta As Double))
+  fullName: SadRogue.Primitives.PolarCoordinate.Inequality(SadRogue.Primitives.PolarCoordinate, System.ValueTuple<System.Double, System.Double>)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Inequality(SadRogue.Primitives.PolarCoordinate, System.ValueTuple(Of System.Double, System.Double))
+  nameWithType: PolarCoordinate.Inequality(PolarCoordinate, (Double radius, Double theta))
+  nameWithType.vb: PolarCoordinate.Inequality(PolarCoordinate, (radius As Double, theta As Double))
+- uid: SadRogue.Primitives.PolarCoordinate.op_Inequality(System.ValueTuple{System.Double,System.Double},SadRogue.Primitives.PolarCoordinate)
+  name: Inequality((Double radius, Double theta), PolarCoordinate)
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Inequality_System_ValueTuple_System_Double_System_Double__SadRogue_Primitives_PolarCoordinate_
+  commentId: M:SadRogue.Primitives.PolarCoordinate.op_Inequality(System.ValueTuple{System.Double,System.Double},SadRogue.Primitives.PolarCoordinate)
+  name.vb: Inequality((radius As Double, theta As Double), PolarCoordinate)
+  fullName: SadRogue.Primitives.PolarCoordinate.Inequality(System.ValueTuple<System.Double, System.Double>, SadRogue.Primitives.PolarCoordinate)
+  fullName.vb: SadRogue.Primitives.PolarCoordinate.Inequality(System.ValueTuple(Of System.Double, System.Double), SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinate.Inequality((Double radius, Double theta), PolarCoordinate)
+  nameWithType.vb: PolarCoordinate.Inequality((radius As Double, theta As Double), PolarCoordinate)
+- uid: SadRogue.Primitives.PolarCoordinate.op_Inequality*
+  name: Inequality
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_op_Inequality_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.op_Inequality
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.Inequality
+  nameWithType: PolarCoordinate.Inequality
+- uid: SadRogue.Primitives.PolarCoordinate.Radius
+  name: Radius
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Radius
+  commentId: F:SadRogue.Primitives.PolarCoordinate.Radius
+  fullName: SadRogue.Primitives.PolarCoordinate.Radius
+  nameWithType: PolarCoordinate.Radius
+- uid: SadRogue.Primitives.PolarCoordinate.Theta
+  name: Theta
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_Theta
+  commentId: F:SadRogue.Primitives.PolarCoordinate.Theta
+  fullName: SadRogue.Primitives.PolarCoordinate.Theta
+  nameWithType: PolarCoordinate.Theta
+- uid: SadRogue.Primitives.PolarCoordinate.ToCartesian
+  name: ToCartesian()
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_ToCartesian
+  commentId: M:SadRogue.Primitives.PolarCoordinate.ToCartesian
+  fullName: SadRogue.Primitives.PolarCoordinate.ToCartesian()
+  nameWithType: PolarCoordinate.ToCartesian()
+- uid: SadRogue.Primitives.PolarCoordinate.ToCartesian*
+  name: ToCartesian
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_ToCartesian_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.ToCartesian
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.ToCartesian
+  nameWithType: PolarCoordinate.ToCartesian
+- uid: SadRogue.Primitives.PolarCoordinate.ToString
+  name: ToString()
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_ToString
+  commentId: M:SadRogue.Primitives.PolarCoordinate.ToString
+  fullName: SadRogue.Primitives.PolarCoordinate.ToString()
+  nameWithType: PolarCoordinate.ToString()
+- uid: SadRogue.Primitives.PolarCoordinate.ToString*
+  name: ToString
+  href: api/SadRogue.Primitives.PolarCoordinate.html#SadRogue_Primitives_PolarCoordinate_ToString_
+  commentId: Overload:SadRogue.Primitives.PolarCoordinate.ToString
+  isSpec: "True"
+  fullName: SadRogue.Primitives.PolarCoordinate.ToString
+  nameWithType: PolarCoordinate.ToString
 - uid: SadRogue.Primitives.Radius
   name: Radius
   href: api/SadRogue.Primitives.Radius.html
@@ -4748,6 +7040,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Radius.GetHashCode
   nameWithType: Radius.GetHashCode
+- uid: SadRogue.Primitives.Radius.Matches(SadRogue.Primitives.Radius)
+  name: Matches(Radius)
+  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Matches_SadRogue_Primitives_Radius_
+  commentId: M:SadRogue.Primitives.Radius.Matches(SadRogue.Primitives.Radius)
+  fullName: SadRogue.Primitives.Radius.Matches(SadRogue.Primitives.Radius)
+  nameWithType: Radius.Matches(Radius)
+- uid: SadRogue.Primitives.Radius.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_Matches_
+  commentId: Overload:SadRogue.Primitives.Radius.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Radius.Matches
+  nameWithType: Radius.Matches
 - uid: SadRogue.Primitives.Radius.op_Equality(SadRogue.Primitives.Radius,SadRogue.Primitives.Radius)
   name: Equality(Radius, Radius)
   href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_op_Equality_SadRogue_Primitives_Radius_SadRogue_Primitives_Radius_
@@ -4779,6 +7084,24 @@ references:
   fullName.vb: SadRogue.Primitives.Radius.Widening(SadRogue.Primitives.Radius to SadRogue.Primitives.Distance)
   nameWithType: Radius.Implicit(Radius to Distance)
   nameWithType.vb: Radius.Widening(Radius to Distance)
+- uid: SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.Radius.Types
+  name: Implicit(Radius to Radius.Types)
+  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius__SadRogue_Primitives_Radius_Types
+  commentId: M:SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius)~SadRogue.Primitives.Radius.Types
+  name.vb: Widening(Radius to Radius.Types)
+  fullName: SadRogue.Primitives.Radius.Implicit(SadRogue.Primitives.Radius to SadRogue.Primitives.Radius.Types)
+  fullName.vb: SadRogue.Primitives.Radius.Widening(SadRogue.Primitives.Radius to SadRogue.Primitives.Radius.Types)
+  nameWithType: Radius.Implicit(Radius to Radius.Types)
+  nameWithType.vb: Radius.Widening(Radius to Radius.Types)
+- uid: SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius.Types)~SadRogue.Primitives.Radius
+  name: Implicit(Radius.Types to Radius)
+  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_op_Implicit_SadRogue_Primitives_Radius_Types__SadRogue_Primitives_Radius
+  commentId: M:SadRogue.Primitives.Radius.op_Implicit(SadRogue.Primitives.Radius.Types)~SadRogue.Primitives.Radius
+  name.vb: Widening(Radius.Types to Radius)
+  fullName: SadRogue.Primitives.Radius.Implicit(SadRogue.Primitives.Radius.Types to SadRogue.Primitives.Radius)
+  fullName.vb: SadRogue.Primitives.Radius.Widening(SadRogue.Primitives.Radius.Types to SadRogue.Primitives.Radius)
+  nameWithType: Radius.Implicit(Radius.Types to Radius)
+  nameWithType.vb: Radius.Widening(Radius.Types to Radius)
 - uid: SadRogue.Primitives.Radius.op_Implicit*
   name: Implicit
   href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_op_Implicit_
@@ -4820,6 +7143,18 @@ references:
   commentId: M:SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.RadiusLocationContext)
   fullName: SadRogue.Primitives.Radius.PositionsInRadius(SadRogue.Primitives.RadiusLocationContext)
   nameWithType: Radius.PositionsInRadius(RadiusLocationContext)
+- uid: SadRogue.Primitives.Radius.PositionsInRadius(System.Int32,System.Int32,System.Int32)
+  name: PositionsInRadius(Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.Radius.PositionsInRadius(System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.Radius.PositionsInRadius(System.Int32, System.Int32, System.Int32)
+  nameWithType: Radius.PositionsInRadius(Int32, Int32, Int32)
+- uid: SadRogue.Primitives.Radius.PositionsInRadius(System.Int32,System.Int32,System.Int32,SadRogue.Primitives.Rectangle)
+  name: PositionsInRadius(Int32, Int32, Int32, Rectangle)
+  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.Radius.PositionsInRadius(System.Int32,System.Int32,System.Int32,SadRogue.Primitives.Rectangle)
+  fullName: SadRogue.Primitives.Radius.PositionsInRadius(System.Int32, System.Int32, System.Int32, SadRogue.Primitives.Rectangle)
+  nameWithType: Radius.PositionsInRadius(Int32, Int32, Int32, Rectangle)
 - uid: SadRogue.Primitives.Radius.PositionsInRadius*
   name: PositionsInRadius
   href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_PositionsInRadius_
@@ -4833,19 +7168,6 @@ references:
   commentId: F:SadRogue.Primitives.Radius.Square
   fullName: SadRogue.Primitives.Radius.Square
   nameWithType: Radius.Square
-- uid: SadRogue.Primitives.Radius.ToRadius(SadRogue.Primitives.Radius.Types)
-  name: ToRadius(Radius.Types)
-  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_ToRadius_SadRogue_Primitives_Radius_Types_
-  commentId: M:SadRogue.Primitives.Radius.ToRadius(SadRogue.Primitives.Radius.Types)
-  fullName: SadRogue.Primitives.Radius.ToRadius(SadRogue.Primitives.Radius.Types)
-  nameWithType: Radius.ToRadius(Radius.Types)
-- uid: SadRogue.Primitives.Radius.ToRadius*
-  name: ToRadius
-  href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_ToRadius_
-  commentId: Overload:SadRogue.Primitives.Radius.ToRadius
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Radius.ToRadius
-  nameWithType: Radius.ToRadius
 - uid: SadRogue.Primitives.Radius.ToString
   name: ToString()
   href: api/SadRogue.Primitives.Radius.html#SadRogue_Primitives_Radius_ToString
@@ -4907,6 +7229,18 @@ references:
   commentId: M:SadRogue.Primitives.RadiusLocationContext.#ctor(SadRogue.Primitives.Point,System.Int32,SadRogue.Primitives.Rectangle)
   fullName: SadRogue.Primitives.RadiusLocationContext.RadiusLocationContext(SadRogue.Primitives.Point, System.Int32, SadRogue.Primitives.Rectangle)
   nameWithType: RadiusLocationContext.RadiusLocationContext(Point, Int32, Rectangle)
+- uid: SadRogue.Primitives.RadiusLocationContext.#ctor(System.Int32,System.Int32,System.Int32)
+  name: RadiusLocationContext(Int32, Int32, Int32)
+  href: api/SadRogue.Primitives.RadiusLocationContext.html#SadRogue_Primitives_RadiusLocationContext__ctor_System_Int32_System_Int32_System_Int32_
+  commentId: M:SadRogue.Primitives.RadiusLocationContext.#ctor(System.Int32,System.Int32,System.Int32)
+  fullName: SadRogue.Primitives.RadiusLocationContext.RadiusLocationContext(System.Int32, System.Int32, System.Int32)
+  nameWithType: RadiusLocationContext.RadiusLocationContext(Int32, Int32, Int32)
+- uid: SadRogue.Primitives.RadiusLocationContext.#ctor(System.Int32,System.Int32,System.Int32,SadRogue.Primitives.Rectangle)
+  name: RadiusLocationContext(Int32, Int32, Int32, Rectangle)
+  href: api/SadRogue.Primitives.RadiusLocationContext.html#SadRogue_Primitives_RadiusLocationContext__ctor_System_Int32_System_Int32_System_Int32_SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.RadiusLocationContext.#ctor(System.Int32,System.Int32,System.Int32,SadRogue.Primitives.Rectangle)
+  fullName: SadRogue.Primitives.RadiusLocationContext.RadiusLocationContext(System.Int32, System.Int32, System.Int32, SadRogue.Primitives.Rectangle)
+  nameWithType: RadiusLocationContext.RadiusLocationContext(Int32, Int32, Int32, Rectangle)
 - uid: SadRogue.Primitives.RadiusLocationContext.#ctor*
   name: RadiusLocationContext
   href: api/SadRogue.Primitives.RadiusLocationContext.html#SadRogue_Primitives_RadiusLocationContext__ctor_
@@ -4990,19 +7324,58 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.Area
   nameWithType: Rectangle.Area
-- uid: SadRogue.Primitives.Rectangle.BottomEdgePositions
-  name: BottomEdgePositions()
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BottomEdgePositions
-  commentId: M:SadRogue.Primitives.Rectangle.BottomEdgePositions
-  fullName: SadRogue.Primitives.Rectangle.BottomEdgePositions()
-  nameWithType: Rectangle.BottomEdgePositions()
-- uid: SadRogue.Primitives.Rectangle.BottomEdgePositions*
-  name: BottomEdgePositions
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BottomEdgePositions_
-  commentId: Overload:SadRogue.Primitives.Rectangle.BottomEdgePositions
+- uid: SadRogue.Primitives.Rectangle.Bisect
+  name: Bisect()
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Bisect
+  commentId: M:SadRogue.Primitives.Rectangle.Bisect
+  fullName: SadRogue.Primitives.Rectangle.Bisect()
+  nameWithType: Rectangle.Bisect()
+- uid: SadRogue.Primitives.Rectangle.Bisect*
+  name: Bisect
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Bisect_
+  commentId: Overload:SadRogue.Primitives.Rectangle.Bisect
   isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.BottomEdgePositions
-  nameWithType: Rectangle.BottomEdgePositions
+  fullName: SadRogue.Primitives.Rectangle.Bisect
+  nameWithType: Rectangle.Bisect
+- uid: SadRogue.Primitives.Rectangle.BisectHorizontally
+  name: BisectHorizontally()
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BisectHorizontally
+  commentId: M:SadRogue.Primitives.Rectangle.BisectHorizontally
+  fullName: SadRogue.Primitives.Rectangle.BisectHorizontally()
+  nameWithType: Rectangle.BisectHorizontally()
+- uid: SadRogue.Primitives.Rectangle.BisectHorizontally*
+  name: BisectHorizontally
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BisectHorizontally_
+  commentId: Overload:SadRogue.Primitives.Rectangle.BisectHorizontally
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.BisectHorizontally
+  nameWithType: Rectangle.BisectHorizontally
+- uid: SadRogue.Primitives.Rectangle.BisectRecursive(System.Int32)
+  name: BisectRecursive(Int32)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BisectRecursive_System_Int32_
+  commentId: M:SadRogue.Primitives.Rectangle.BisectRecursive(System.Int32)
+  fullName: SadRogue.Primitives.Rectangle.BisectRecursive(System.Int32)
+  nameWithType: Rectangle.BisectRecursive(Int32)
+- uid: SadRogue.Primitives.Rectangle.BisectRecursive*
+  name: BisectRecursive
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BisectRecursive_
+  commentId: Overload:SadRogue.Primitives.Rectangle.BisectRecursive
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.BisectRecursive
+  nameWithType: Rectangle.BisectRecursive
+- uid: SadRogue.Primitives.Rectangle.BisectVertically
+  name: BisectVertically()
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BisectVertically
+  commentId: M:SadRogue.Primitives.Rectangle.BisectVertically
+  fullName: SadRogue.Primitives.Rectangle.BisectVertically()
+  nameWithType: Rectangle.BisectVertically()
+- uid: SadRogue.Primitives.Rectangle.BisectVertically*
+  name: BisectVertically
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_BisectVertically_
+  commentId: Overload:SadRogue.Primitives.Rectangle.BisectVertically
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.BisectVertically
+  nameWithType: Rectangle.BisectVertically
 - uid: SadRogue.Primitives.Rectangle.Center
   name: Center
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Center
@@ -5029,6 +7402,25 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.ChangeHeight
   nameWithType: Rectangle.ChangeHeight
+- uid: SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Direction)
+  name: ChangePosition(Direction)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangePosition_SadRogue_Primitives_Direction_
+  commentId: M:SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Direction)
+  fullName: SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Direction)
+  nameWithType: Rectangle.ChangePosition(Direction)
+- uid: SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Point)
+  name: ChangePosition(Point)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangePosition_SadRogue_Primitives_Point_
+  commentId: M:SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Point)
+  fullName: SadRogue.Primitives.Rectangle.ChangePosition(SadRogue.Primitives.Point)
+  nameWithType: Rectangle.ChangePosition(Point)
+- uid: SadRogue.Primitives.Rectangle.ChangePosition*
+  name: ChangePosition
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangePosition_
+  commentId: Overload:SadRogue.Primitives.Rectangle.ChangePosition
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.ChangePosition
+  nameWithType: Rectangle.ChangePosition
 - uid: SadRogue.Primitives.Rectangle.ChangeSize(SadRogue.Primitives.Point)
   name: ChangeSize(Point)
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangeSize_SadRogue_Primitives_Point_
@@ -5055,6 +7447,32 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.ChangeWidth
   nameWithType: Rectangle.ChangeWidth
+- uid: SadRogue.Primitives.Rectangle.ChangeX(System.Int32)
+  name: ChangeX(Int32)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangeX_System_Int32_
+  commentId: M:SadRogue.Primitives.Rectangle.ChangeX(System.Int32)
+  fullName: SadRogue.Primitives.Rectangle.ChangeX(System.Int32)
+  nameWithType: Rectangle.ChangeX(Int32)
+- uid: SadRogue.Primitives.Rectangle.ChangeX*
+  name: ChangeX
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangeX_
+  commentId: Overload:SadRogue.Primitives.Rectangle.ChangeX
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.ChangeX
+  nameWithType: Rectangle.ChangeX
+- uid: SadRogue.Primitives.Rectangle.ChangeY(System.Int32)
+  name: ChangeY(Int32)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangeY_System_Int32_
+  commentId: M:SadRogue.Primitives.Rectangle.ChangeY(System.Int32)
+  fullName: SadRogue.Primitives.Rectangle.ChangeY(System.Int32)
+  nameWithType: Rectangle.ChangeY(Int32)
+- uid: SadRogue.Primitives.Rectangle.ChangeY*
+  name: ChangeY
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ChangeY_
+  commentId: Overload:SadRogue.Primitives.Rectangle.ChangeY
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.ChangeY
+  nameWithType: Rectangle.ChangeY
 - uid: SadRogue.Primitives.Rectangle.Contains(SadRogue.Primitives.Point)
   name: Contains(Point)
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Contains_SadRogue_Primitives_Point_
@@ -5099,6 +7517,19 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.Deconstruct
   nameWithType: Rectangle.Deconstruct
+- uid: SadRogue.Primitives.Rectangle.Divide(SadRogue.Primitives.Rectangle)
+  name: Divide(Rectangle)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Divide_SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.Rectangle.Divide(SadRogue.Primitives.Rectangle)
+  fullName: SadRogue.Primitives.Rectangle.Divide(SadRogue.Primitives.Rectangle)
+  nameWithType: Rectangle.Divide(Rectangle)
+- uid: SadRogue.Primitives.Rectangle.Divide*
+  name: Divide
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Divide_
+  commentId: Overload:SadRogue.Primitives.Rectangle.Divide
+  isSpec: "True"
+  fullName: SadRogue.Primitives.Rectangle.Divide
+  nameWithType: Rectangle.Divide
 - uid: SadRogue.Primitives.Rectangle.Empty
   name: Empty
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Empty
@@ -5252,71 +7683,50 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.IsEmpty
   nameWithType: Rectangle.IsEmpty
-- uid: SadRogue.Primitives.Rectangle.IsOnBottomEdge(SadRogue.Primitives.Point)
-  name: IsOnBottomEdge(Point)
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnBottomEdge_SadRogue_Primitives_Point_
-  commentId: M:SadRogue.Primitives.Rectangle.IsOnBottomEdge(SadRogue.Primitives.Point)
-  fullName: SadRogue.Primitives.Rectangle.IsOnBottomEdge(SadRogue.Primitives.Point)
-  nameWithType: Rectangle.IsOnBottomEdge(Point)
-- uid: SadRogue.Primitives.Rectangle.IsOnBottomEdge*
-  name: IsOnBottomEdge
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnBottomEdge_
-  commentId: Overload:SadRogue.Primitives.Rectangle.IsOnBottomEdge
+- uid: SadRogue.Primitives.Rectangle.IsOnSide(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)
+  name: IsOnSide(Point, Direction)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnSide_SadRogue_Primitives_Point_SadRogue_Primitives_Direction_
+  commentId: M:SadRogue.Primitives.Rectangle.IsOnSide(SadRogue.Primitives.Point,SadRogue.Primitives.Direction)
+  fullName: SadRogue.Primitives.Rectangle.IsOnSide(SadRogue.Primitives.Point, SadRogue.Primitives.Direction)
+  nameWithType: Rectangle.IsOnSide(Point, Direction)
+- uid: SadRogue.Primitives.Rectangle.IsOnSide*
+  name: IsOnSide
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnSide_
+  commentId: Overload:SadRogue.Primitives.Rectangle.IsOnSide
   isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.IsOnBottomEdge
-  nameWithType: Rectangle.IsOnBottomEdge
-- uid: SadRogue.Primitives.Rectangle.IsOnLeftEdge(SadRogue.Primitives.Point)
-  name: IsOnLeftEdge(Point)
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnLeftEdge_SadRogue_Primitives_Point_
-  commentId: M:SadRogue.Primitives.Rectangle.IsOnLeftEdge(SadRogue.Primitives.Point)
-  fullName: SadRogue.Primitives.Rectangle.IsOnLeftEdge(SadRogue.Primitives.Point)
-  nameWithType: Rectangle.IsOnLeftEdge(Point)
-- uid: SadRogue.Primitives.Rectangle.IsOnLeftEdge*
-  name: IsOnLeftEdge
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnLeftEdge_
-  commentId: Overload:SadRogue.Primitives.Rectangle.IsOnLeftEdge
+  fullName: SadRogue.Primitives.Rectangle.IsOnSide
+  nameWithType: Rectangle.IsOnSide
+- uid: SadRogue.Primitives.Rectangle.Matches(SadRogue.Primitives.Rectangle)
+  name: Matches(Rectangle)
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Matches_SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.Rectangle.Matches(SadRogue.Primitives.Rectangle)
+  fullName: SadRogue.Primitives.Rectangle.Matches(SadRogue.Primitives.Rectangle)
+  nameWithType: Rectangle.Matches(Rectangle)
+- uid: SadRogue.Primitives.Rectangle.Matches(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})
+  name: Matches((Point minExtent, Point maxExtent))
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Matches_System_ValueTuple_SadRogue_Primitives_Point_SadRogue_Primitives_Point__
+  commentId: M:SadRogue.Primitives.Rectangle.Matches(System.ValueTuple{SadRogue.Primitives.Point,SadRogue.Primitives.Point})
+  name.vb: Matches((minExtent As Point, maxExtent As Point))
+  fullName: SadRogue.Primitives.Rectangle.Matches(System.ValueTuple<SadRogue.Primitives.Point, SadRogue.Primitives.Point>)
+  fullName.vb: SadRogue.Primitives.Rectangle.Matches(System.ValueTuple(Of SadRogue.Primitives.Point, SadRogue.Primitives.Point))
+  nameWithType: Rectangle.Matches((Point minExtent, Point maxExtent))
+  nameWithType.vb: Rectangle.Matches((minExtent As Point, maxExtent As Point))
+- uid: SadRogue.Primitives.Rectangle.Matches(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})
+  name: Matches((Int32 x, Int32 y, Int32 width, Int32 height))
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Matches_System_ValueTuple_System_Int32_System_Int32_System_Int32_System_Int32__
+  commentId: M:SadRogue.Primitives.Rectangle.Matches(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32})
+  name.vb: Matches((x As Int32, y As Int32, width As Int32, height As Int32))
+  fullName: SadRogue.Primitives.Rectangle.Matches(System.ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32>)
+  fullName.vb: SadRogue.Primitives.Rectangle.Matches(System.ValueTuple(Of System.Int32, System.Int32, System.Int32, System.Int32))
+  nameWithType: Rectangle.Matches((Int32 x, Int32 y, Int32 width, Int32 height))
+  nameWithType.vb: Rectangle.Matches((x As Int32, y As Int32, width As Int32, height As Int32))
+- uid: SadRogue.Primitives.Rectangle.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Matches_
+  commentId: Overload:SadRogue.Primitives.Rectangle.Matches
   isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.IsOnLeftEdge
-  nameWithType: Rectangle.IsOnLeftEdge
-- uid: SadRogue.Primitives.Rectangle.IsOnRightEdge(SadRogue.Primitives.Point)
-  name: IsOnRightEdge(Point)
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnRightEdge_SadRogue_Primitives_Point_
-  commentId: M:SadRogue.Primitives.Rectangle.IsOnRightEdge(SadRogue.Primitives.Point)
-  fullName: SadRogue.Primitives.Rectangle.IsOnRightEdge(SadRogue.Primitives.Point)
-  nameWithType: Rectangle.IsOnRightEdge(Point)
-- uid: SadRogue.Primitives.Rectangle.IsOnRightEdge*
-  name: IsOnRightEdge
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnRightEdge_
-  commentId: Overload:SadRogue.Primitives.Rectangle.IsOnRightEdge
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.IsOnRightEdge
-  nameWithType: Rectangle.IsOnRightEdge
-- uid: SadRogue.Primitives.Rectangle.IsOnTopEdge(SadRogue.Primitives.Point)
-  name: IsOnTopEdge(Point)
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnTopEdge_SadRogue_Primitives_Point_
-  commentId: M:SadRogue.Primitives.Rectangle.IsOnTopEdge(SadRogue.Primitives.Point)
-  fullName: SadRogue.Primitives.Rectangle.IsOnTopEdge(SadRogue.Primitives.Point)
-  nameWithType: Rectangle.IsOnTopEdge(Point)
-- uid: SadRogue.Primitives.Rectangle.IsOnTopEdge*
-  name: IsOnTopEdge
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_IsOnTopEdge_
-  commentId: Overload:SadRogue.Primitives.Rectangle.IsOnTopEdge
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.IsOnTopEdge
-  nameWithType: Rectangle.IsOnTopEdge
-- uid: SadRogue.Primitives.Rectangle.LeftEdgePositions
-  name: LeftEdgePositions()
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_LeftEdgePositions
-  commentId: M:SadRogue.Primitives.Rectangle.LeftEdgePositions
-  fullName: SadRogue.Primitives.Rectangle.LeftEdgePositions()
-  nameWithType: Rectangle.LeftEdgePositions()
-- uid: SadRogue.Primitives.Rectangle.LeftEdgePositions*
-  name: LeftEdgePositions
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_LeftEdgePositions_
-  commentId: Overload:SadRogue.Primitives.Rectangle.LeftEdgePositions
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.LeftEdgePositions
-  nameWithType: Rectangle.LeftEdgePositions
+  fullName: SadRogue.Primitives.Rectangle.Matches
+  nameWithType: Rectangle.Matches
 - uid: SadRogue.Primitives.Rectangle.MaxExtent
   name: MaxExtent
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_MaxExtent
@@ -5643,19 +8053,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.PositionsOnSide
   nameWithType: Rectangle.PositionsOnSide
-- uid: SadRogue.Primitives.Rectangle.RightEdgePositions
-  name: RightEdgePositions()
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_RightEdgePositions
-  commentId: M:SadRogue.Primitives.Rectangle.RightEdgePositions
-  fullName: SadRogue.Primitives.Rectangle.RightEdgePositions()
-  nameWithType: Rectangle.RightEdgePositions()
-- uid: SadRogue.Primitives.Rectangle.RightEdgePositions*
-  name: RightEdgePositions
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_RightEdgePositions_
-  commentId: Overload:SadRogue.Primitives.Rectangle.RightEdgePositions
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.RightEdgePositions
-  nameWithType: Rectangle.RightEdgePositions
 - uid: SadRogue.Primitives.Rectangle.Size
   name: Size
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_Size
@@ -5669,19 +8066,6 @@ references:
   isSpec: "True"
   fullName: SadRogue.Primitives.Rectangle.Size
   nameWithType: Rectangle.Size
-- uid: SadRogue.Primitives.Rectangle.TopEdgePositions
-  name: TopEdgePositions()
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_TopEdgePositions
-  commentId: M:SadRogue.Primitives.Rectangle.TopEdgePositions
-  fullName: SadRogue.Primitives.Rectangle.TopEdgePositions()
-  nameWithType: Rectangle.TopEdgePositions()
-- uid: SadRogue.Primitives.Rectangle.TopEdgePositions*
-  name: TopEdgePositions
-  href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_TopEdgePositions_
-  commentId: Overload:SadRogue.Primitives.Rectangle.TopEdgePositions
-  isSpec: "True"
-  fullName: SadRogue.Primitives.Rectangle.TopEdgePositions
-  nameWithType: Rectangle.TopEdgePositions
 - uid: SadRogue.Primitives.Rectangle.ToString
   name: ToString()
   href: api/SadRogue.Primitives.Rectangle.html#SadRogue_Primitives_Rectangle_ToString
@@ -5978,3 +8362,682 @@ references:
   commentId: F:SadRogue.Primitives.Rectangle.Y
   fullName: SadRogue.Primitives.Rectangle.Y
   nameWithType: Rectangle.Y
+- uid: SadRogue.Primitives.RectangleExtensions
+  name: RectangleExtensions
+  href: api/SadRogue.Primitives.RectangleExtensions.html
+  commentId: T:SadRogue.Primitives.RectangleExtensions
+  fullName: SadRogue.Primitives.RectangleExtensions
+  nameWithType: RectangleExtensions
+- uid: SadRogue.Primitives.RectangleExtensions.Matches(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)
+  name: Matches(Rectangle, Rectangle)
+  href: api/SadRogue.Primitives.RectangleExtensions.html#SadRogue_Primitives_RectangleExtensions_Matches_SadRogue_Primitives_Rectangle_SadRogue_Primitives_Rectangle_
+  commentId: M:SadRogue.Primitives.RectangleExtensions.Matches(SadRogue.Primitives.Rectangle,SadRogue.Primitives.Rectangle)
+  fullName: SadRogue.Primitives.RectangleExtensions.Matches(SadRogue.Primitives.Rectangle, SadRogue.Primitives.Rectangle)
+  nameWithType: RectangleExtensions.Matches(Rectangle, Rectangle)
+- uid: SadRogue.Primitives.RectangleExtensions.Matches*
+  name: Matches
+  href: api/SadRogue.Primitives.RectangleExtensions.html#SadRogue_Primitives_RectangleExtensions_Matches_
+  commentId: Overload:SadRogue.Primitives.RectangleExtensions.Matches
+  isSpec: "True"
+  fullName: SadRogue.Primitives.RectangleExtensions.Matches
+  nameWithType: RectangleExtensions.Matches
+- uid: SadRogue.Primitives.SerializedTypes
+  name: SadRogue.Primitives.SerializedTypes
+  href: api/SadRogue.Primitives.SerializedTypes.html
+  commentId: N:SadRogue.Primitives.SerializedTypes
+  fullName: SadRogue.Primitives.SerializedTypes
+  nameWithType: SadRogue.Primitives.SerializedTypes
+- uid: SadRogue.Primitives.SerializedTypes.AreaSerialized
+  name: AreaSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.AreaSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.AreaSerialized
+  nameWithType: AreaSerialized
+- uid: SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.Area)~SadRogue.Primitives.SerializedTypes.AreaSerialized
+  name: Implicit(Area to AreaSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html#SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_SadRogue_Primitives_Area__SadRogue_Primitives_SerializedTypes_AreaSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.Area)~SadRogue.Primitives.SerializedTypes.AreaSerialized
+  name.vb: Widening(Area to AreaSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.AreaSerialized.Implicit(SadRogue.Primitives.Area to SadRogue.Primitives.SerializedTypes.AreaSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.AreaSerialized.Widening(SadRogue.Primitives.Area to SadRogue.Primitives.SerializedTypes.AreaSerialized)
+  nameWithType: AreaSerialized.Implicit(Area to AreaSerialized)
+  nameWithType.vb: AreaSerialized.Widening(Area to AreaSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.AreaSerialized)~SadRogue.Primitives.Area
+  name: Implicit(AreaSerialized to Area)
+  href: api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html#SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_AreaSerialized__SadRogue_Primitives_Area
+  commentId: M:SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.AreaSerialized)~SadRogue.Primitives.Area
+  name.vb: Widening(AreaSerialized to Area)
+  fullName: SadRogue.Primitives.SerializedTypes.AreaSerialized.Implicit(SadRogue.Primitives.SerializedTypes.AreaSerialized to SadRogue.Primitives.Area)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.AreaSerialized.Widening(SadRogue.Primitives.SerializedTypes.AreaSerialized to SadRogue.Primitives.Area)
+  nameWithType: AreaSerialized.Implicit(AreaSerialized to Area)
+  nameWithType.vb: AreaSerialized.Widening(AreaSerialized to Area)
+- uid: SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html#SadRogue_Primitives_SerializedTypes_AreaSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.AreaSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.AreaSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.AreaSerialized.Widening
+  nameWithType: AreaSerialized.Implicit
+  nameWithType.vb: AreaSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.AreaSerialized.Positions
+  name: Positions
+  href: api/SadRogue.Primitives.SerializedTypes.AreaSerialized.html#SadRogue_Primitives_SerializedTypes_AreaSerialized_Positions
+  commentId: F:SadRogue.Primitives.SerializedTypes.AreaSerialized.Positions
+  fullName: SadRogue.Primitives.SerializedTypes.AreaSerialized.Positions
+  nameWithType: AreaSerialized.Positions
+- uid: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized
+  name: BoundedRectangleSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized
+  nameWithType: BoundedRectangleSerialized
+- uid: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Area
+  name: Area
+  href: api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html#SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_Area
+  commentId: F:SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Area
+  fullName: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Area
+  nameWithType: BoundedRectangleSerialized.Area
+- uid: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Bounds
+  name: Bounds
+  href: api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html#SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_Bounds
+  commentId: F:SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Bounds
+  fullName: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Bounds
+  nameWithType: BoundedRectangleSerialized.Bounds
+- uid: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.BoundedRectangle)~SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized
+  name: Implicit(BoundedRectangle to BoundedRectangleSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html#SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_SadRogue_Primitives_BoundedRectangle__SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.BoundedRectangle)~SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized
+  name.vb: Widening(BoundedRectangle to BoundedRectangleSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Implicit(SadRogue.Primitives.BoundedRectangle to SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Widening(SadRogue.Primitives.BoundedRectangle to SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized)
+  nameWithType: BoundedRectangleSerialized.Implicit(BoundedRectangle to BoundedRectangleSerialized)
+  nameWithType.vb: BoundedRectangleSerialized.Widening(BoundedRectangle to BoundedRectangleSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized)~SadRogue.Primitives.BoundedRectangle
+  name: Implicit(BoundedRectangleSerialized to BoundedRectangle)
+  href: api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html#SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized__SadRogue_Primitives_BoundedRectangle
+  commentId: M:SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized)~SadRogue.Primitives.BoundedRectangle
+  name.vb: Widening(BoundedRectangleSerialized to BoundedRectangle)
+  fullName: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Implicit(SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized to SadRogue.Primitives.BoundedRectangle)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Widening(SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized to SadRogue.Primitives.BoundedRectangle)
+  nameWithType: BoundedRectangleSerialized.Implicit(BoundedRectangleSerialized to BoundedRectangle)
+  nameWithType.vb: BoundedRectangleSerialized.Widening(BoundedRectangleSerialized to BoundedRectangle)
+- uid: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.html#SadRogue_Primitives_SerializedTypes_BoundedRectangleSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.BoundedRectangleSerialized.Widening
+  nameWithType: BoundedRectangleSerialized.Implicit
+  nameWithType.vb: BoundedRectangleSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized
+  name: ColorSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.ColorSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized
+  nameWithType: ColorSerialized
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.A
+  name: A
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_A
+  commentId: F:SadRogue.Primitives.SerializedTypes.ColorSerialized.A
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.A
+  nameWithType: ColorSerialized.A
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.B
+  name: B
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_B
+  commentId: F:SadRogue.Primitives.SerializedTypes.ColorSerialized.B
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.B
+  nameWithType: ColorSerialized.B
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.G
+  name: G
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_G
+  commentId: F:SadRogue.Primitives.SerializedTypes.ColorSerialized.G
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.G
+  nameWithType: ColorSerialized.G
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.SerializedTypes.ColorSerialized
+  name: Implicit(Color to ColorSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_SadRogue_Primitives_Color__SadRogue_Primitives_SerializedTypes_ColorSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.Color)~SadRogue.Primitives.SerializedTypes.ColorSerialized
+  name.vb: Widening(Color to ColorSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.Implicit(SadRogue.Primitives.Color to SadRogue.Primitives.SerializedTypes.ColorSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.ColorSerialized.Widening(SadRogue.Primitives.Color to SadRogue.Primitives.SerializedTypes.ColorSerialized)
+  nameWithType: ColorSerialized.Implicit(Color to ColorSerialized)
+  nameWithType.vb: ColorSerialized.Widening(Color to ColorSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.ColorSerialized)~SadRogue.Primitives.Color
+  name: Implicit(ColorSerialized to Color)
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_ColorSerialized__SadRogue_Primitives_Color
+  commentId: M:SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.ColorSerialized)~SadRogue.Primitives.Color
+  name.vb: Widening(ColorSerialized to Color)
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.Implicit(SadRogue.Primitives.SerializedTypes.ColorSerialized to SadRogue.Primitives.Color)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.ColorSerialized.Widening(SadRogue.Primitives.SerializedTypes.ColorSerialized to SadRogue.Primitives.Color)
+  nameWithType: ColorSerialized.Implicit(ColorSerialized to Color)
+  nameWithType.vb: ColorSerialized.Widening(ColorSerialized to Color)
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.ColorSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.ColorSerialized.Widening
+  nameWithType: ColorSerialized.Implicit
+  nameWithType.vb: ColorSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.ColorSerialized.R
+  name: R
+  href: api/SadRogue.Primitives.SerializedTypes.ColorSerialized.html#SadRogue_Primitives_SerializedTypes_ColorSerialized_R
+  commentId: F:SadRogue.Primitives.SerializedTypes.ColorSerialized.R
+  fullName: SadRogue.Primitives.SerializedTypes.ColorSerialized.R
+  nameWithType: ColorSerialized.R
+- uid: SadRogue.Primitives.SerializedTypes.GradientSerialized
+  name: GradientSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.GradientSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.GradientSerialized
+  nameWithType: GradientSerialized
+- uid: SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.SerializedTypes.GradientSerialized
+  name: Implicit(Gradient to GradientSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html#SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_SadRogue_Primitives_Gradient__SadRogue_Primitives_SerializedTypes_GradientSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.Gradient)~SadRogue.Primitives.SerializedTypes.GradientSerialized
+  name.vb: Widening(Gradient to GradientSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.GradientSerialized.Implicit(SadRogue.Primitives.Gradient to SadRogue.Primitives.SerializedTypes.GradientSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GradientSerialized.Widening(SadRogue.Primitives.Gradient to SadRogue.Primitives.SerializedTypes.GradientSerialized)
+  nameWithType: GradientSerialized.Implicit(Gradient to GradientSerialized)
+  nameWithType.vb: GradientSerialized.Widening(Gradient to GradientSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientSerialized)~SadRogue.Primitives.Gradient
+  name: Implicit(GradientSerialized to Gradient)
+  href: api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html#SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_GradientSerialized__SadRogue_Primitives_Gradient
+  commentId: M:SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientSerialized)~SadRogue.Primitives.Gradient
+  name.vb: Widening(GradientSerialized to Gradient)
+  fullName: SadRogue.Primitives.SerializedTypes.GradientSerialized.Implicit(SadRogue.Primitives.SerializedTypes.GradientSerialized to SadRogue.Primitives.Gradient)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GradientSerialized.Widening(SadRogue.Primitives.SerializedTypes.GradientSerialized to SadRogue.Primitives.Gradient)
+  nameWithType: GradientSerialized.Implicit(GradientSerialized to Gradient)
+  nameWithType.vb: GradientSerialized.Widening(GradientSerialized to Gradient)
+- uid: SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html#SadRogue_Primitives_SerializedTypes_GradientSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.GradientSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.GradientSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GradientSerialized.Widening
+  nameWithType: GradientSerialized.Implicit
+  nameWithType.vb: GradientSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.GradientSerialized.Stops
+  name: Stops
+  href: api/SadRogue.Primitives.SerializedTypes.GradientSerialized.html#SadRogue_Primitives_SerializedTypes_GradientSerialized_Stops
+  commentId: F:SadRogue.Primitives.SerializedTypes.GradientSerialized.Stops
+  fullName: SadRogue.Primitives.SerializedTypes.GradientSerialized.Stops
+  nameWithType: GradientSerialized.Stops
+- uid: SadRogue.Primitives.SerializedTypes.GradientStopSerialized
+  name: GradientStopSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.GradientStopSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.GradientStopSerialized
+  nameWithType: GradientStopSerialized
+- uid: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Color
+  name: Color
+  href: api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html#SadRogue_Primitives_SerializedTypes_GradientStopSerialized_Color
+  commentId: F:SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Color
+  fullName: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Color
+  nameWithType: GradientStopSerialized.Color
+- uid: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.GradientStop)~SadRogue.Primitives.SerializedTypes.GradientStopSerialized
+  name: Implicit(GradientStop to GradientStopSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html#SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_SadRogue_Primitives_GradientStop__SadRogue_Primitives_SerializedTypes_GradientStopSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.GradientStop)~SadRogue.Primitives.SerializedTypes.GradientStopSerialized
+  name.vb: Widening(GradientStop to GradientStopSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Implicit(SadRogue.Primitives.GradientStop to SadRogue.Primitives.SerializedTypes.GradientStopSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Widening(SadRogue.Primitives.GradientStop to SadRogue.Primitives.SerializedTypes.GradientStopSerialized)
+  nameWithType: GradientStopSerialized.Implicit(GradientStop to GradientStopSerialized)
+  nameWithType.vb: GradientStopSerialized.Widening(GradientStop to GradientStopSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientStopSerialized)~SadRogue.Primitives.GradientStop
+  name: Implicit(GradientStopSerialized to GradientStop)
+  href: api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html#SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_GradientStopSerialized__SadRogue_Primitives_GradientStop
+  commentId: M:SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.GradientStopSerialized)~SadRogue.Primitives.GradientStop
+  name.vb: Widening(GradientStopSerialized to GradientStop)
+  fullName: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Implicit(SadRogue.Primitives.SerializedTypes.GradientStopSerialized to SadRogue.Primitives.GradientStop)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Widening(SadRogue.Primitives.SerializedTypes.GradientStopSerialized to SadRogue.Primitives.GradientStop)
+  nameWithType: GradientStopSerialized.Implicit(GradientStopSerialized to GradientStop)
+  nameWithType.vb: GradientStopSerialized.Widening(GradientStopSerialized to GradientStop)
+- uid: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html#SadRogue_Primitives_SerializedTypes_GradientStopSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.GradientStopSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Widening
+  nameWithType: GradientStopSerialized.Implicit
+  nameWithType.vb: GradientStopSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Stop
+  name: Stop
+  href: api/SadRogue.Primitives.SerializedTypes.GradientStopSerialized.html#SadRogue_Primitives_SerializedTypes_GradientStopSerialized_Stop
+  commentId: F:SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Stop
+  fullName: SadRogue.Primitives.SerializedTypes.GradientStopSerialized.Stop
+  nameWithType: GradientStopSerialized.Stop
+- uid: SadRogue.Primitives.SerializedTypes.GridViews
+  name: SadRogue.Primitives.SerializedTypes.GridViews
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.html
+  commentId: N:SadRogue.Primitives.SerializedTypes.GridViews
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews
+  nameWithType: SadRogue.Primitives.SerializedTypes.GridViews
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1
+  name: ArrayViewSerialized<T>
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1
+  name.vb: ArrayViewSerialized(Of T)
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T)
+  nameWithType: ArrayViewSerialized<T>
+  nameWithType.vb: ArrayViewSerialized(Of T)
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.Data
+  name: Data
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_Data
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.Data
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>.Data
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T).Data
+  nameWithType: ArrayViewSerialized<T>.Data
+  nameWithType.vb: ArrayViewSerialized(Of T).Data
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView{`0})~SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized{`0}
+  name: Implicit(ArrayView<T> to ArrayViewSerialized<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_ArrayView__0___SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.ArrayView{`0})~SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized{`0}
+  name.vb: Widening(ArrayView(Of T) to ArrayViewSerialized(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>.Implicit(SadRogue.Primitives.GridViews.ArrayView<T> to SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T).Widening(SadRogue.Primitives.GridViews.ArrayView(Of T) to SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T))
+  nameWithType: ArrayViewSerialized<T>.Implicit(ArrayView<T> to ArrayViewSerialized<T>)
+  nameWithType.vb: ArrayViewSerialized(Of T).Widening(ArrayView(Of T) to ArrayViewSerialized(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized{`0})~SadRogue.Primitives.GridViews.ArrayView{`0}
+  name: Implicit(ArrayViewSerialized<T> to ArrayView<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized__0___SadRogue_Primitives_GridViews_ArrayView__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized{`0})~SadRogue.Primitives.GridViews.ArrayView{`0}
+  name.vb: Widening(ArrayViewSerialized(Of T) to ArrayView(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>.Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T> to SadRogue.Primitives.GridViews.ArrayView<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T).Widening(SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T) to SadRogue.Primitives.GridViews.ArrayView(Of T))
+  nameWithType: ArrayViewSerialized<T>.Implicit(ArrayViewSerialized<T> to ArrayView<T>)
+  nameWithType.vb: ArrayViewSerialized(Of T).Widening(ArrayViewSerialized(Of T) to ArrayView(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T).Widening
+  nameWithType: ArrayViewSerialized<T>.Implicit
+  nameWithType.vb: ArrayViewSerialized(Of T).Widening
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.Width
+  name: Width
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ArrayViewSerialized_1_Width
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized`1.Width
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized<T>.Width
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ArrayViewSerialized(Of T).Width
+  nameWithType: ArrayViewSerialized<T>.Width
+  nameWithType.vb: ArrayViewSerialized(Of T).Width
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1
+  name: DiffAwareGridViewSerialized<T>
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1
+  name.vb: DiffAwareGridViewSerialized(Of T)
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T)
+  nameWithType: DiffAwareGridViewSerialized<T>
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T)
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.AutoCompress
+  name: AutoCompress
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_AutoCompress
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.AutoCompress
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.AutoCompress
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).AutoCompress
+  nameWithType: DiffAwareGridViewSerialized<T>.AutoCompress
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).AutoCompress
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.BaseGrid
+  name: BaseGrid
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_BaseGrid
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.BaseGrid
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.BaseGrid
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).BaseGrid
+  nameWithType: DiffAwareGridViewSerialized<T>.BaseGrid
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).BaseGrid
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.CurrentDiffIndex
+  name: CurrentDiffIndex
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_CurrentDiffIndex
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.CurrentDiffIndex
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.CurrentDiffIndex
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).CurrentDiffIndex
+  nameWithType: DiffAwareGridViewSerialized<T>.CurrentDiffIndex
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).CurrentDiffIndex
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.Diffs
+  name: Diffs
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_Diffs
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.Diffs
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.Diffs
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).Diffs
+  nameWithType: DiffAwareGridViewSerialized<T>.Diffs
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).Diffs
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.DiffAwareGridView{`0})~SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized{`0}
+  name: Implicit(DiffAwareGridView<T> to DiffAwareGridViewSerialized<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_DiffAwareGridView__0___SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.DiffAwareGridView{`0})~SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized{`0}
+  name.vb: Widening(DiffAwareGridView(Of T) to DiffAwareGridViewSerialized(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.Implicit(SadRogue.Primitives.GridViews.DiffAwareGridView<T> to SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).Widening(SadRogue.Primitives.GridViews.DiffAwareGridView(Of T) to SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T))
+  nameWithType: DiffAwareGridViewSerialized<T>.Implicit(DiffAwareGridView<T> to DiffAwareGridViewSerialized<T>)
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).Widening(DiffAwareGridView(Of T) to DiffAwareGridViewSerialized(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized{`0})~SadRogue.Primitives.GridViews.DiffAwareGridView{`0}
+  name: Implicit(DiffAwareGridViewSerialized<T> to DiffAwareGridView<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized__0___SadRogue_Primitives_GridViews_DiffAwareGridView__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized{`0})~SadRogue.Primitives.GridViews.DiffAwareGridView{`0}
+  name.vb: Widening(DiffAwareGridViewSerialized(Of T) to DiffAwareGridView(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T> to SadRogue.Primitives.GridViews.DiffAwareGridView<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).Widening(SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T) to SadRogue.Primitives.GridViews.DiffAwareGridView(Of T))
+  nameWithType: DiffAwareGridViewSerialized<T>.Implicit(DiffAwareGridViewSerialized<T> to DiffAwareGridView<T>)
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).Widening(DiffAwareGridViewSerialized(Of T) to DiffAwareGridView(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffAwareGridViewSerialized_1_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized`1.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized<T>.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffAwareGridViewSerialized(Of T).Widening
+  nameWithType: DiffAwareGridViewSerialized<T>.Implicit
+  nameWithType.vb: DiffAwareGridViewSerialized(Of T).Widening
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1
+  name: DiffSerialized<T>
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1
+  name.vb: DiffSerialized(Of T)
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T>
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T)
+  nameWithType: DiffSerialized<T>
+  nameWithType.vb: DiffSerialized(Of T)
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.Changes
+  name: Changes
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_Changes
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.Changes
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T>.Changes
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T).Changes
+  nameWithType: DiffSerialized<T>.Changes
+  nameWithType.vb: DiffSerialized(Of T).Changes
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.Diff{`0})~SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized{`0}
+  name: Implicit(Diff<T> to DiffSerialized<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_Diff__0___SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.Diff{`0})~SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized{`0}
+  name.vb: Widening(Diff(Of T) to DiffSerialized(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T>.Implicit(SadRogue.Primitives.GridViews.Diff<T> to SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T).Widening(SadRogue.Primitives.GridViews.Diff(Of T) to SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T))
+  nameWithType: DiffSerialized<T>.Implicit(Diff<T> to DiffSerialized<T>)
+  nameWithType.vb: DiffSerialized(Of T).Widening(Diff(Of T) to DiffSerialized(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized{`0})~SadRogue.Primitives.GridViews.Diff{`0}
+  name: Implicit(DiffSerialized<T> to Diff<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized__0___SadRogue_Primitives_GridViews_Diff__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized{`0})~SadRogue.Primitives.GridViews.Diff{`0}
+  name.vb: Widening(DiffSerialized(Of T) to Diff(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T>.Implicit(SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T> to SadRogue.Primitives.GridViews.Diff<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T).Widening(SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T) to SadRogue.Primitives.GridViews.Diff(Of T))
+  nameWithType: DiffSerialized<T>.Implicit(DiffSerialized<T> to Diff<T>)
+  nameWithType.vb: DiffSerialized(Of T).Widening(DiffSerialized(Of T) to Diff(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_DiffSerialized_1_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized`1.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized<T>.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.DiffSerialized(Of T).Widening
+  nameWithType: DiffSerialized<T>.Implicit
+  nameWithType.vb: DiffSerialized(Of T).Widening
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1
+  name: ValueChangeSerialized<T>
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1
+  name.vb: ValueChangeSerialized(Of T)
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T)
+  nameWithType: ValueChangeSerialized<T>
+  nameWithType.vb: ValueChangeSerialized(Of T)
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.NewValue
+  name: NewValue
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_NewValue
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.NewValue
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>.NewValue
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T).NewValue
+  nameWithType: ValueChangeSerialized<T>.NewValue
+  nameWithType.vb: ValueChangeSerialized(Of T).NewValue
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.OldValue
+  name: OldValue
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_OldValue
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.OldValue
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>.OldValue
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T).OldValue
+  nameWithType: ValueChangeSerialized<T>.OldValue
+  nameWithType.vb: ValueChangeSerialized(Of T).OldValue
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.ValueChange{`0})~SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized{`0}
+  name: Implicit(ValueChange<T> to ValueChangeSerialized<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_SadRogue_Primitives_GridViews_ValueChange__0___SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit(SadRogue.Primitives.GridViews.ValueChange{`0})~SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized{`0}
+  name.vb: Widening(ValueChange(Of T) to ValueChangeSerialized(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>.Implicit(SadRogue.Primitives.GridViews.ValueChange<T> to SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T).Widening(SadRogue.Primitives.GridViews.ValueChange(Of T) to SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T))
+  nameWithType: ValueChangeSerialized<T>.Implicit(ValueChange<T> to ValueChangeSerialized<T>)
+  nameWithType.vb: ValueChangeSerialized(Of T).Widening(ValueChange(Of T) to ValueChangeSerialized(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized{`0})~SadRogue.Primitives.GridViews.ValueChange{`0}
+  name: Implicit(ValueChangeSerialized<T> to ValueChange<T>)
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized__0___SadRogue_Primitives_GridViews_ValueChange__0_
+  commentId: M:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized{`0})~SadRogue.Primitives.GridViews.ValueChange{`0}
+  name.vb: Widening(ValueChangeSerialized(Of T) to ValueChange(Of T))
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>.Implicit(SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T> to SadRogue.Primitives.GridViews.ValueChange<T>)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T).Widening(SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T) to SadRogue.Primitives.GridViews.ValueChange(Of T))
+  nameWithType: ValueChangeSerialized<T>.Implicit(ValueChangeSerialized<T> to ValueChange<T>)
+  nameWithType.vb: ValueChangeSerialized(Of T).Widening(ValueChangeSerialized(Of T) to ValueChange(Of T))
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T).Widening
+  nameWithType: ValueChangeSerialized<T>.Implicit
+  nameWithType.vb: ValueChangeSerialized(Of T).Widening
+- uid: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.Position
+  name: Position
+  href: api/SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized-1.html#SadRogue_Primitives_SerializedTypes_GridViews_ValueChangeSerialized_1_Position
+  commentId: F:SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized`1.Position
+  fullName: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized<T>.Position
+  fullName.vb: SadRogue.Primitives.SerializedTypes.GridViews.ValueChangeSerialized(Of T).Position
+  nameWithType: ValueChangeSerialized<T>.Position
+  nameWithType.vb: ValueChangeSerialized(Of T).Position
+- uid: SadRogue.Primitives.SerializedTypes.PaletteSerialized
+  name: PaletteSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.PaletteSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.PaletteSerialized
+  nameWithType: PaletteSerialized
+- uid: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Colors
+  name: Colors
+  href: api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html#SadRogue_Primitives_SerializedTypes_PaletteSerialized_Colors
+  commentId: F:SadRogue.Primitives.SerializedTypes.PaletteSerialized.Colors
+  fullName: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Colors
+  nameWithType: PaletteSerialized.Colors
+- uid: SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.Palette)~SadRogue.Primitives.SerializedTypes.PaletteSerialized
+  name: Implicit(Palette to PaletteSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html#SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_SadRogue_Primitives_Palette__SadRogue_Primitives_SerializedTypes_PaletteSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.Palette)~SadRogue.Primitives.SerializedTypes.PaletteSerialized
+  name.vb: Widening(Palette to PaletteSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Implicit(SadRogue.Primitives.Palette to SadRogue.Primitives.SerializedTypes.PaletteSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Widening(SadRogue.Primitives.Palette to SadRogue.Primitives.SerializedTypes.PaletteSerialized)
+  nameWithType: PaletteSerialized.Implicit(Palette to PaletteSerialized)
+  nameWithType.vb: PaletteSerialized.Widening(Palette to PaletteSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PaletteSerialized)~SadRogue.Primitives.Palette
+  name: Implicit(PaletteSerialized to Palette)
+  href: api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html#SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PaletteSerialized__SadRogue_Primitives_Palette
+  commentId: M:SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PaletteSerialized)~SadRogue.Primitives.Palette
+  name.vb: Widening(PaletteSerialized to Palette)
+  fullName: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Implicit(SadRogue.Primitives.SerializedTypes.PaletteSerialized to SadRogue.Primitives.Palette)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Widening(SadRogue.Primitives.SerializedTypes.PaletteSerialized to SadRogue.Primitives.Palette)
+  nameWithType: PaletteSerialized.Implicit(PaletteSerialized to Palette)
+  nameWithType.vb: PaletteSerialized.Widening(PaletteSerialized to Palette)
+- uid: SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.PaletteSerialized.html#SadRogue_Primitives_SerializedTypes_PaletteSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.PaletteSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PaletteSerialized.Widening
+  nameWithType: PaletteSerialized.Implicit
+  nameWithType.vb: PaletteSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.PointSerialized
+  name: PointSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.PointSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.PointSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.PointSerialized
+  nameWithType: PointSerialized
+- uid: SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.SerializedTypes.PointSerialized
+  name: Implicit(Point to PointSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.PointSerialized.html#SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_SadRogue_Primitives_Point__SadRogue_Primitives_SerializedTypes_PointSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.Point)~SadRogue.Primitives.SerializedTypes.PointSerialized
+  name.vb: Widening(Point to PointSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.PointSerialized.Implicit(SadRogue.Primitives.Point to SadRogue.Primitives.SerializedTypes.PointSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PointSerialized.Widening(SadRogue.Primitives.Point to SadRogue.Primitives.SerializedTypes.PointSerialized)
+  nameWithType: PointSerialized.Implicit(Point to PointSerialized)
+  nameWithType.vb: PointSerialized.Widening(Point to PointSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PointSerialized)~SadRogue.Primitives.Point
+  name: Implicit(PointSerialized to Point)
+  href: api/SadRogue.Primitives.SerializedTypes.PointSerialized.html#SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PointSerialized__SadRogue_Primitives_Point
+  commentId: M:SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PointSerialized)~SadRogue.Primitives.Point
+  name.vb: Widening(PointSerialized to Point)
+  fullName: SadRogue.Primitives.SerializedTypes.PointSerialized.Implicit(SadRogue.Primitives.SerializedTypes.PointSerialized to SadRogue.Primitives.Point)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PointSerialized.Widening(SadRogue.Primitives.SerializedTypes.PointSerialized to SadRogue.Primitives.Point)
+  nameWithType: PointSerialized.Implicit(PointSerialized to Point)
+  nameWithType.vb: PointSerialized.Widening(PointSerialized to Point)
+- uid: SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.PointSerialized.html#SadRogue_Primitives_SerializedTypes_PointSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.PointSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.PointSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PointSerialized.Widening
+  nameWithType: PointSerialized.Implicit
+  nameWithType.vb: PointSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.PointSerialized.X
+  name: X
+  href: api/SadRogue.Primitives.SerializedTypes.PointSerialized.html#SadRogue_Primitives_SerializedTypes_PointSerialized_X
+  commentId: F:SadRogue.Primitives.SerializedTypes.PointSerialized.X
+  fullName: SadRogue.Primitives.SerializedTypes.PointSerialized.X
+  nameWithType: PointSerialized.X
+- uid: SadRogue.Primitives.SerializedTypes.PointSerialized.Y
+  name: Y
+  href: api/SadRogue.Primitives.SerializedTypes.PointSerialized.html#SadRogue_Primitives_SerializedTypes_PointSerialized_Y
+  commentId: F:SadRogue.Primitives.SerializedTypes.PointSerialized.Y
+  fullName: SadRogue.Primitives.SerializedTypes.PointSerialized.Y
+  nameWithType: PointSerialized.Y
+- uid: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized
+  name: PolarCoordinateSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized
+  nameWithType: PolarCoordinateSerialized
+- uid: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized
+  name: Implicit(PolarCoordinate to PolarCoordinateSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html#SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_SadRogue_Primitives_PolarCoordinate__SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.PolarCoordinate)~SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized
+  name.vb: Widening(PolarCoordinate to PolarCoordinateSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Implicit(SadRogue.Primitives.PolarCoordinate to SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Widening(SadRogue.Primitives.PolarCoordinate to SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized)
+  nameWithType: PolarCoordinateSerialized.Implicit(PolarCoordinate to PolarCoordinateSerialized)
+  nameWithType.vb: PolarCoordinateSerialized.Widening(PolarCoordinate to PolarCoordinateSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized)~SadRogue.Primitives.PolarCoordinate
+  name: Implicit(PolarCoordinateSerialized to PolarCoordinate)
+  href: api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html#SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized__SadRogue_Primitives_PolarCoordinate
+  commentId: M:SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized)~SadRogue.Primitives.PolarCoordinate
+  name.vb: Widening(PolarCoordinateSerialized to PolarCoordinate)
+  fullName: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Implicit(SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized to SadRogue.Primitives.PolarCoordinate)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Widening(SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized to SadRogue.Primitives.PolarCoordinate)
+  nameWithType: PolarCoordinateSerialized.Implicit(PolarCoordinateSerialized to PolarCoordinate)
+  nameWithType.vb: PolarCoordinateSerialized.Widening(PolarCoordinateSerialized to PolarCoordinate)
+- uid: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html#SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Widening
+  nameWithType: PolarCoordinateSerialized.Implicit
+  nameWithType.vb: PolarCoordinateSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Radius
+  name: Radius
+  href: api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html#SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_Radius
+  commentId: F:SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Radius
+  fullName: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Radius
+  nameWithType: PolarCoordinateSerialized.Radius
+- uid: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Theta
+  name: Theta
+  href: api/SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.html#SadRogue_Primitives_SerializedTypes_PolarCoordinateSerialized_Theta
+  commentId: F:SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Theta
+  fullName: SadRogue.Primitives.SerializedTypes.PolarCoordinateSerialized.Theta
+  nameWithType: PolarCoordinateSerialized.Theta
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized
+  name: RectangleSerialized
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html
+  commentId: T:SadRogue.Primitives.SerializedTypes.RectangleSerialized
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized
+  nameWithType: RectangleSerialized
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Height
+  name: Height
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_Height
+  commentId: F:SadRogue.Primitives.SerializedTypes.RectangleSerialized.Height
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Height
+  nameWithType: RectangleSerialized.Height
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.Rectangle)~SadRogue.Primitives.SerializedTypes.RectangleSerialized
+  name: Implicit(Rectangle to RectangleSerialized)
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_SadRogue_Primitives_Rectangle__SadRogue_Primitives_SerializedTypes_RectangleSerialized
+  commentId: M:SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.Rectangle)~SadRogue.Primitives.SerializedTypes.RectangleSerialized
+  name.vb: Widening(Rectangle to RectangleSerialized)
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Implicit(SadRogue.Primitives.Rectangle to SadRogue.Primitives.SerializedTypes.RectangleSerialized)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Widening(SadRogue.Primitives.Rectangle to SadRogue.Primitives.SerializedTypes.RectangleSerialized)
+  nameWithType: RectangleSerialized.Implicit(Rectangle to RectangleSerialized)
+  nameWithType.vb: RectangleSerialized.Widening(Rectangle to RectangleSerialized)
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.RectangleSerialized)~SadRogue.Primitives.Rectangle
+  name: Implicit(RectangleSerialized to Rectangle)
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_SadRogue_Primitives_SerializedTypes_RectangleSerialized__SadRogue_Primitives_Rectangle
+  commentId: M:SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit(SadRogue.Primitives.SerializedTypes.RectangleSerialized)~SadRogue.Primitives.Rectangle
+  name.vb: Widening(RectangleSerialized to Rectangle)
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Implicit(SadRogue.Primitives.SerializedTypes.RectangleSerialized to SadRogue.Primitives.Rectangle)
+  fullName.vb: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Widening(SadRogue.Primitives.SerializedTypes.RectangleSerialized to SadRogue.Primitives.Rectangle)
+  nameWithType: RectangleSerialized.Implicit(RectangleSerialized to Rectangle)
+  nameWithType.vb: RectangleSerialized.Widening(RectangleSerialized to Rectangle)
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit*
+  name: Implicit
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_op_Implicit_
+  commentId: Overload:SadRogue.Primitives.SerializedTypes.RectangleSerialized.op_Implicit
+  isSpec: "True"
+  name.vb: Widening
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Implicit
+  fullName.vb: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Widening
+  nameWithType: RectangleSerialized.Implicit
+  nameWithType.vb: RectangleSerialized.Widening
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Width
+  name: Width
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_Width
+  commentId: F:SadRogue.Primitives.SerializedTypes.RectangleSerialized.Width
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Width
+  nameWithType: RectangleSerialized.Width
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.X
+  name: X
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_X
+  commentId: F:SadRogue.Primitives.SerializedTypes.RectangleSerialized.X
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.X
+  nameWithType: RectangleSerialized.X
+- uid: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Y
+  name: Y
+  href: api/SadRogue.Primitives.SerializedTypes.RectangleSerialized.html#SadRogue_Primitives_SerializedTypes_RectangleSerialized_Y
+  commentId: F:SadRogue.Primitives.SerializedTypes.RectangleSerialized.Y
+  fullName: SadRogue.Primitives.SerializedTypes.RectangleSerialized.Y
+  nameWithType: RectangleSerialized.Y


### PR DESCRIPTION
# Changes
- Updated docs (hosted via GitHub pages) to v1.0
- Minor docs edits to better reflect the current state
- Updated csproj in prep for v1.0 release

# Notes
This is intended to be the final PR before v1.0 release, contingent upon us being willing to handle #61 (color helper method bug) after release.  It should involve no API-breaking changes, so this should be fine.

If we want to fix that first, feel free to let me know, and I'll see if I can get that done.