### PR TITLE
Added cached arrays for DirectionsOfNeighbors Enumerables

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/AdjacencyRuleCache.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/AdjacencyRuleCache.cs
@@ -1,0 +1,83 @@
+﻿using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    /// <summary>
+    /// Performance tests demonstrating the benefit of keeping cached versions of DirectionsOfNeighbors type functions
+    /// in AdjacencyRule
+    /// </summary>
+    public class AdjacencyRuleCache
+    {
+        [ParamsAllValues]
+        public AdjacencyRule.Types RuleType;
+
+        private AdjacencyRule _rule;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _rule = RuleType;
+        }
+
+        [Benchmark]
+        public int NeighborsViaEnumerable()
+        {
+            int sum = 0;
+            foreach (var dir in _rule.DirectionsOfNeighbors())
+                sum += (int)dir.Type;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int NeighborsViaCache()
+        {
+            int sum = 0;
+            for (int i = 0; i < _rule.DirectionsOfNeighborsCache.Length; i++)
+                sum += (int)_rule.DirectionsOfNeighborsCache[i].Type;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int NeighborsClockwiseViaEnumerable()
+        {
+            int sum = 0;
+            foreach (var dir in _rule.DirectionsOfNeighborsClockwise())
+                sum += (int)dir.Type;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int NeighborsClockwiseViaCache()
+        {
+            int sum = 0;
+            for (int i = 0; i < _rule.DirectionsOfNeighborsClockwiseCache.Length; i++)
+                sum += (int)_rule.DirectionsOfNeighborsClockwiseCache[i].Type;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int NeighborsCounterClockwiseViaEnumerable()
+        {
+            int sum = 0;
+            foreach (var dir in _rule.DirectionsOfNeighborsCounterClockwise())
+                sum += (int)dir.Type;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int NeighborsCounterClockwiseViaCache()
+        {
+            int sum = 0;
+            for (int i = 0; i < _rule.DirectionsOfNeighborsCounterClockwiseCache.Length; i++)
+                sum += (int)_rule.DirectionsOfNeighborsCounterClockwiseCache[i].Type;
+
+            return sum;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/AdjacencyRuleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AdjacencyRuleTests.cs
@@ -327,5 +327,17 @@ namespace SadRogue.Primitives.UnitTests
         }
 
         #endregion
+
+        #region Caches Equal to Functions
+
+        [Theory]
+        [MemberDataEnumerable(nameof(AdjacencyRules))]
+        public void CachesEqualToFunction(AdjacencyRule rule)
+        {
+            TestUtils.AssertElementEquals(rule.DirectionsOfNeighbors().ToArray(), rule.DirectionsOfNeighborsCache);
+            TestUtils.AssertElementEquals(rule.DirectionsOfNeighborsClockwise().ToArray(), rule.DirectionsOfNeighborsClockwiseCache);
+            TestUtils.AssertElementEquals(rule.DirectionsOfNeighborsCounterClockwise().ToArray(), rule.DirectionsOfNeighborsCounterClockwiseCache);
+        }
+        #endregion
     }
 }

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.1.1</Version>
+	<Version>1.2.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -16,7 +16,7 @@
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>
-		- Added more custom Point hashing algorithm implementations
+		- Added arrays that cache adjacency rules
 	</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
# Changes
- Each `AdjacencyRule` now has 3 additional fields:
    - `DirectionsOfNeighborsCache`
    - `DirectionsOfNeighborsClockwiseCache`
    - `DirectionsOfNeighborsCounterClockwiseCache`
- Each field is an array that caches the result of the corresponding `DirectionsOfNeighborsX()` function called with default parameters

# Notes
`foreach` loops and functions that use `yield return` are convenient constructs in C#, but unfortunately can be particularly slow in some circumstances, compared to iteration over an array or more concrete data structure.  This is particularly so when the number of items being returned from the enumerable is small, and/or the body of the loop doesn't take very long; this is because the overhead of enumerator creation takes up a larger amount of time compared to the time taken by the body of the loop.

Iteration over neighboring directions occurs quite frequently in many algorithms (including some of GoRogue's); use cases include pathing, FOV, flood fill, and more.  These cases are particularly susceptible to the above issues, because there are only 4-8 directions to iterate over, and it is often done many different times where the body of the loop exits early.  Therefore, many of these types of applications can achieve notable performance benefits by iterating over an array of directions (omitting the foreach loop and instead using a traditional for-loop and the `Length` property) rather than an enumerable.

Therefore, this PR modifies `AdjacencyRule` to provide public fields which cache the results of calling these types of functions with the default parameters.  This prevents such algorithms from needing to create their own cache; and thus, restricts the allocation necessary to support this to the approximately 64 bytes taken up by `AdjacencyRule`'s caching.

As evidence to support the potential for performance gains here, I have included some performance tests which use both the enumerables and the new caches, to iterate over directions and execute a trivial loop body.  The following table shows the results on my system:
```bash
|                                 Method |  RuleType |      Mean |     Error |    StdDev |
|--------------------------------------- |---------- |----------:|----------:|----------:|
|                 NeighborsViaEnumerable | Cardinals | 25.012 ns | 0.4518 ns | 0.4005 ns |
|                      NeighborsViaCache | Cardinals |  1.950 ns | 0.0501 ns | 0.0468 ns |
|        NeighborsClockwiseViaEnumerable | Cardinals | 56.266 ns | 1.1136 ns | 1.1915 ns |
|             NeighborsClockwiseViaCache | Cardinals |  1.919 ns | 0.0157 ns | 0.0147 ns |
| NeighborsCounterClockwiseViaEnumerable | Cardinals | 54.184 ns | 0.9015 ns | 0.8433 ns |
|      NeighborsCounterClockwiseViaCache | Cardinals |  1.963 ns | 0.0411 ns | 0.0365 ns |
|                 NeighborsViaEnumerable | Diagonals | 28.188 ns | 0.3892 ns | 0.3640 ns |
|                      NeighborsViaCache | Diagonals |  1.928 ns | 0.0150 ns | 0.0133 ns |
|        NeighborsClockwiseViaEnumerable | Diagonals | 56.078 ns | 0.5055 ns | 0.4221 ns |
|             NeighborsClockwiseViaCache | Diagonals |  1.931 ns | 0.0247 ns | 0.0219 ns |
| NeighborsCounterClockwiseViaEnumerable | Diagonals | 56.410 ns | 1.0836 ns | 0.9606 ns |
|      NeighborsCounterClockwiseViaCache | Diagonals |  1.943 ns | 0.0338 ns | 0.0282 ns |
|                 NeighborsViaEnumerable |  EightWay | 39.864 ns | 0.6878 ns | 0.6098 ns |
|                      NeighborsViaCache |  EightWay |  4.390 ns | 0.0300 ns | 0.0266 ns |
|        NeighborsClockwiseViaEnumerable |  EightWay | 92.836 ns | 1.8455 ns | 2.0512 ns |
|             NeighborsClockwiseViaCache |  EightWay |  4.419 ns | 0.0380 ns | 0.0337 ns |
| NeighborsCounterClockwiseViaEnumerable |  EightWay | 91.679 ns | 1.5921 ns | 1.3295 ns |
|      NeighborsCounterClockwiseViaCache |  EightWay |  4.397 ns | 0.0219 ns | 0.0183 ns |
```

As you can see, caching very clearly has the potential to provide a tangible benefit.  Realistic algorithms will not see benefits as pronounced as the ones seen here (because a real algorithm would have a more substantial loop body), however realistic cases in GoRogue have been able to achieve 20%-50% gains, in some cases, by keeping their own cache and using it.