### PR TITLE
Optimizations

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/FillAndClear.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/FillAndClear.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives.GridViews;
+
+namespace TheSadRogue.Primitives.PerformanceTests.GridViews
+{
+    public enum FillTestTypes
+    {
+        ArrayView,
+        ArrayView2D,
+        BitArrayView
+    }
+
+    public class FillAndClear
+    {
+        [Params(10, 100, 200)]
+        public int Size;
+
+        [ParamsAllValues]
+        public FillTestTypes Type;
+
+        private ISettableGridView<bool> _gridView = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _gridView = Type switch
+            {
+                FillTestTypes.ArrayView => new ArrayView<bool>(Size, Size),
+                FillTestTypes.ArrayView2D => new ArrayView2D<bool>(Size, Size),
+                FillTestTypes.BitArrayView => new BitArrayView(Size, Size),
+                _ => throw new Exception("Unsupported grid view type.")
+            };
+        }
+
+        [Benchmark]
+        public ISettableGridView<bool> Clear()
+        {
+            _gridView.Clear();
+
+            return _gridView;
+        }
+
+        [Benchmark]
+        public ISettableGridView<bool> Fill()
+        {
+            _gridView.Fill(true);
+            return _gridView;
+        }
+
+        [Benchmark]
+        public ISettableGridView<bool> OldFill()
+        {
+            // This method is much faster for BitArrayView, so we'll special-case it to provide the best optimization
+            // we can.  It's still better to call the BitArrayView directly, but since the Fill method can be
+            // easily 10x faster for Bit arrays, even with both of these casts it's still faster than not
+            if (_gridView is BitArrayView bitArray)
+                bitArray.Fill(true);
+            else
+                _gridView.ApplyOverlay(_ => true);
+
+            return _gridView;
+        }
+
+        [Benchmark]
+        public ISettableGridView<bool> ManualFill()
+        {
+            for (int i = 0; i < _gridView.Count; i++)
+                _gridView[i] = true;
+
+            return _gridView;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
@@ -1,0 +1,126 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+using SadRogue.Primitives.GridViews;
+
+namespace TheSadRogue.Primitives.PerformanceTests.GridViews
+{
+
+    public struct CustomPositionsEnumerable
+    {
+        private Point _current;
+
+        public Point Current => _current;
+
+        private readonly Rectangle _positions;
+
+        public CustomPositionsEnumerable(Rectangle positions)
+        {
+            _positions = positions;
+
+            _current = positions.MinExtent;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            //var maxExtent = _positions.MaxExtent;
+            if (_current.X < _positions.MaxExtent.X)
+            {
+                _current = new Point(_current.X + 1, _current.Y);
+                return true;
+            }
+            else if (_current.Y < _positions.MaxExtent.Y)
+            {
+                _current = new Point(_positions.MinExtent.X, _current.Y + 1);
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public CustomPositionsEnumerable GetEnumerator() => this;
+
+        public IEnumerable<Point> ToEnumerable()
+        {
+            foreach (var point in this)
+                yield return point;
+        }
+    }
+
+    public static class CustomPositionsExtension
+    {
+        public static CustomPositionsEnumerable PositionsCustom<T>(this IGridView<T> gridView)
+            => new CustomPositionsEnumerable(gridView.Bounds());
+    }
+
+    public class PositionsEnumeration
+    {
+        [Params(10, 100, 200)]
+        public int Size;
+
+        private IGridView<bool> _gridView = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _gridView = new ArrayView<bool>(Size, Size);
+        }
+
+        [Benchmark]
+        public int ManualPositionsIteration()
+        {
+            int sum = 0;
+            int height = _gridView.Height;
+            int width = _gridView.Width;
+            for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
+                    sum += x + y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ManualPositionsIterationNoCachingWidthHeight()
+        {
+            int sum = 0;
+            for (int y = 0; y < _gridView.Height; y++)
+            for (int x = 0; x < _gridView.Width; x++)
+                sum += x + y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PositionsIteration()
+        {
+            int sum = 0;
+            foreach (var pos in _gridView.Positions())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int CustomPositionsIteration()
+        {
+            int sum = 0;
+            foreach (var pos in _gridView.PositionsCustom())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int CustomPositionsEnumerableIteration()
+        {
+            int sum = 0;
+            foreach (var pos in _gridView.PositionsCustom().ToEnumerable())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Reports;
 using SadRogue.Primitives;
 using SadRogue.Primitives.GridViews;
 
@@ -39,7 +40,18 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
         }
 
         [Benchmark]
-        public int ManualPositionsIteration()
+        public int ManualPositionsIterationNormal()
+        {
+            int sum = 0;
+            for (int y = 0; y < _gridView.Height; y++)
+                for (int x = 0; x < _gridView.Width; x++)
+                    sum += x + y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ManualPositionsIterationCacheWidthHeight()
         {
             int sum = 0;
             int height = _gridView.Height;
@@ -52,12 +64,30 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
         }
 
         [Benchmark]
-        public int ManualPositionsIterationNoCachingWidthHeight()
+        public int ManualPositionsIterationCountNormal()
         {
             int sum = 0;
-            for (int y = 0; y < _gridView.Height; y++)
-            for (int x = 0; x < _gridView.Width; x++)
-                sum += x + y;
+            for (int i = 0; i < _gridView.Count; i++)
+            {
+                var pos = Point.FromIndex(i, _gridView.Width);
+                sum += pos.X + pos.Y;
+            }
+                
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ManualPositionsIterationCountCacheCountAndWidth()
+        {
+            int count = _gridView.Count;
+            int width = _gridView.Width;
+            int sum = 0;
+            for (int i = 0; i < count; i++)
+            {
+                var pos = Point.FromIndex(i, width);
+                sum += pos.X + pos.Y;
+            }
 
             return sum;
         }
@@ -73,7 +103,7 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
         }
 
         [Benchmark]
-        public int OldEnumerablePositionsIteration()
+        public int OldEnumerablePositionsIterationNormal()
         {
             int sum = 0;
             foreach (var pos in _gridView.PositionsIEnumerable())
@@ -93,7 +123,7 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
         }
 
         [Benchmark]
-        public int PositionsEnumerableIteration()
+        public int PositionsToEnumerableIteration()
         {
             int sum = 0;
             foreach (var pos in _gridView.Positions().ToEnumerable())

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Reports;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SadRogue.Primitives;
 using SadRogue.Primitives.GridViews;
 
@@ -23,6 +24,12 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
             for (int y = 0; y < height; y++)
                 for (int x = 0; x < width; x++)
                     yield return new Point(x, y);
+        }
+
+        public static IEnumerable<Point> ToEnumerableShortcut(this RectanglePositionsEnumerable enumerable)
+        {
+            foreach (var pos in enumerable)
+                yield return pos;
         }
     }
 
@@ -127,6 +134,16 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
         {
             int sum = 0;
             foreach (var pos in _gridView.Positions().ToEnumerable())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PositionsToEnumerableIterationShortcutMethod()
+        {
+            int sum = 0;
+            foreach (var pos in _gridView.Positions().ToEnumerableShortcut())
                 sum += pos.X + pos.Y;
 
             return sum;

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -34,7 +34,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.Y == yToCheck).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.Y == yToCheck).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
@@ -54,7 +54,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.X == rect.MaxExtentX).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.X == rect.MaxExtentX).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
@@ -76,7 +76,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.Y == yToCheck).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.Y == yToCheck).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
@@ -96,7 +96,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.X == rect.MinExtentX).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.X == rect.MinExtentX).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test

--- a/TheSadRogue.Primitives.UnitTests/GridViews/GridViewTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/GridViewTests.cs
@@ -231,5 +231,22 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             for (int i = 0; i < view.Count; i++)
                 Assert.Contains(Point.FromIndex(i, view.Width), set);
         }
+
+        [Fact]
+        public void PositionsEmptyRectTest()
+        {
+            var rect1 = new Rectangle(1, 2, 1, 0);
+            var rect2 = new Rectangle(1, 2, 0, 1);
+            var rect3 = new Rectangle(1, 2, 0, 0);
+
+            var set1 = rect1.Positions().ToEnumerable().ToHashSet();
+            Assert.Empty(set1);
+
+            var set2 = rect2.Positions().ToEnumerable().ToHashSet();
+            Assert.Empty(set2);
+
+            var set3 = rect3.Positions().ToEnumerable().ToHashSet();
+            Assert.Empty(set3);
+        }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/GridViews/GridViewTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/GridViewTests.cs
@@ -1,4 +1,5 @@
-﻿using SadRogue.Primitives.GridViews;
+﻿using System.Linq;
+using SadRogue.Primitives.GridViews;
 using SadRogue.Primitives.UnitTests.Mocks;
 using Xunit;
 // Should disable this because the functions triggering it are just assertion methods
@@ -215,6 +216,20 @@ namespace SadRogue.Primitives.UnitTests.GridViews
                     Assert.Equal(0, unboundedViewport[pos]);
                 else
                     Assert.Equal(1, unboundedViewport[pos]);
+        }
+
+        [Fact]
+        public void PositionsTest()
+        {
+            const int gridWidth = 80;
+            const int gridHeight = 61;
+
+            IGridView<bool> view = new ArrayView<bool>(gridWidth, gridHeight);
+            var set = view.Positions().ToEnumerable().ToHashSet();
+
+            Assert.Equal(view.Count, set.Count);
+            for (int i = 0; i < view.Count; i++)
+                Assert.Contains(Point.FromIndex(i, view.Width), set);
         }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/GridViews/GridViewTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/GridViewTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using SadRogue.Primitives.GridViews;
 using SadRogue.Primitives.UnitTests.Mocks;
 using Xunit;
@@ -233,20 +234,20 @@ namespace SadRogue.Primitives.UnitTests.GridViews
         }
 
         [Fact]
-        public void PositionsEmptyRectTest()
+        public void PositionsIEnumerableEquivalent()
         {
-            var rect1 = new Rectangle(1, 2, 1, 0);
-            var rect2 = new Rectangle(1, 2, 0, 1);
-            var rect3 = new Rectangle(1, 2, 0, 0);
+            const int gridWidth = 80;
+            const int gridHeight = 61;
 
-            var set1 = rect1.Positions().ToEnumerable().ToHashSet();
-            Assert.Empty(set1);
+            IGridView<bool> view = new ArrayView<bool>(gridWidth, gridHeight);
 
-            var set2 = rect2.Positions().ToEnumerable().ToHashSet();
-            Assert.Empty(set2);
+            var l1 = new List<Point>();
+            foreach (var pos in view.Positions())
+                l1.Add(pos);
 
-            var set3 = rect3.Positions().ToEnumerable().ToHashSet();
-            Assert.Empty(set3);
+            var l2 = view.Positions().ToEnumerable().ToList();
+
+            Assert.Equal((IEnumerable<Point>)l1, l2);
         }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
@@ -132,7 +132,7 @@ namespace SadRogue.Primitives.UnitTests
 
             // Positions returned should be exactly the ones within the radius
             var positionsHashExpected =
-                area.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
+                area.Positions().ToEnumerable().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
             Assert.Equal(positionsHashExpected, positionsHash);
         }
 
@@ -159,7 +159,7 @@ namespace SadRogue.Primitives.UnitTests
 
             // Positions returned should be exactly the ones within the radius
             var positionsHashExpected =
-                bounds.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
+                bounds.Positions().ToEnumerable().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
             Assert.Equal(positionsHashExpected, positionsHash);
         }
 

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -254,5 +254,22 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Empty(yLocations.Where(location => location < dividend.MinExtentY || location > dividend.MaxExtentY ));
         }
         #endregion
+
+        [Fact]
+        public void PositionsEmptyRectTest()
+        {
+            var rect1 = new Rectangle(1, 2, 1, 0);
+            var rect2 = new Rectangle(1, 2, 0, 1);
+            var rect3 = new Rectangle(1, 2, 0, 0);
+
+            var set1 = rect1.Positions().ToEnumerable().ToHashSet();
+            Assert.Empty(set1);
+
+            var set2 = rect2.Positions().ToEnumerable().ToHashSet();
+            Assert.Empty(set2);
+
+            var set3 = rect3.Positions().ToEnumerable().ToHashSet();
+            Assert.Empty(set3);
+        }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/Comparisons.cs
@@ -37,7 +37,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             };
 
         public static Func<object, object, bool> GetComparisonFunc(object obj)
-            => _equalityMethods.GetValueOrDefault(obj.GetType(), (o1, o2) => o1.Equals(o2))!;
+            => _equalityMethods.GetValueOrDefault(obj.GetType(), (o1, o2) => o1.Equals(o2));
 
         private static Func<object, object, bool> CastFromObject<T>(Func<T, T, bool> func)
             => (o1, o2) => func((T) o1, (T) o2);

--- a/TheSadRogue.Primitives.UnitTests/Serialization/ImplicitConversionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/ImplicitConversionTests.cs
@@ -18,9 +18,9 @@ namespace SadRogue.Primitives.UnitTests.Serialization
 
         private static MethodInfo? FindImplicitConversionOnType(Type typeToScan, Type from, Type to)
         {
-            typeToScan = TestData.ImplicitTypeConversionMap.GetValueOrDefault(typeToScan, typeToScan)!;
-            from = TestData.ImplicitTypeConversionMap.GetValueOrDefault(from, from)!;
-            to = TestData.ImplicitTypeConversionMap.GetValueOrDefault(to, to)!;
+            typeToScan = TestData.ImplicitTypeConversionMap.GetValueOrDefault(typeToScan, typeToScan);
+            from = TestData.ImplicitTypeConversionMap.GetValueOrDefault(from, from);
+            to = TestData.ImplicitTypeConversionMap.GetValueOrDefault(to, to);
 
             var methods = typeToScan.GetMethods();
             foreach (var method in methods)

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -418,7 +418,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="rectangle">Rectangle containing positions to remove.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Remove(Rectangle rectangle) => Remove(rectangle.Positions());
+        public void Remove(Rectangle rectangle) => Remove(rectangle.Positions().ToEnumerable());
 
         /// <summary>
         /// Returns the string of each position in the area, in a square-bracket enclosed list,

--- a/TheSadRogue.Primitives/GridViews/ArrayView.cs
+++ b/TheSadRogue.Primitives/GridViews/ArrayView.cs
@@ -97,11 +97,9 @@ namespace SadRogue.Primitives.GridViews
         /// <returns>The underlying ArrayView data as a 1D array.</returns>
         public T[] ToArray() => this;
 
-        /// <summary>
-        /// Sets each element in the ArrayView to the default for type T.
-        /// </summary>
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Clear() => Array.Clear(_array, 0, _array.Length);
+        public override void Clear() => Array.Clear(_array, 0, _array.Length);
 
         /// <summary>
         /// Returns a string representation of the grid values.

--- a/TheSadRogue.Primitives/GridViews/ArrayView2D.cs
+++ b/TheSadRogue.Primitives/GridViews/ArrayView2D.cs
@@ -104,11 +104,9 @@ namespace SadRogue.Primitives.GridViews
         /// <returns/>
         public static ArrayView2D<T> FromMultidimensionalArray(T[,] array) => new ArrayView2D<T>(array);
 
-        /// <summary>
-        /// Sets each element in the ArrayView to the default for type T.
-        /// </summary>
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Clear() => Array.Clear(_array, 0, _array.Length);
+        public override void Clear() => Array.Clear(_array, 0, _array.Length);
 
         /// <summary>
         /// Returns a string representation of the grid values.

--- a/TheSadRogue.Primitives/GridViews/BitArrayView.cs
+++ b/TheSadRogue.Primitives/GridViews/BitArrayView.cs
@@ -96,16 +96,9 @@ namespace SadRogue.Primitives.GridViews
         /// <returns>The underlying BitArray data as a 1D array.</returns>
         public BitArray ToBitArray() => this;
 
-        /// <summary>
-        /// Sets each location in the grid view to the value specified.
-        /// </summary>
-        /// <remarks>
-        /// This method is much faster than the typical Fill extension method for grid views; and is even faster than an
-        /// equivalently sized boolean array's Clear operation.
-        /// </remarks>
-        /// <param name="value">Value to fill the grid view with.</param>
+        /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Fill(bool value) => _array.SetAll(value);
+        public override void Fill(bool value) => _array.SetAll(value);
 
         /// <summary>
         /// Returns a string representation of the grid values.

--- a/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
+++ b/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
@@ -167,23 +167,6 @@ namespace SadRogue.Primitives.GridViews
         }
 
         /// <summary>
-        /// Sets each location in the grid view to the value specified.
-        /// </summary>
-        /// <typeparam name="T" />
-        /// <param name="self" />
-        /// <param name="value">Value to fill the grid view with.</param>
-        public static void Fill<T>(this ISettableGridView<T> self, T value)
-        {
-            // This method is much faster for BitArrayView, so we'll special-case it to provide the best optimization
-            // we can.  It's still better to call the BitArrayView directly, but since the Fill method can be
-            // easily 10x faster for Bit arrays, even with both of these casts it's still faster than not
-            if (self is BitArrayView bitArray && value is bool b)
-                bitArray.Fill(b);
-            else
-                self.ApplyOverlay(_ => value);
-        }
-
-        /// <summary>
         /// Iterates through each position in the grid view.
         /// </summary>
         /// <typeparam name="T" />

--- a/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
+++ b/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
@@ -172,11 +172,7 @@ namespace SadRogue.Primitives.GridViews
         /// <typeparam name="T" />
         /// <param name="gridView" />
         /// <returns>All positions in the IGridView.</returns>
-        public static IEnumerable<Point> Positions<T>(this IGridView<T> gridView)
-        {
-            for (var y = 0; y < gridView.Height; y++)
-                for (var x = 0; x < gridView.Width; x++)
-                    yield return new Point(x, y);
-        }
+        public static RectanglePositionsEnumerable Positions<T>(this IGridView<T> gridView)
+            => gridView.Bounds().Positions();
     }
 }

--- a/TheSadRogue.Primitives/GridViews/ISettableGridView.cs
+++ b/TheSadRogue.Primitives/GridViews/ISettableGridView.cs
@@ -48,5 +48,25 @@
         /// <param name="index1D">1D index of location to get/set the "value" for.</param>
         /// <returns>The "value" associated with the given location.</returns>
         new T this[int index1D] { get; set; }
+
+        /// <summary>
+        /// Sets every location within the grid view to the given value.
+        /// </summary>
+        /// <param name="value">Value to set to all locations in the grid view.</param>
+        void Fill(T value)
+        {
+            for (int i = 0; i < Count; i++)
+                this[i] = value;
+        }
+
+        /// <summary>
+        /// Sets every location within the grid view to the default value for the type.
+        /// </summary>
+        /// <remarks>
+        /// This function can sometimes be implemented more efficiently than Fill(default), so it is provided as an interface function to enable dispatching.
+        /// 
+        /// Remember the default value of a non-nullable type is null for reference types; so use with caution if your element type is non-nullable!
+        /// </remarks>
+        void Clear() => Fill(default!);
     }
 }

--- a/TheSadRogue.Primitives/GridViews/SettableGridView1DIndexBase.cs
+++ b/TheSadRogue.Primitives/GridViews/SettableGridView1DIndexBase.cs
@@ -45,5 +45,15 @@ namespace SadRogue.Primitives.GridViews
 
         /// <inheritdoc cref="ISettableGridView{T}"/>
         public abstract T this[int index1D] { get; set; }
+
+        /// <inheritdoc/>
+        public virtual void Fill(T value)
+        {
+            for (int i = 0; i < Count; i++)
+                this[i] = value;
+        }
+
+        /// <inheritdoc/>
+        public virtual void Clear() => Fill(default!);
     }
 }

--- a/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs
+++ b/TheSadRogue.Primitives/GridViews/SettableGridViewBase.cs
@@ -39,5 +39,15 @@ namespace SadRogue.Primitives.GridViews
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => this[Point.FromIndex(index1D, Width)] = value;
         }
+
+        /// <inheritdoc/>
+        public virtual void Fill(T value)
+        {
+            for (int i = 0; i < Count; i++)
+                this[i] = value;
+        }
+
+        /// <inheritdoc/>
+        public virtual void Clear() => Fill(default!);
     }
 }

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -546,12 +546,7 @@ namespace SadRogue.Primitives
         /// <returns>All positions in the rectangle.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IEnumerable<Point> Positions()
-        {
-            for (int y = Y; y <= MaxExtentY; y++)
-                for (int x = X; x <= MaxExtentX; x++)
-                    yield return new Point(x, y);
-        }
+        public RectanglePositionsEnumerable Positions() => new RectanglePositionsEnumerable(this);
 
         /// <summary>
         /// Creates and returns a new rectangle that has the same position and width as the current

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -36,7 +36,7 @@ namespace SadRogue.Primitives
         {
             _positions = positions;
 
-            _current = positions.MinExtent - new Point(1, 0);
+            _current = (_positions.Width * _positions.Height > 0) ? positions.MinExtent - new Point(1, 0) : _positions.MaxExtent;
         }
 
         /// <summary>

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -36,7 +36,7 @@ namespace SadRogue.Primitives
         {
             _positions = positions;
 
-            _current = positions.MinExtent;
+            _current = positions.MinExtent - new Point(1, 0);
         }
 
         /// <summary>
@@ -46,12 +46,12 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MoveNext()
         {
-            if (_current.X < _positions.MaxExtent.X)
+            if (_current.X + 1 <= _positions.MaxExtent.X)
             {
                 _current = new Point(_current.X + 1, _current.Y);
                 return true;
             }
-            else if (_current.Y < _positions.MaxExtent.Y)
+            else if (_current.Y + 1 <= _positions.MaxExtent.Y)
             {
                 _current = new Point(_positions.MinExtent.X, _current.Y + 1);
                 return true;

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -86,11 +86,10 @@ namespace SadRogue.Primitives
             //    yield return pos
             //
             // However, this is slightly faster.
-            int width = _positions.Width;
-            int height = _positions.Height;
+            var maxExtent = _positions.MaxExtent;
 
-            for (int y = 0; y < height; y++)
-                for (int x = 0; x < width; x++)
+            for (int y = _positions.MinExtentY; y <= maxExtent.Y; y++)
+                for (int x = _positions.MinExtentX; x < maxExtent.X; x++)
                     yield return new Point(x, y);
         }
     }

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -89,7 +89,7 @@ namespace SadRogue.Primitives
             var maxExtent = _positions.MaxExtent;
 
             for (int y = _positions.MinExtentY; y <= maxExtent.Y; y++)
-                for (int x = _positions.MinExtentX; x < maxExtent.X; x++)
+                for (int x = _positions.MinExtentX; x <= maxExtent.X; x++)
                     yield return new Point(x, y);
         }
     }

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -81,8 +81,17 @@ namespace SadRogue.Primitives
         /// </returns>
         public IEnumerable<Point> ToEnumerable()
         {
-            foreach (var point in this)
-                yield return point;
+            // This is equivalent of:
+            // foreach (var pos in this)
+            //    yield return pos
+            //
+            // However, this is slightly faster.
+            int width = _positions.Width;
+            int height = _positions.Height;
+
+            for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
+                    yield return new Point(x, y);
         }
     }
 }

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// A custom enumerator used to iterate over all positions within a rectangle with a foreach loop efficiently.
+    /// </summary>
+    /// <remarks>
+    /// This type is a struct, and as such is much more efficient than using the otherwise equivalent type of
+    /// IEnumerable&lt;Point&gt; with "yield return".  The type does contain a function <see cref="ToEnumerable"/> which
+    /// creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the returned layer sets to be used with
+    /// LINQ; however using this function is not recommended in situations where runtime performance is a primary
+    /// concern.
+    /// </remarks>
+    public struct RectanglePositionsEnumerable
+    {
+        // Suppress warning stating to use auto-property because we want to guarantee micro-performance
+        // characteristics.
+#pragma warning disable IDE0032 // Use auto property
+        private Point _current;
+#pragma warning restore IDE0032 // Use auto property
+
+        /// <summary>
+        /// The current value for enumeration.
+        /// </summary>
+        public Point Current => _current;
+
+        private readonly Rectangle _positions;
+
+        /// <summary>
+        /// Creates an enumerator which iterates over all positions in the given rectangle.
+        /// </summary>
+        /// <param name="positions">A rectangle containing the positions to iterate over.</param>
+        public RectanglePositionsEnumerable(Rectangle positions)
+        {
+            _positions = positions;
+
+            _current = positions.MinExtent;
+        }
+
+        /// <summary>
+        /// Advances the iterator to the next position.
+        /// </summary>
+        /// <returns>True if the a position within the rectangle was found; false otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            if (_current.X < _positions.MaxExtent.X)
+            {
+                _current = new Point(_current.X + 1, _current.Y);
+                return true;
+            }
+            else if (_current.Y < _positions.MaxExtent.Y)
+            {
+                _current = new Point(_positions.MinExtent.X, _current.Y + 1);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns this enumerator.
+        /// </summary>
+        /// <returns>This enumerator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RectanglePositionsEnumerable GetEnumerator() => this;
+
+        /// <summary>
+        /// Converts the result of the enumerable to a <see cref="IEnumerable{T}"/>, which can be useful if you need
+        /// to use the result with LINQ.
+        /// </summary>
+        /// <remarks>
+        /// Note that this function advances the state of the enumerator, evaluating it to its fullest extent.  Also
+        /// note that it is NOT recommended to use this function in cases where performance is critical.
+        /// </remarks>
+        /// <returns>
+        /// An IEnumerable&lt;Point&gt; which iterates over all positions within the rectangle specified to this
+        /// enumerator.
+        /// </returns>
+        public IEnumerable<Point> ToEnumerable()
+        {
+            foreach (var point in this)
+                yield return point;
+        }
+    }
+}

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.3.2</Version>
+	<Version>1.4.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
@@ -16,7 +16,11 @@
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>
-		- Modified Distance to use abstract class instead of switch expression for better performance.
+        - Removed IGridView.Fill extension method (replaced with interface methods)
+        - Added IGridView.Fill and IGridView.Clear as native interface methods
+            - Default implementations are provided, and the Base classes implement them as well
+		- Modified Positions() enumerable functions to use custom enumerators for improved performance with foreach loops
+            - Use Positions().ToEnumerable() if you need an IEnumerable for LINQ usage or similar
 	</PackageReleaseNotes>
 	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR implements various performance optimizations.

# Changes
- Removed `ISettableGridView.Fill` extension method and replaced it with a native interface method with a default implementation
    - Closes #76 
- Added `ISettableGridView.Clear` method to interface
- Modified `.Positions()` enumerator functions to return and use a custom iterator
    - The custom iterator has a `ToEnumerable()` function you can use to get an `IEnumerable<Point>` for LINQ usage, etc

# Notes and Benchmarks

## Grid View Fill and Clear
The `ISettableGridView.Fill` method currently in the integration library is convenient, but has a number of performance issues.  First, it really just calls `ApplyOverlay`, which uses a `Func` to specify the value to set; this adds many function calls which slows the process down.  Second, and more importantly, some grid view types like `ArrayView<T>` and `BitArrayView` can have their underlying data structures filled or cleared in a much more efficient way than simply iterating over all positions and assigning a value.

The current implementation of `ISettableGridView.Fill` uses a special case for `BitArray` to perform the operation faster for `BitArrayView`; but does nothing for `ArrayView`.  Furthermore, special-cases for various types is not a very flexible system for controlling this.  Therefore, this PR removes the extension method, and adds it as a method of `ISettableGridView` directly, so that implementers can provide their own implementations specific to their type.

A default interface implementation is provided in order to minimize impact to the existing API.  Additionally, the "base" classes for implementing your own grid views (`SettableGridViewBase`, etc) also provide implementations, so if custom classes inherit from these, there will be no additional work.  This allows `BitArrayView` and array view variations to provide a more efficient implementation.

Similarly, a `Clear` function has been added to the `ISettableGridView` interface, since clear can sometimes be implemented more efficiently than `Fill`.

The following performance tests outline the performance increases yielded as a result of this change on types which have the potential to implement fill/clear operations more efficiently:

|     Method | Size |         Type |           Mean |         Error |        StdDev |
|----------- |----- |------------- |---------------:|--------------:|--------------:|
|      Clear |   10 |    ArrayView |       7.518 ns |     0.1018 ns |     0.0952 ns |
|       Fill |   10 |    ArrayView |     347.121 ns |     4.7932 ns |     4.4836 ns |
|    OldFill |   10 |    ArrayView |   1,096.287 ns |     9.4300 ns |     8.3594 ns |
| ManualFill |   10 |    ArrayView |     517.721 ns |     8.5281 ns |     7.9771 ns |
|      Clear |   10 |  ArrayView2D |       7.683 ns |     0.1191 ns |     0.1114 ns |
|       Fill |   10 |  ArrayView2D |   1,422.502 ns |    22.7307 ns |    27.9153 ns |
|    OldFill |   10 |  ArrayView2D |   1,612.172 ns |    10.8591 ns |    10.1576 ns |
| ManualFill |   10 |  ArrayView2D |   1,639.171 ns |    13.0407 ns |    10.1813 ns |
|      Clear |   10 | BitArrayView |       5.829 ns |     0.0853 ns |     0.0756 ns |
|       Fill |   10 | BitArrayView |       5.427 ns |     0.0498 ns |     0.0416 ns |
|    OldFill |   10 | BitArrayView |       5.517 ns |     0.0955 ns |     0.0847 ns |
| ManualFill |   10 | BitArrayView |     603.479 ns |     5.5270 ns |     4.6153 ns |
|      Clear |  100 |    ArrayView |      89.358 ns |     0.3181 ns |     0.2483 ns |
|       Fill |  100 |    ArrayView |  33,291.069 ns |   550.4695 ns |   487.9768 ns |
|    OldFill |  100 |    ArrayView | 101,582.738 ns |   675.7490 ns |   632.0961 ns |
| ManualFill |  100 |    ArrayView |  50,033.891 ns |   390.2617 ns |   345.9569 ns |
|      Clear |  100 |  ArrayView2D |      87.728 ns |     0.4218 ns |     0.3522 ns |
|       Fill |  100 |  ArrayView2D | 137,495.269 ns |   478.7204 ns |   399.7533 ns |
|    OldFill |  100 |  ArrayView2D | 151,239.834 ns |   456.4445 ns |   356.3618 ns |
| ManualFill |  100 |  ArrayView2D | 162,698.369 ns | 1,339.3460 ns | 1,187.2954 ns |
|      Clear |  100 | BitArrayView |      23.143 ns |     0.1230 ns |     0.1151 ns |
|       Fill |  100 | BitArrayView |      18.798 ns |     0.0725 ns |     0.0679 ns |
|    OldFill |  100 | BitArrayView |      19.321 ns |     0.0733 ns |     0.0650 ns |
| ManualFill |  100 | BitArrayView |  58,734.706 ns |   410.5886 ns |   384.0648 ns |
|      Clear |  200 |    ArrayView |     612.813 ns |     5.2026 ns |     4.8665 ns |
|       Fill |  200 |    ArrayView | 133,094.646 ns | 1,018.6014 ns |   902.9636 ns |
|    OldFill |  200 |    ArrayView | 407,197.750 ns | 2,306.1648 ns | 2,044.3550 ns |
| ManualFill |  200 |    ArrayView | 199,615.820 ns | 1,626.6210 ns | 1,358.3022 ns |
|      Clear |  200 |  ArrayView2D |     608.558 ns |    12.1963 ns |    12.5247 ns |
|       Fill |  200 |  ArrayView2D | 552,939.521 ns | 2,164.6341 ns | 1,807.5675 ns |
|    OldFill |  200 |  ArrayView2D | 612,126.322 ns | 3,703.7907 ns | 3,464.5281 ns |
| ManualFill |  200 |  ArrayView2D | 645,408.421 ns | 3,129.0164 ns | 2,612.8704 ns |
|      Clear |  200 | BitArrayView |      53.136 ns |     0.2383 ns |     0.1861 ns |
|       Fill |  200 | BitArrayView |      66.284 ns |     0.2616 ns |     0.2319 ns |
|    OldFill |  200 | BitArrayView |      66.551 ns |     0.2705 ns |     0.2259 ns |
| ManualFill |  200 | BitArrayView | 233,529.564 ns | 2,152.5208 ns | 2,013.4693 ns |

`Clear` and `Fill` represent this PR's implementation of those functions.  `OldFill` represents the old extension method.  `ManualFill` represents the result of using a set of `for` loops to just set the new value to each location (the default implementation of the interface method).

As evidence by the above tests, the current `Fill` and `Clear` implementations far out-perform the current implementations on these types.

Note that the `OldFill` function has the same special case for `BitArrayView` as the old implementation did; this is why the performance gains aren't as evident on this type.

## Positions Enumerables
Currently, `Rectangle` and `IGridView` both provide a `Positions` function of some sort to iterate over all positions in them.  This is implemented by simply using `yield return` to create an `IEnumerable<Point>`.  However, since points are small value types, the overhead of enumerables/generators comes into play heavily here, particularly if the body of the loop is relatively fast.

This PR, therefore, implements a custom enumerator for enumerating over the positions in a rectangular area, and uses that enumerator to implement the `Positions()` functions for both `Rectangle` and `IGridView`.  The new `Positions` function will work identically in a foreach loop, but it's a struct and therefore avoids much of the boxing and allocation that has to take place in the case of the `IEnumerable` implementation.

One result of this change is that you can no longer use `System.Linq` functions directly on the result of the `Positions()` function.  For this use case, the enumerator which is now returned by that function has a `ToEnumerator()` function; so where before you might do `myGridView.Positions().Where(p => p.X == 10)`, you can now do `myGridView.Positions().ToEnumerable().Where(p => p.X == 10)`.

Also note that `ToEnumerable()` is implemented slightly differently (internally) than the previous `Positions()` function was; the new way is slightly better performance wise.

The following outlines the results of performance tests on this new implementation vs the old one:

|                                          Method | Size |          Mean |        Error |       StdDev |
|------------------------------------------------ |----- |--------------:|-------------:|-------------:|
|                  ManualPositionsIterationNormal |   10 |     209.19 ns |     1.035 ns |     0.808 ns |
|        ManualPositionsIterationCacheWidthHeight |   10 |      41.34 ns |     0.204 ns |     0.181 ns |
|             ManualPositionsIterationCountNormal |   10 |     768.99 ns |     5.721 ns |     5.071 ns |
| ManualPositionsIterationCountCacheCountAndWidth |   10 |     364.11 ns |     1.875 ns |     1.565 ns |
|                              PositionsIteration |   10 |     162.65 ns |     0.772 ns |     0.722 ns |
|           OldEnumerablePositionsIterationNormal |   10 |     777.74 ns |     7.341 ns |     6.866 ns |
| OldEnumerablePositionsIterationCacheWidthHeight |   10 |     654.60 ns |     3.705 ns |     3.285 ns |
|                  PositionsToEnumerableIteration |   10 |     638.97 ns |     2.324 ns |     1.815 ns |
|    PositionsToEnumerableIterationShortcutMethod |   10 |     731.70 ns |     1.989 ns |     1.763 ns |
|                  ManualPositionsIterationNormal |  100 |  20,835.91 ns |   157.029 ns |   146.885 ns |
|        ManualPositionsIterationCacheWidthHeight |  100 |   4,705.53 ns |    17.613 ns |    15.613 ns |
|             ManualPositionsIterationCountNormal |  100 |  75,506.37 ns |   412.176 ns |   365.384 ns |
| ManualPositionsIterationCountCacheCountAndWidth |  100 |  35,312.72 ns |   170.125 ns |   159.135 ns |
|                              PositionsIteration |  100 |  15,450.15 ns |   168.212 ns |   140.464 ns |
|           OldEnumerablePositionsIterationNormal |  100 |  73,348.51 ns |   464.810 ns |   434.784 ns |
| OldEnumerablePositionsIterationCacheWidthHeight |  100 |  63,980.28 ns |   207.250 ns |   161.807 ns |
|                  PositionsToEnumerableIteration |  100 |  61,171.52 ns |   175.065 ns |   163.756 ns |
|    PositionsToEnumerableIterationShortcutMethod |  100 |  70,518.70 ns |   154.078 ns |   128.662 ns |
|                  ManualPositionsIterationNormal |  200 |  74,758.23 ns |   809.573 ns |   757.275 ns |
|        ManualPositionsIterationCacheWidthHeight |  200 |  18,763.24 ns |    29.602 ns |    27.689 ns |
|             ManualPositionsIterationCountNormal |  200 | 301,921.13 ns | 1,477.911 ns | 1,310.130 ns |
| ManualPositionsIterationCountCacheCountAndWidth |  200 | 140,903.36 ns |   634.363 ns |   529.722 ns |
|                              PositionsIteration |  200 |  60,929.27 ns |   173.272 ns |   162.079 ns |
|           OldEnumerablePositionsIterationNormal |  200 | 292,128.97 ns | 1,353.992 ns | 1,130.645 ns |
| OldEnumerablePositionsIterationCacheWidthHeight |  200 | 254,856.63 ns |   680.767 ns |   568.471 ns |
|                  PositionsToEnumerableIteration |  200 | 244,469.45 ns |   947.353 ns |   886.155 ns |
|    PositionsToEnumerableIterationShortcutMethod |  200 | 282,435.41 ns |   990.563 ns |   827.165 ns |

Brief descriptions of and observations about the tests above:
- **PositionsIteration:** Tests which use this PR's implementation of `Positions()`, which uses the custom enumerator.
- **ManualPositionsIteration\*:** Tests which use a set of for loops (or a single in the case of the `Count` tests instead of an enumerator of any sort.  the `Cache*` tests use loops where the `Width` and `Height` are cached, instead of baked into the loop conditional (see source code for details).
- **OldEnumerablePositions\*:** Tests which use the old implementation of the `Positions()` functions, which uses `yield return` and `IEnumerable<Point>`.  As before, the `Cache` versions simply cache width/height values as appropriate instead of calling on the property of the grid view in the loop condition.
- **PositionsToEnumerableIteration:** Tests which use the custom enumerable's `ToEnumerable` function to work with an `IEnumerable`.  This represents the new approach a user would take if they specifically need an `IEnumerable` for `System.Linq` or similar.
- **PositionsToEnumerableIterationShortcutMethod: ** Similar to `PositionsToEnumerableIteration`, but uses an alternate method which proves slower (for reference as to why the current implementation is the way it is).

Notably, the `PositionsIteration` test, eg. the one that uses this PR's custom enumerator, is faster than nearly everything else; _including_ `ManualPositionsIterationNormal`, which I would argue represents the most common way a user would implement the loops manually.  You can, of course, achieve superior performance with manual for loops by caching the width/height; but this is to be expected (no enumerator in C# has 0 overhead).  For reference, the new `Positions()` implementation is about 6-8x faster than the old one in these test cases.

# Breaking Changes
This PR minimizes breaking changes, but there are a few limited cases where some minor breaking can occur.

First, if a user has a custom implementation of `ISettableGridView`, which does _not_ inherit from one of the provided base classes, _and_ they also call `Fill` on that view without it being casted to `ISettableGridView`, then they will have to add that function to their implementation.  This should be extremely straightforward, and should only apply in a very limited subset of cases.

Second, any use case of `Positions()` functions which depend on the result being `IEnumerable<Point>` will require slight modifications to account for this update.  These use cases would include anything operating on the `Positions()` result using `System.Linq`, and perhaps some custom interfaces.  `myObj.Positions()` must now be written as `myObj.Positions().ToEnumerable()` in these cases.  This change should be straightforward as well, however, and simple `foreach` usages (arguably the most common) obviously will not need this change.

Although I typically don't like introducing these types of breaking changes (although very minor ones) within a minor version, these changes do provide a significant performance boost as outlined above, so I believe they should be worth it here given the minimal impact to the API.