### PR TITLE
Fixed repository URL in project files

### DIFF
--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -16,7 +16,7 @@
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
 	<PackageReleaseNotes>Multi-targeted to .NET 6.  Updated to depend on most recent 1.x release of core primitives.</PackageReleaseNotes>
-	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
+	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -15,8 +15,8 @@
 
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>Multi-targted to .NET 6.  Updated to use the most recent 1.x version of the primitives library.</PackageReleaseNotes>
-	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
+	<PackageReleaseNotes>Multi-targeted to .NET 6.  Updated to use the most recent 1.x version of the primitives library.</PackageReleaseNotes>
+	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -19,7 +19,7 @@
 		- Added grid view which wraps a BitArray
     - Optimized speed (~60% faster) and memory usage (~8x less) for PositionsInRadius
 	</PackageReleaseNotes>
-	<RepositoryUrl>https://https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
+	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Currently, the link to the repository on nuget.org is broken due to the schema being inserted twice.