### PR TITLE
Add new GridView and Misc Performance Updates

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -2,20 +2,20 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0</Version>
+	<Version>1.0.1</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
 	<Copyright>Copyright © 2021 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
-	
+
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-	<PackageReleaseNotes>Initial release.  Updated to use non-alpha versions of core primitives package.</PackageReleaseNotes>
+	<PackageReleaseNotes>Multi-targeted to .NET 6.  Updated to depend on most recent 1.x release of core primitives.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -26,7 +26,7 @@
 	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;monogame;sadrogue;thesadrogue;extensions</PackageTags>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.MonoGame.xml</DocumentationFile>
   </PropertyGroup>
@@ -40,9 +40,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
   </ItemGroup>
-  
+
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
     <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/BitArray.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/BitArray.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+using SadRogue.Primitives.GridViews;
+using SadRogue.Primitives.PointHashers;
+
+namespace TheSadRogue.Primitives.PerformanceTests.GridViews
+{
+    /// <summary>
+    /// This class benchmarks BitArray against some functionally equivalent data structures.
+    /// </summary>
+    /// <remarks>
+    /// In general, this is designed to gauge performance differences between BitArray and bool[].  It does so by
+    /// testing cases that use the corresponding grid views, as well as a case where BitArray is used directly, in order
+    /// to determine any overhead caused via access through the grid view.
+    ///
+    /// In order to keep these timings fair, BitArrayView must implement the indexers to not double-calculate index
+    /// -> Point -> index (ie, it must implement all the indexers custom instead of using SettableGridViewBase), and the
+    /// values are consistently accessed as if the starting value was a point (ie. using the ToIndex function).  The private
+    /// variables for the data structures must also be of the concrete type (ie. BitArrayView or ArrayView) rather than
+    /// the interface they implement (ie. IMapView).  Making them interfaces will trigger vtable indirections when calling
+    /// interface methods; however, accessing them as their concrete type should _not_, since the types are sealed.
+    /// This is a mirco-optimization, but since the get benchmarks take on the order of half a nanosecond or less, it is
+    /// relevant here.
+    /// </remarks>
+    public class BitArray
+    {
+        [Params(10, 100, 200)]
+        public int Size;
+
+        private readonly Point _on = new Point(1, 2);
+
+        private ArrayView<bool> _boolArrayView = null!;
+        private BitArrayView _bitArrayView = null!;
+        private System.Collections.BitArray _bitArray = null!;
+        private HashSet<Point> _hashSet = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _boolArrayView = new ArrayView<bool>(Size, Size) { [_on] = true };
+            _bitArray = new System.Collections.BitArray(Size * Size) { [_on.ToIndex(Size)] = true };
+            _bitArrayView = new BitArrayView(Size, Size) { [_on] = true };
+            _hashSet = new HashSet<Point>(new KnownSizeHasher(Size)) { _on };
+        }
+
+        [Benchmark]
+        public bool BoolArrayViewGet() => _boolArrayView[_on];
+
+        [Benchmark]
+        public bool BitArrayGet() => _bitArray[_on.ToIndex(Size)];
+
+        [Benchmark]
+        public bool BitArrayViewGet() => _bitArrayView[_on];
+
+        [Benchmark]
+        public bool HashSetGet() => _hashSet.Contains(_on);
+
+        [Benchmark]
+        public ArrayView<bool> BoolArrayViewFill()
+        {
+            _boolArrayView.Clear();
+            return _boolArrayView;
+        }
+
+        [Benchmark]
+        public System.Collections.BitArray BitArrayFill()
+        {
+            _bitArray.SetAll(false);
+            return _bitArray;
+        }
+
+        [Benchmark]
+        public BitArrayView BitArrayViewFill()
+        {
+            _bitArrayView.Fill(false);
+            return _bitArrayView;
+        }
+
+        /// <summary>
+        /// Note: This benchmark is not very fair compared to the other Fill benchmarks, since HashSet.Clear will scale
+        /// linearly with the amount of items in the hash set (1 in this test case) where the others will not.
+        /// Nonetheless, it is included for completeness.
+        /// </summary>
+        [Benchmark]
+        public HashSet<Point> HashSetFill()
+        {
+            _hashSet.Clear();
+            return _hashSet;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/PositionsInRadius.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PositionsInRadius.cs
@@ -1,0 +1,50 @@
+﻿using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks for the Radius.PositionsInRadius functions.
+    /// </summary>
+    public class PositionsInRadius
+    {
+        [Params(10, 50, 100, 200)]
+        public int MapSize;
+
+        [Params(5, 10, 25)]
+        public int Radius;
+
+        [ParamsAllValues]
+        public Radius.Types RadiusShapeType;
+
+        private Radius _radiusShape;
+        private RadiusLocationContext _existingContext = null!;
+        private Point _center;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _radiusShape = RadiusShapeType;
+            _center = new Point(MapSize / 2, MapSize / 2);
+            _existingContext = new RadiusLocationContext(_center, Radius);
+        }
+
+        [Benchmark]
+        public int IteratePositionsNewContext()
+        {
+            int sum = 0;
+            foreach (var pos in _radiusShape.PositionsInRadius(_center, Radius))
+                sum += pos.ToIndex(MapSize);
+            return sum;
+        }
+
+        [Benchmark]
+        public int IteratePositionsExistingContext()
+        {
+            int sum = 0;
+            foreach (var pos in _radiusShape.PositionsInRadius(_existingContext))
+                sum += pos.ToIndex(MapSize);
+            return sum;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
+++ b/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -2,20 +2,20 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.0</Version>
+	<Version>1.0.1</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
 	<Copyright>Copyright © 2021 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with SFML's equivalents.</Description>
-	
+
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>Initial release.  Updated to use non-alpha versions of core primitives package.</PackageReleaseNotes>
+	<PackageReleaseNotes>Multi-targted to .NET 6.  Updated to use the most recent 1.x version of the primitives library.</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -26,7 +26,7 @@
 	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sfml;sadrogue;thesadrogue;extensions</PackageTags>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
   </PropertyGroup>
@@ -40,9 +40,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="SFML.Graphics" Version="2.5.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.0.0" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
   </ItemGroup>
-  
+
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
     <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />

--- a/TheSadRogue.Primitives/GridViews/ArrayView2D.cs
+++ b/TheSadRogue.Primitives/GridViews/ArrayView2D.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace SadRogue.Primitives.GridViews
 {
@@ -63,7 +64,10 @@ namespace SadRogue.Primitives.GridViews
         /// <inheritdoc />
         public override T this[Point pos]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _array[pos.X, pos.Y];
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => _array[pos.X, pos.Y] = value;
         }
 
@@ -103,6 +107,7 @@ namespace SadRogue.Primitives.GridViews
         /// <summary>
         /// Sets each element in the ArrayView to the default for type T.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear() => Array.Clear(_array, 0, _array.Length);
 
         /// <summary>

--- a/TheSadRogue.Primitives/GridViews/GridView1DIndexBase.cs
+++ b/TheSadRogue.Primitives/GridViews/GridView1DIndexBase.cs
@@ -1,0 +1,42 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives.GridViews
+{
+    /// <summary>
+    /// Exactly like <see cref="GridViewBase{T}"/>, except for the one indexer left to the user to implement
+    /// is the one which takes a 1D array, and the position-based indexers are implemented off that.
+    /// </summary>
+    /// <remarks>
+    /// This can be more convenient than <see cref="GridViewBase{T}"/> for use cases where 1D indices are easiest
+    /// to work with, and is technically more efficient for cases such as wrapping a 1D array, where the backing data
+    /// structure takes an index (although this should typically be considered a micro-optimization).
+    /// </remarks>
+    /// <typeparam name="T">The type of value being stored.</typeparam>
+    public abstract class GridView1DIndexBase<T> : IGridView<T>
+    {
+        /// <inheritdoc />
+        public abstract int Height { get; }
+        /// <inheritdoc />
+        public abstract int Width { get; }
+
+        /// <inheritdoc />
+        public T this[Point pos]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[pos.ToIndex(Width)];
+        }
+
+        /// <inheritdoc />
+        public int Count => Width * Height;
+
+        /// <inheritdoc />
+        public T this[int x, int y]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[new Point(x, y)];
+        }
+
+        /// <inheritdoc />
+        public abstract T this[int index1D] { get; }
+    }
+}

--- a/TheSadRogue.Primitives/GridViews/GridViewBase.cs
+++ b/TheSadRogue.Primitives/GridViews/GridViewBase.cs
@@ -1,4 +1,6 @@
-﻿namespace SadRogue.Primitives.GridViews
+﻿using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives.GridViews
 {
     /// <summary>
     /// A convenient base class to inherit from when implementing <see cref="IGridView{T}"/> that minimizes
@@ -18,9 +20,17 @@
         public int Count => Width * Height;
 
         /// <inheritdoc />
-        public T this[int x, int y] => this[new Point(x, y)];
+        public T this[int x, int y]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[new Point(x, y)];
+        }
 
         /// <inheritdoc />
-        public T this[int index1D] => this[Point.FromIndex(index1D, Width)];
+        public T this[int index1D]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[Point.FromIndex(index1D, Width)];
+        }
     }
 }

--- a/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
+++ b/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
@@ -173,7 +173,15 @@ namespace SadRogue.Primitives.GridViews
         /// <param name="self" />
         /// <param name="value">Value to fill the grid view with.</param>
         public static void Fill<T>(this ISettableGridView<T> self, T value)
-            => self.ApplyOverlay(_ => value);
+        {
+            // This method is much faster for BitArrayView, so we'll special-case it to provide the best optimization
+            // we can.  It's still better to call the BitArrayView directly, but since the Fill method can be
+            // easily 10x faster for Bit arrays, even with both of these casts it's still faster than not
+            if (self is BitArrayView bitArray && value is bool b)
+                bitArray.Fill(b);
+            else
+                self.ApplyOverlay(_ => value);
+        }
 
         /// <summary>
         /// Iterates through each position in the grid view.

--- a/TheSadRogue.Primitives/GridViews/SettableGridView1DIndexBase.cs
+++ b/TheSadRogue.Primitives/GridViews/SettableGridView1DIndexBase.cs
@@ -1,0 +1,49 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives.GridViews
+{
+    /// <summary>
+    /// Exactly like <see cref="SettableGridViewBase{T}"/>, except for the one indexer left to the user to implement
+    /// is the one which takes a 1D array, and the position-based indexers are implemented off that.
+    /// </summary>
+    /// <remarks>
+    /// This can be more convenient than <see cref="SettableGridViewBase{T}"/> for use cases where 1D indices are easiest
+    /// to work with, and is technically more efficient for cases such as wrapping a 1D array, where the backing data
+    /// structure takes an index (although this should typically be considered a micro-optimization).
+    /// </remarks>
+    /// <typeparam name="T">The type of value being stored.</typeparam>
+    public abstract class SettableGridView1DIndexBase<T> : ISettableGridView<T>
+    {
+        /// <inheritdoc />
+        public abstract int Height { get; }
+
+        /// <inheritdoc />
+        public abstract int Width { get; }
+
+        /// <inheritdoc />
+        public int Count => Width * Height;
+
+        /// <inheritdoc cref="ISettableGridView{T}"/>
+        public T this[Point pos]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[pos.ToIndex(Width)];
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => this[pos.ToIndex(Width)] = value;
+        }
+
+        /// <inheritdoc cref="ISettableGridView{T}"/>
+        public T this[int x, int y]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[Point.ToIndex(x, y, Width)];
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => this[Point.ToIndex(x, y, Width)] = value;
+        }
+
+        /// <inheritdoc cref="ISettableGridView{T}"/>
+        public abstract T this[int index1D] { get; set; }
+    }
+}

--- a/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs
+++ b/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs
@@ -1,4 +1,6 @@
-﻿namespace SadRogue.Primitives.GridViews
+﻿using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives.GridViews
 {
     /// <summary>
     /// A convenient base class to inherit from when implementing <see cref="ISettableGridView{T}"/> that minimizes
@@ -21,14 +23,20 @@
         /// <inheritdoc cref="ISettableGridView{T}"/>
         public T this[int x, int y]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => this[new Point(x, y)];
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => this[new Point(x, y)] = value;
         }
 
         /// <inheritdoc cref="ISettableGridView{T}"/>
         public T this[int index1D]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => this[Point.FromIndex(index1D, Width)];
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => this[Point.FromIndex(index1D, Width)] = value;
         }
     }

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using SadRogue.Primitives.GridViews;
 
 namespace SadRogue.Primitives
 {
@@ -179,9 +180,9 @@ namespace SadRogue.Primitives
             if (context._newlyInitialized)
                 context._newlyInitialized = false;
             else
-                Array.Clear(context._inQueue, 0, context._inQueue.Length);
+                context._inQueue.Fill(false);
 
-            int startArrayIndex = context._inQueue.GetLength(0) / 2;
+            int startArrayIndex = context._inQueue.Width / 2;
             Point topLeft = context.Center - context.Radius;
             AdjacencyRule rule = this;
             Distance distCalc = this;
@@ -336,7 +337,7 @@ namespace SadRogue.Primitives
     /// </summary>
     public class RadiusLocationContext
     {
-        internal bool[,] _inQueue;
+        internal BitArrayView _inQueue;
         internal bool _newlyInitialized;
 
         private int _radius;
@@ -353,7 +354,7 @@ namespace SadRogue.Primitives
                 {
                     _radius = value;
                     int size = _radius * 2 + 1;
-                    _inQueue = new bool[size, size];
+                    _inQueue = new BitArrayView(size, size);
                 }
             }
         }
@@ -385,7 +386,7 @@ namespace SadRogue.Primitives
             Bounds = bounds;
 
             int size = _radius * 2 + 1;
-            _inQueue = new bool[size, size];
+            _inQueue = new BitArrayView(size, size);
             _newlyInitialized = true;
         }
 

--- a/TheSadRogue.Primitives/Radius.cs
+++ b/TheSadRogue.Primitives/Radius.cs
@@ -199,8 +199,9 @@ namespace SadRogue.Primitives
                 yield return cur;
 
                 // Add neighbors
-                foreach (Point neighbor in rule.Neighbors(cur))
+                for (int i = 0; i < rule.DirectionsOfNeighborsCache.Length; i++)
                 {
+                    var neighbor = cur + rule.DirectionsOfNeighborsCache[i];
                     localNeighbor = neighbor - topLeft;
 
                     if (distCalc.Calculate(context.Center, neighbor) > context.Radius ||

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.2.0</Version>
+	<Version>1.3.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -16,7 +16,8 @@
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>
-		- Added arrays that cache adjacency rules
+		- Added grid view which wraps a BitArray
+    - Optimized speed (~60% faster) and memory usage (~8x less) for PositionsInRadius
 	</PackageReleaseNotes>
 	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
- Modified `PositionsInRadius` to used cached Direction arrays (~60% speed increase)
    - Added performance tests for `PositionsInRadius` to validate
- Added a grid view that implements `ISettableGridView<bool>` as a wrapper around a `BitArray`
    - Memory usage ~8x better than `bool[]` for that purpose (`bool` is 1 byte, and `BitArray` uses only 1 bit per location)
    - `Clear` operation is much faster than `bool[]`, since it only involves bit sets 32x at a time
    - `Get` operation is slightly slower (about a quarter nanosecond); depends on use case and is hard to measure
- Added performance tests to justify `BitArray`
- Ported `PositionsInRadius` to use `BitArrayView` instead of array of bools
- Modified all packages to multi-target to .NET 6
- Bumped version of all packages
- Modified MonoGame and SFML packages to using floating version reference (1.*) to reference core `SadRogue.Primitives` package
    - This should cause the packages to always reference the latest stable 1.x release, which will prevent version updates from needing to be released for these packages upon minor version updates (providing no breaking changes)