### PR TITLE
Optimize Bisection API and Area Enumeration

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -42,6 +42,26 @@ namespace TheSadRogue.Primitives.PerformanceTests
         }
 
         [Benchmark]
+        public int BenchmarkFastEnumerable()
+        {
+            int sum = 0;
+            foreach (var pos in _areaInterface.FastEnumerator())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BenchmarkFastEnumerableAsConcrete()
+        {
+            int sum = 0;
+            foreach (var pos in _area.FastEnumerator())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
         public int BenchmarkManualFor()
         {
             int sum = 0;

--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -40,15 +40,5 @@ namespace TheSadRogue.Primitives.PerformanceTests
 
             return sum;
         }
-
-        [Benchmark]
-        public int BenchmarkFastEnumerable()
-        {
-            int sum = 0;
-            foreach (var pos in _areaInterface.FastEnumerator())
-                sum += pos.X + pos.Y;
-
-            return sum;
-        }
     }
 }

--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -1,0 +1,54 @@
+﻿using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks for <see cref="SadRogue.Primitives.Area"/>.
+    /// </summary>
+    public class Area
+    {
+        [Params(10, 100, 200)]
+        public int Size;
+
+        private SadRogue.Primitives.Area _area = null!;
+        private IReadOnlyArea _areaInterface = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions().ToEnumerable());
+            _areaInterface = _area;
+        }
+
+        [Benchmark]
+        public int BenchmarkEnumerable()
+        {
+            int sum = 0;
+            foreach (var pos in _areaInterface)
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BenchmarkEnumerableAsConcrete()
+        {
+            int sum = 0;
+            foreach (var pos in _area)
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BenchmarkFastEnumerable()
+        {
+            int sum = 0;
+            foreach (var pos in _areaInterface.FastEnumerator())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -12,6 +12,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public int Size;
 
         private SadRogue.Primitives.Area _area = null!;
+        private SadRogue.Primitives.Area _area2 = null!;
         private IReadOnlyArea _areaInterface = null!;
 
         [GlobalSetup]
@@ -19,6 +20,8 @@ namespace TheSadRogue.Primitives.PerformanceTests
         {
             _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions().ToEnumerable());
             _areaInterface = _area;
+
+            _area2 = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size / 2, Size / 2).Positions().ToEnumerable());
         }
 
         [Benchmark]
@@ -114,5 +117,23 @@ namespace TheSadRogue.Primitives.PerformanceTests
 
             return sum;
         }
+
+        [Benchmark]
+        public SadRogue.Primitives.Area Intersection()
+            => SadRogue.Primitives.Area.GetIntersection(_area, _area2);
+
+        [Benchmark]
+        public SadRogue.Primitives.Area Difference()
+            => SadRogue.Primitives.Area.GetDifference(_area, _area2);
+
+        [Benchmark]
+        public SadRogue.Primitives.Area Union()
+            => SadRogue.Primitives.Area.GetUnion(_area, _area2);
+
+        [Benchmark]
+        public bool ContainsArea()
+            => _area.Contains(_area2);
+
+
     }
 }

--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -40,5 +40,59 @@ namespace TheSadRogue.Primitives.PerformanceTests
 
             return sum;
         }
+
+        [Benchmark]
+        public int BenchmarkManualFor()
+        {
+            int sum = 0;
+            for (int i = 0; i < _areaInterface.Count; i++)
+            {
+                var pos = _areaInterface[i];
+                sum += pos.X + pos.Y;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BenchmarkManualForCachedCount()
+        {
+            int sum = 0;
+            int count = _areaInterface.Count;
+            for (int i = 0; i < count; i++)
+            {
+                var pos = _areaInterface[i];
+                sum += pos.X + pos.Y;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BenchmarkManualForAsConcrete()
+        {
+            int sum = 0;
+            for (int i = 0; i < _area.Count; i++)
+            {
+                var pos = _area[i];
+                sum += pos.X + pos.Y;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BenchmarkManualForAsConcreteCachedCount()
+        {
+            int sum = 0;
+            int count = _area.Count;
+            for (int i = 0; i < count; i++)
+            {
+                var pos = _area[i];
+                sum += pos.X + pos.Y;
+            }
+
+            return sum;
+        }
     }
 }

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Reports;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SadRogue.Primitives;
 using SadRogue.Primitives.GridViews;
 

--- a/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    public static class RectangleTestingExtensions
+    {
+        public static IEnumerable<SadRogue.Primitives.Rectangle> BisectHorizontallyNativeEnumerator(this SadRogue.Primitives.Rectangle rectangle)
+        {
+            int startX = rectangle.MinExtentX;
+            int stopY = rectangle.MaxExtentY;
+            int startY = rectangle.MinExtentY;
+            int stopX = rectangle.MaxExtentX;
+            int bisection = (startY + stopY) / 2;
+
+            yield return new SadRogue.Primitives.Rectangle(new Point(startX, startY), new Point(stopX, bisection));
+            yield return new SadRogue.Primitives.Rectangle(new Point(startX, bisection + 1), new Point(stopX, stopY));
+        }
+    }
+
+    /// <summary>
+    /// Benchmarks for <see cref="SadRogue.Primitives.Rectangle"/>.
+    /// </summary>
+    public class Rectangle
+    {
+        [Params(10, 50, 100)]
+        public int Width;
+        [Params(10, 50, 100)]
+        public int Height;
+
+        private SadRogue.Primitives.Rectangle _rectangle;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _rectangle = new SadRogue.Primitives.Rectangle(0, 0, Width, Height);
+        }
+
+        #region Library Implementations
+
+        [Benchmark]
+        public int Bisect()
+        {
+            var result = _rectangle.Bisect();
+            int sum = result.Rect1.Width + result.Rect1.Height;
+            sum += result.Rect2.Width + result.Rect2.Height;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BisectVertically()
+        {
+            var result = _rectangle.BisectVertically();
+            int sum = result.Rect1.Width + result.Rect1.Height;
+            sum += result.Rect2.Width + result.Rect2.Height;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BisectHorizontally()
+        {
+            var result = _rectangle.BisectHorizontally();
+            int sum = result.Rect1.Width + result.Rect1.Height;
+            sum += result.Rect2.Width + result.Rect2.Height;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BisectRecursive()
+        {
+            int sum = 0;
+            foreach (var rect in _rectangle.BisectRecursive(3))
+                sum += rect.Width + rect.Height;
+
+            return sum;
+        }
+
+
+        [Benchmark]
+        public int BisectToEnumerable()
+        {
+            int sum = 0;
+            foreach (var rect in _rectangle.Bisect().ToEnumerable())
+                sum += rect.Width + rect.Height;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BisectVerticallyToEnumerable()
+        {
+            int sum = 0;
+            foreach (var rect in _rectangle.BisectVertically().ToEnumerable())
+                sum += rect.Width + rect.Height;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int BisectHorizontallyToEnumerable()
+        {
+            int sum = 0;
+            foreach (var rect in _rectangle.BisectHorizontally().ToEnumerable())
+                sum += rect.Width + rect.Height;
+
+            return sum;
+        }
+        #endregion
+
+        #region IEnumerable Implementations
+
+        [Benchmark]
+        public int BisectHorizontallyNativeEnumerable()
+        {
+            int sum = 0;
+            foreach (var rect in _rectangle.BisectHorizontallyNativeEnumerator())
+                sum += rect.Width + rect.Height;
+
+            return sum;
+        }
+        #endregion
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/DirectionTests.cs
@@ -80,8 +80,8 @@ namespace SadRogue.Primitives.UnitTests
             );
 
         public static IEnumerable<(Direction, bool)> IsCardinalPairs
-            => AdjacencyRule.Cardinals.DirectionsOfNeighbors().Combinate(true.ToEnumerable())
-                .Concat(AdjacencyRule.Diagonals.DirectionsOfNeighbors().Combinate(false.ToEnumerable()))
+            => AdjacencyRule.Cardinals.DirectionsOfNeighbors().Combinate(true.Yield())
+                .Concat(AdjacencyRule.Diagonals.DirectionsOfNeighbors().Combinate(false.Yield()))
                 .Append((Direction.None, false));
 
         #endregion

--- a/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
+++ b/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
@@ -13,7 +13,7 @@ namespace SadRogue.Primitives.UnitTests
     {
         public static void Fail(string message) => Assert.True(false, message);
 
-        public static IEnumerable<T> ToEnumerable<T>(this T obj)
+        public static IEnumerable<T> Yield<T>(this T obj)
         {
             yield return obj;
         }

--- a/TheSadRogue.Primitives.UnitTests/AdjacencyRuleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AdjacencyRuleTests.cs
@@ -76,9 +76,9 @@ namespace SadRogue.Primitives.UnitTests
             => new[] { Direction.Up, Direction.Right, Direction.Down, Direction.Left };
 
         public static IEnumerable<(AdjacencyRule, Direction)> ClockwisePairs
-            => AdjacencyRule.EightWay.ToEnumerable().Combinate(EightWayDirectionsClockwise)
-                .Concat(AdjacencyRule.Cardinals.ToEnumerable().Combinate(CardinalsDirectionsClockwise))
-                .Concat(AdjacencyRule.Diagonals.ToEnumerable().Combinate(DiagonalDirectionsClockwise));
+            => AdjacencyRule.EightWay.Yield().Combinate(EightWayDirectionsClockwise)
+                .Concat(AdjacencyRule.Cardinals.Yield().Combinate(CardinalsDirectionsClockwise))
+                .Concat(AdjacencyRule.Diagonals.Yield().Combinate(DiagonalDirectionsClockwise));
 
         public static IEnumerable<(AdjacencyRule, Direction)> AdjacencyDefaultsClockwise
             => TestUtils.Enumerable((AdjacencyRule.Cardinals, Direction.Up), (AdjacencyRule.EightWay, Direction.Up),
@@ -89,8 +89,8 @@ namespace SadRogue.Primitives.UnitTests
                 (AdjacencyRule.Diagonals, Direction.UpLeft));
 
         public static IEnumerable<(AdjacencyRule, Direction)> RotatePairs =>
-            AdjacencyRule.Cardinals.ToEnumerable().Combinate(DiagonalDirectionsClockwise)
-                .Concat(AdjacencyRule.Diagonals.ToEnumerable().Combinate(CardinalsDirectionsClockwise));
+            AdjacencyRule.Cardinals.Yield().Combinate(DiagonalDirectionsClockwise)
+                .Concat(AdjacencyRule.Diagonals.Yield().Combinate(CardinalsDirectionsClockwise));
 
         public static IEnumerable<(Point, AdjacencyRule)> PointAdjacencyPairs =>
             TestUtils.Enumerable<Point>((1, 2), (-1, -2), (0, 4), (3, 0)).Combinate(AdjacencyRules);

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace SadRogue.Primitives.UnitTests
@@ -9,14 +10,30 @@ namespace SadRogue.Primitives.UnitTests
     public class AreaTests
     {
         [Fact]
-        public void EnumerableEquivalence()
+        public void EnumerableCorrect()
         {
-            var area = new Area(new Rectangle(0, 0, 15, 15).Positions().ToEnumerable());
+            var rect = new Rectangle(0, 0, 15, 15);
+            var area = new Area(rect.Positions().ToEnumerable());
+            IReadOnlyArea areaInterface = area;
 
-            var l1 = area.ToList();
-            var l2 = area.FastEnumerator().ToEnumerable().ToList();
+            var expected = new List<Point>();
+            for (int i = 0; i < area.Count; i++)
+                expected.Add(area[i]);
 
-            Assert.Equal(l1, l2);
+            List<Point> l1 = area.ToEnumerable().ToList();
+
+            var l2 = new List<Point>();
+            foreach (var pos in area)
+                l2.Add(pos);
+
+            var l3 = new List<Point>();
+            foreach (var pos in areaInterface)
+                l3.Add(pos);
+            
+
+            Assert.Equal(expected, l1);
+            Assert.Equal(expected, l2);
+            Assert.Equal(expected, l3);
         }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace SadRogue.Primitives.UnitTests
+{
+    /// <summary>
+    /// Tests for the <see cref="Area"/> class
+    /// </summary>
+    public class AreaTests
+    {
+        [Fact]
+        public void EnumerableEquivalence()
+        {
+            var area = new Area(new Rectangle(0, 0, 15, 15).Positions().ToEnumerable());
+
+            var l1 = area.ToList();
+            var l2 = area.FastEnumerator().ToEnumerable().ToList();
+
+            Assert.Equal(l1, l2);
+        }
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -20,7 +20,7 @@ namespace SadRogue.Primitives.UnitTests
             for (int i = 0; i < area.Count; i++)
                 expected.Add(area[i]);
 
-            List<Point> l1 = area.ToEnumerable().ToList();
+            List<Point> l1 = area.ToList();
 
             var l2 = new List<Point>();
             foreach (var pos in area)
@@ -29,11 +29,17 @@ namespace SadRogue.Primitives.UnitTests
             var l3 = new List<Point>();
             foreach (var pos in areaInterface)
                 l3.Add(pos);
+
+            var l4 = new List<Point>();
+            foreach (var pos in area.FastEnumerator())
+                l4.Add(pos);
             
 
             Assert.Equal(expected, l1);
             Assert.Equal(expected, l2);
             Assert.Equal(expected, l3);
+            Assert.Equal(expected, l4);
+
         }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -132,7 +132,7 @@ namespace SadRogue.Primitives.UnitTests
             {
                 for (int j = 0; j < 30; j++)
                 {
-                    int count = rectangles.Where(r => r.Contains(new Point(i, j))).Count();
+                    int count = rectangles.Count(r => r.Contains(new Point(i, j)));
                     Assert.Equal(1, count);
                 }
             }
@@ -142,7 +142,7 @@ namespace SadRogue.Primitives.UnitTests
         public void BisectInHalfTest()
         {
             Rectangle rectangle = new Rectangle(0, 0, 5, 13);
-            List<Rectangle> rectangles = rectangle.Bisect().ToList();
+            List<Rectangle> rectangles = rectangle.Bisect().ToEnumerable().ToList();
             foreach (Point c in rectangles[0].Positions())
             {
                 Assert.True(rectangle.Contains(c));
@@ -163,7 +163,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(5, rectangles[1].Width);
 
             rectangle = new Rectangle(0, 0, 13, 5);
-            rectangles.AddRange(rectangle.Bisect().ToList());
+            rectangles.AddRange(rectangle.Bisect().ToEnumerable());
             foreach (Point c in rectangles[2].Positions())
             {
                 Assert.True(rectangle.Contains(c));
@@ -188,7 +188,7 @@ namespace SadRogue.Primitives.UnitTests
         public void BisectHorizontallyTest()
         {
             Rectangle rectangle = new Rectangle(0, 0, 5, 13);
-            List<Rectangle> rectangles = rectangle.BisectHorizontally().ToList();
+            List<Rectangle> rectangles = rectangle.BisectHorizontally().ToEnumerable().ToList();
             foreach (Point c in rectangles[0].Positions())
             {
                 Assert.True(rectangle.Contains(c));
@@ -208,7 +208,7 @@ namespace SadRogue.Primitives.UnitTests
         public void BisectVerticallyTest()
         {
             Rectangle rectangle = new Rectangle(0, 0, 13, 5);
-            List<Rectangle> rectangles = rectangle.BisectVertically().ToList();
+            List<Rectangle> rectangles = rectangle.BisectVertically().ToEnumerable().ToList();
             foreach (Point c in rectangles[0].Positions())
             {
                 Assert.True(rectangle.Contains(c));

--- a/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
@@ -38,6 +38,12 @@ namespace SadRogue.Primitives.UnitTests.Serialization
                 },
                 PointHasher = EqualityComparer<Point>.Default
             },
+            // BisectionResultSerialized
+            new BisectionResultSerialized()
+            {
+                Rect1 = new Rectangle(1, 2, 5, 7),
+                Rect2 = new Rectangle(7, 8, 10, 19)
+            },
             // BoundedRectangleSerialized
             new BoundedRectangleSerialized
             {
@@ -170,6 +176,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         {
             // AdjacencyRules
             AdjacencyRule.Cardinals, AdjacencyRule.EightWay,
+            // BisectionResult
+            new BisectionResult(new Rectangle(1, 2, 5, 7), new Rectangle(7, 8, 10, 19)),
             // BoundedRectangle
             new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
             // Colors
@@ -203,6 +211,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             { typeof(AdjacencyRule), new[] { "Type" } },
             { typeof(ArrayViewSerialized<int>), new[] { "Width", "Data" } },
             { typeof(AreaSerialized), new[] { "Positions", "PointHasher" } },
+            { typeof(BisectionResult), new[] { "Rect1", "Rect2" } },
+            { typeof(BisectionResultSerialized), new[] { "Rect1", "Rect2" } },
             { typeof(BoundedRectangle), new[] { "_area", "_boundingBox" } },
             { typeof(BoundedRectangleSerialized), new[] { "Area", "Bounds" } },
             { typeof(Color), new[] { "_packedValue" } },
@@ -254,6 +264,7 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             [typeof(ArrayView<int>)] = typeof(ArrayViewSerialized<int>),
             [typeof(AdjacencyRule)] = typeof(AdjacencyRule.Types),
             [typeof(Area)] = typeof(AreaSerialized),
+            [typeof(BisectionResult)] = typeof(BisectionResultSerialized),
             [typeof(BoundedRectangle)] = typeof(BoundedRectangleSerialized),
             [typeof(Color)] = typeof(ColorSerialized),
             // [typeof(DiffAwareGridView<int>)] = typeof(DiffAwareGridViewSerialized<int>),

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -486,9 +486,7 @@ namespace SadRogue.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Swap(ref IReadOnlyArea lhs, ref IReadOnlyArea rhs)
         {
-            IReadOnlyArea temp = lhs;
-            lhs = rhs;
-            rhs = temp;
+            (rhs, lhs) = (lhs, rhs);
         }
 
         private static IEnumerable<Point> YieldPoint(Point item)

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -448,13 +448,13 @@ namespace SadRogue.Primitives
         /// Returns an enumerator that iterates through all positions in the Area, in the order they were added.
         /// </summary>
         /// <returns>An enumerator that iterates through all the positions in the Area, in the order they were added.</returns>
-        public ReadOnlyAreaPostionsEnumerable GetEnumerator() => new ReadOnlyAreaPostionsEnumerable(this);
+        public IEnumerator<Point> GetEnumerator() => _positions.GetEnumerator();
 
         /// <summary>
         /// Returns an enumerator that iterates through all positions in the Area, in the order they were added.
         /// </summary>
         /// <returns>An enumerator that iterates through all the positions in the Area, in the order they were added.</returns>
-        //IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_positions).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_positions).GetEnumerator();
 
         private void RecalculateBounds()
         {

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -90,6 +89,9 @@ namespace SadRogue.Primitives
         /// </summary>
         public int Count => _positions.Count;
 
+        /// <inheritdoc/>
+        public bool UseIndexEnumeration => true;
+
         /// <summary>
         /// Gets an area containing all positions in <paramref name="area1"/>, minus those that are in
         /// <paramref name="area2"/>.
@@ -164,7 +166,7 @@ namespace SadRogue.Primitives
         {
             Area retVal = new Area();
 
-            foreach (Point pos in lhs)
+            foreach (Point pos in lhs.FastEnumerator())
                 retVal.Add(pos + rhs);
 
             return retVal;
@@ -267,7 +269,7 @@ namespace SadRogue.Primitives
         /// <param name="area">Area containing positions to add.</param>
         public void Add(IReadOnlyArea area)
         {
-            foreach (Point pos in area)
+            foreach (Point pos in area.FastEnumerator())
                 Add(pos);
         }
 
@@ -329,7 +331,7 @@ namespace SadRogue.Primitives
                 return false;
             }
 
-            foreach (Point pos in area)
+            foreach (Point pos in area.FastEnumerator())
                 if (Contains(pos))
                     return true;
 
@@ -363,10 +365,14 @@ namespace SadRogue.Primitives
         {
             bool recalculateBounds = false;
 
-            foreach (Point pos in _positions.Where(predicate))
+            foreach (Point pos in _positions)
+            {
+                if (!predicate(pos)) continue;
+
                 if (_positionsSet.Remove(pos))
                     if (pos.X == _left || pos.X == _right || pos.Y == _top || pos.Y == _bottom)
                         recalculateBounds = true;
+            }
 
             _positions.RemoveAll(c => predicate(c));
 

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -448,13 +448,13 @@ namespace SadRogue.Primitives
         /// Returns an enumerator that iterates through all positions in the Area, in the order they were added.
         /// </summary>
         /// <returns>An enumerator that iterates through all the positions in the Area, in the order they were added.</returns>
-        public IEnumerator<Point> GetEnumerator() => _positions.GetEnumerator();
+        public ReadOnlyAreaPostionsEnumerable GetEnumerator() => new ReadOnlyAreaPostionsEnumerable(this);
 
         /// <summary>
         /// Returns an enumerator that iterates through all positions in the Area, in the order they were added.
         /// </summary>
         /// <returns>An enumerator that iterates through all the positions in the Area, in the order they were added.</returns>
-        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_positions).GetEnumerator();
+        //IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_positions).GetEnumerator();
 
         private void RecalculateBounds()
         {

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -104,7 +104,7 @@ namespace SadRogue.Primitives
         {
             Area retVal = new Area();
 
-            foreach (Point pos in area1)
+            foreach (Point pos in area1.FastEnumerator())
             {
                 if (area2.Contains(pos))
                     continue;
@@ -129,9 +129,9 @@ namespace SadRogue.Primitives
                 return retVal;
 
             if (area1.Count > area2.Count)
-                Swap(ref area1, ref area2);
+                (area2, area1) = (area1, area2);
 
-            foreach (Point pos in area1)
+            foreach (Point pos in area1.FastEnumerator())
                 if (area2.Contains(pos))
                     retVal.Add(pos);
 
@@ -302,7 +302,7 @@ namespace SadRogue.Primitives
             if (!Bounds.Contains(area.Bounds))
                 return false;
 
-            foreach (Point pos in area)
+            foreach (Point pos in area.FastEnumerator())
                 if (!Contains(pos))
                     return false;
 
@@ -344,8 +344,14 @@ namespace SadRogue.Primitives
         /// remove operations, it would be best to group them into 1 using <see cref="Remove(IEnumerable{Point})"/>.
         /// </summary>
         /// <param name="position">The position to remove.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Remove(Point position) => Remove(YieldPoint(position));
+        public void Remove(Point position)
+        {
+            if (!_positionsSet.Remove(position)) return;
+
+            _positions.Remove(position);
+            if (position.X == _left || position.X == _right || position.Y == _top || position.Y == _bottom)
+                RecalculateBounds();
+        }
 
         /// <summary>
         /// Removes the given position specified from the area. Particularly when the remove operation
@@ -355,7 +361,7 @@ namespace SadRogue.Primitives
         /// <param name="positionX">X-value of the position to remove.</param>
         /// <param name="positionY">Y-value of the position to remove.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Remove(int positionX, int positionY) => Remove(YieldPoint(new Point(positionX, positionY)));
+        public void Remove(int positionX, int positionY) => Remove(new Point(positionX, positionY));
 
         /// <summary>
         /// Removes positions for which the given predicate returns true from the area.
@@ -487,17 +493,6 @@ namespace SadRogue.Primitives
             _right = rightLocal;
             _top = topLocal;
             _bottom = bottomLocal;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Swap(ref IReadOnlyArea lhs, ref IReadOnlyArea rhs)
-        {
-            (rhs, lhs) = (lhs, rhs);
-        }
-
-        private static IEnumerable<Point> YieldPoint(Point item)
-        {
-            yield return item;
         }
     }
 }

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -98,11 +98,15 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="area1"/>
         /// <param name="area2"/>
+        /// <param name="pointHasher">
+        /// A custom equality comparer/hashing algorithm to use when storing points in the new Area.  If not specified, it defaults
+        /// to using the Equals and GetHashCode functions of the Point struct.
+        /// </param>
         /// <returns>A area with exactly those positions in <paramref name="area1"/> that are NOT in
         /// <paramref name="area2"/>.</returns>
-        public static Area GetDifference(IReadOnlyArea area1, IReadOnlyArea area2)
+        public static Area GetDifference(IReadOnlyArea area1, IReadOnlyArea area2, IEqualityComparer<Point>? pointHasher = null)
         {
-            Area retVal = new Area();
+            Area retVal = new Area(pointHasher);
 
             foreach (Point pos in area1.FastEnumerator())
             {
@@ -120,10 +124,14 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="area1"/>
         /// <param name="area2"/>
+        /// <param name="pointHasher">
+        /// A custom equality comparer/hashing algorithm to use when storing points in the new Area.  If not specified, it defaults
+        /// to using the Equals and GetHashCode functions of the Point struct.
+        /// </param>
         /// <returns>An area containing exactly those positions contained in both of the given areas.</returns>
-        public static Area GetIntersection(IReadOnlyArea area1, IReadOnlyArea area2)
+        public static Area GetIntersection(IReadOnlyArea area1, IReadOnlyArea area2, IEqualityComparer<Point>? pointHasher = null)
         {
-            Area retVal = new Area();
+            Area retVal = new Area(pointHasher);
 
             if (!area1.Bounds.Intersects(area2.Bounds))
                 return retVal;
@@ -143,10 +151,14 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="area1"/>
         /// <param name="area2"/>
+        /// <param name="pointHasher">
+        /// A custom equality comparer/hashing algorithm to use when storing points in the new Area.  If not specified, it defaults
+        /// to using the Equals and GetHashCode functions of the Point struct.
+        /// </param>
         /// <returns>An area containing only those positions in one or both of the given areas.</returns>
-        public static Area GetUnion(IReadOnlyArea area1, IReadOnlyArea area2)
+        public static Area GetUnion(IReadOnlyArea area1, IReadOnlyArea area2, IEqualityComparer<Point>? pointHasher = null)
         {
-            Area retVal = new Area();
+            Area retVal = new Area(pointHasher);
 
             retVal.Add(area1);
             retVal.Add(area2);
@@ -158,13 +170,13 @@ namespace SadRogue.Primitives
         /// Creates an area with the positions all shifted by the given vector.
         /// </summary>
         /// <param name="lhs"/>
-        /// <param name="rhs">Vector) to add to each position in <paramref name="lhs"/>.</param>
+        /// <param name="rhs">Vector to add to each position in <paramref name="lhs"/>.</param>
         /// <returns>
         /// An area with the positions all translated by the given amount in x and y directions.
         /// </returns>
         public static Area operator +(Area lhs, Point rhs)
         {
-            Area retVal = new Area();
+            Area retVal = new Area(lhs.PointHasher);
 
             foreach (Point pos in lhs.FastEnumerator())
                 retVal.Add(pos + rhs);
@@ -312,7 +324,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Returns whether or not the given map area intersects the current one. If you intend to
         /// determine/use the exact intersection based on this return value, it is best to instead
-        /// call the <see cref="Area.GetIntersection(IReadOnlyArea, IReadOnlyArea)"/>, and
+        /// call the <see cref="GetIntersection"/>, and
         /// check the number of positions in the result (0 if no intersection).
         /// </summary>
         /// <param name="area">The area to check.</param>

--- a/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
+++ b/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace SadRogue.Primitives.GridViews

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -1,7 +1,43 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace SadRogue.Primitives
 {
+    public struct ReadOnlyAreaPostionsEnumerable
+    {
+        private readonly IReadOnlyArea _area;
+
+        private readonly int _count;
+        private int _currentIdx;
+        public Point Current => _area[_currentIdx];
+
+        public ReadOnlyAreaPostionsEnumerable(IReadOnlyArea area)
+        {
+            _area = area;
+            _currentIdx = -1;
+            _count = area.Count;
+        }
+
+        public bool MoveNext()
+        {
+            _currentIdx++;
+            return _currentIdx < _count;
+        }
+
+        /// <summary>
+        /// Returns this enumerator.
+        /// </summary>
+        /// <returns>This enumerator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlyAreaPostionsEnumerable GetEnumerator() => this;
+
+        public IEnumerable<Point> ToEnumerable()
+        {
+            int count = _area.Count;
+            for (int i = 0; i < count; i++)
+                yield return _area[i];
+        }
+    }
     /// <summary>
     /// Read-only interface for an arbitrary 2D area.
     /// </summary>

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -8,6 +8,18 @@ namespace SadRogue.Primitives
     public interface IReadOnlyArea : IMatchable<IReadOnlyArea>, IEnumerable<Point>
     {
         /// <summary>
+        /// Whether or not it is more efficient for this implementation to use enumeration by index,
+        /// rather than generic IEnumerable, when iterating over positions using <see cref="ReadOnlyAreaExtensions.FastEnumerator"/>
+        /// or <see cref="ReadOnlyAreaPositionsEnumerable"/>.
+        /// </summary>
+        /// <remarks>
+        /// Set this to true if your indexer implementation scales well (constant time), and is relatively fast.  Implementations with
+        /// more complex indexers should set this to false.
+        ///
+        /// The default interface implementation returns false, in order to preserve backwards compatibility with previous versions.
+        /// </remarks>
+        public bool UseIndexEnumeration => false;
+        /// <summary>
         /// Smallest possible rectangle that encompasses every position in the area.
         /// </summary>
         Rectangle Bounds { get; }

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -62,7 +62,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Returns whether or not the given map area intersects the current one. If you intend to
         /// determine/use the exact intersection based on this return value, it is best to instead
-        /// call <see cref="Area.GetIntersection(IReadOnlyArea, IReadOnlyArea)"/>, and check the number
+        /// call <see cref="Area.GetIntersection"/>, and check the number
         /// of positions in the result (0 if no intersection).
         /// </summary>
         /// <param name="area">The area to check.</param>

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -1,9 +1,11 @@
-﻿namespace SadRogue.Primitives
+﻿using System.Collections.Generic;
+
+namespace SadRogue.Primitives
 {
     /// <summary>
     /// Read-only interface for an arbitrary 2D area.
     /// </summary>
-    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>
+    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>, IEnumerable<Point>
     {
         /// <summary>
         /// Smallest possible rectangle that encompasses every position in the area.
@@ -54,11 +56,5 @@
         /// <param name="area">The area to check.</param>
         /// <returns>True if the given area intersects the current one, false otherwise.</returns>
         bool Intersects(IReadOnlyArea area);
-
-        /// <summary>
-        /// Returns an enumerator that iterates through all positions in the area, in the order they were added.
-        /// </summary>
-        /// <returns>An enumerator that iterates through all the positions in the area, in the order they were added.</returns>
-        ReadOnlyAreaPostionsEnumerable GetEnumerator() => new ReadOnlyAreaPostionsEnumerable(this);
     }
 }

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -1,43 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-
-namespace SadRogue.Primitives
+﻿namespace SadRogue.Primitives
 {
-    public struct ReadOnlyAreaPostionsEnumerable
-    {
-        private readonly IReadOnlyArea _area;
-
-        private readonly int _count;
-        private int _currentIdx;
-        public Point Current => _area[_currentIdx];
-
-        public ReadOnlyAreaPostionsEnumerable(IReadOnlyArea area)
-        {
-            _area = area;
-            _currentIdx = -1;
-            _count = area.Count;
-        }
-
-        public bool MoveNext()
-        {
-            _currentIdx++;
-            return _currentIdx < _count;
-        }
-
-        /// <summary>
-        /// Returns this enumerator.
-        /// </summary>
-        /// <returns>This enumerator.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyAreaPostionsEnumerable GetEnumerator() => this;
-
-        public IEnumerable<Point> ToEnumerable()
-        {
-            int count = _area.Count;
-            for (int i = 0; i < count; i++)
-                yield return _area[i];
-        }
-    }
     /// <summary>
     /// Read-only interface for an arbitrary 2D area.
     /// </summary>
@@ -93,6 +55,10 @@ namespace SadRogue.Primitives
         /// <returns>True if the given area intersects the current one, false otherwise.</returns>
         bool Intersects(IReadOnlyArea area);
 
+        /// <summary>
+        /// Returns an enumerator that iterates through all positions in the area, in the order they were added.
+        /// </summary>
+        /// <returns>An enumerator that iterates through all the positions in the area, in the order they were added.</returns>
         ReadOnlyAreaPostionsEnumerable GetEnumerator() => new ReadOnlyAreaPostionsEnumerable(this);
     }
 }

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -41,7 +41,7 @@ namespace SadRogue.Primitives
     /// <summary>
     /// Read-only interface for an arbitrary 2D area.
     /// </summary>
-    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>, IEnumerable<Point>
+    public interface IReadOnlyArea : IMatchable<IReadOnlyArea>
     {
         /// <summary>
         /// Smallest possible rectangle that encompasses every position in the area.
@@ -92,5 +92,7 @@ namespace SadRogue.Primitives
         /// <param name="area">The area to check.</param>
         /// <returns>True if the given area intersects the current one, false otherwise.</returns>
         bool Intersects(IReadOnlyArea area);
+
+        ReadOnlyAreaPostionsEnumerable GetEnumerator() => new ReadOnlyAreaPostionsEnumerable(this);
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -1,13 +1,23 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// Extension methods for IReadOnlyArea.
+    /// </summary>
     public static class ReadOnlyAreaExtensions
     {
+        /// <summary>
+        /// Yields the area's positions as an <see cref="IEnumerable{T}"/>, which can be useful if you need
+        /// to use the result with LINQ.
+        /// </summary>
+        /// <remarks>
+        /// Note that it is NOT recommended to use this function in cases where performance is critical.
+        /// </remarks>
+        /// <returns>
+        /// An IEnumerable&lt;Point&gt; which iterates over all positions within the area.
+        /// </returns>
         public static IEnumerable<Point> ToEnumerable(this IReadOnlyArea self)
             => new ReadOnlyAreaPostionsEnumerable(self).ToEnumerable();
-
-        //public static ReadOnlyAreaPostionsEnumerable GetEnumerator(this IReadOnlyArea self) => new ReadOnlyAreaPostionsEnumerable(self);
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace SadRogue.Primitives
+{
+    public static class ReadOnlyAreaExtensions
+    {
+        public static ReadOnlyAreaPostionsEnumerable FastEnumerator(this IReadOnlyArea self)
+            => new ReadOnlyAreaPostionsEnumerable(self);
+    }
+}

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -7,16 +7,18 @@
     {
         /// <summary>
         /// Returns an enumerator which can be used to iterate over the positions in this area with a foreach loop
-        /// much more efficiently than the typical IEnumerable implementation, for many IReadOnlyArea implementations.
+        /// in the most efficient manner possible.
         /// </summary>
         /// <remarks>
-        /// This enumerator simply uses the indexer to iterate over the area, like you might a list.  For implementations
-        /// such as <see cref="Area"/>, using this is typically much faster than using the regular IEnumerable (but still
-        /// slower than a manual for loop in some cases).  For implementations of <see cref="IReadOnlyArea"/> with a more complex
-        /// indexer function, there may not be as much benefit here.
+        /// The enumerator returned will use the area's indexer to iterate over the positions (like you might a list),
+        /// if the area's <see cref="IReadOnlyArea.UseIndexEnumeration"/> is true.  Otherwise, it uses the typical IEnumerator
+        /// implementation for that area.
+        ///
+        /// This may be much faster than the typical IEnumerable/IEnumerator usage for implementations which have <see cref="IReadOnlyArea.UseIndexEnumeration"/>
+        /// set to true; however it won't have much benefit otherwise.
         /// </remarks>
         /// <param name="self"/>
-        /// <returns>A custom enumerator that iterates over the positions in the area using the indexer.</returns>
+        /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible.</returns>
         public static ReadOnlyAreaPositionsEnumerable FastEnumerator(this IReadOnlyArea self)
             => new ReadOnlyAreaPositionsEnumerable(self);
     }

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -1,8 +1,13 @@
-﻿namespace SadRogue.Primitives
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives
 {
     public static class ReadOnlyAreaExtensions
     {
-        public static ReadOnlyAreaPostionsEnumerable FastEnumerator(this IReadOnlyArea self)
-            => new ReadOnlyAreaPostionsEnumerable(self);
+        public static IEnumerable<Point> ToEnumerable(this IReadOnlyArea self)
+            => new ReadOnlyAreaPostionsEnumerable(self).ToEnumerable();
+
+        //public static ReadOnlyAreaPostionsEnumerable GetEnumerator(this IReadOnlyArea self) => new ReadOnlyAreaPostionsEnumerable(self);
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -14,8 +14,8 @@
         /// if the area's <see cref="IReadOnlyArea.UseIndexEnumeration"/> is true.  Otherwise, it uses the typical IEnumerator
         /// implementation for that area.
         ///
-        /// This may be much faster than the typical IEnumerable/IEnumerator usage for implementations which have <see cref="IReadOnlyArea.UseIndexEnumeration"/>
-        /// set to true; however it won't have much benefit otherwise.
+        /// This may be significantly faster than the typical IEnumerable/IEnumerator usage for implementations which have
+        /// <see cref="IReadOnlyArea.UseIndexEnumeration"/> set to true; however it won't have much benefit otherwise.
         /// </remarks>
         /// <param name="self"/>
         /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible.</returns>

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace SadRogue.Primitives
+﻿namespace SadRogue.Primitives
 {
     /// <summary>
     /// Extension methods for IReadOnlyArea.
@@ -8,16 +6,18 @@ namespace SadRogue.Primitives
     public static class ReadOnlyAreaExtensions
     {
         /// <summary>
-        /// Yields the area's positions as an <see cref="IEnumerable{T}"/>, which can be useful if you need
-        /// to use the result with LINQ.
+        /// Returns an enumerator which can be used to iterate over the positions in this area with a foreach loop
+        /// much more efficiently than the typical IEnumerable implementation, for many IReadOnlyArea implementations.
         /// </summary>
         /// <remarks>
-        /// Note that it is NOT recommended to use this function in cases where performance is critical.
+        /// This enumerator simply uses the indexer to iterate over the area, like you might a list.  For implementations
+        /// such as <see cref="Area"/>, using this is typically much faster than using the regular IEnumerable (but still
+        /// slower than a manual for loop in some cases).  For implementations of <see cref="IReadOnlyArea"/> with a more complex
+        /// indexer function, there may not be as much benefit here.
         /// </remarks>
-        /// <returns>
-        /// An IEnumerable&lt;Point&gt; which iterates over all positions within the area.
-        /// </returns>
-        public static IEnumerable<Point> ToEnumerable(this IReadOnlyArea self)
-            => new ReadOnlyAreaPostionsEnumerable(self).ToEnumerable();
+        /// <param name="self"/>
+        /// <returns>A custom enumerator that iterates over the positions in the area using the indexer.</returns>
+        public static ReadOnlyAreaPositionsEnumerable FastEnumerator(this IReadOnlyArea self)
+            => new ReadOnlyAreaPositionsEnumerable(self);
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerable.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace SadRogue.Primitives
 {
@@ -8,12 +7,9 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient than using the otherwise equivalent type of
-    /// IEnumerable&lt;Point&gt; with "yield return".  The type does contain a function <see cref="ToEnumerable"/> which
-    /// creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the returned positions to be used with
-    /// LINQ; however using this function is not recommended in situations where runtime performance is a primary
-    /// concern.
+    /// IEnumerable&lt;Point&gt; with "yield return".
     /// </remarks>
-    public struct ReadOnlyAreaPostionsEnumerable
+    public struct ReadOnlyAreaPositionsEnumerable
     {
         private readonly IReadOnlyArea _area;
 
@@ -29,7 +25,7 @@ namespace SadRogue.Primitives
         /// Creates an enumerator which iterates over all positions in the given area.
         /// </summary>
         /// <param name="area">A read-only area containing the positions to iterate over.</param>
-        public ReadOnlyAreaPostionsEnumerable(IReadOnlyArea area)
+        public ReadOnlyAreaPositionsEnumerable(IReadOnlyArea area)
         {
             _area = area;
             _currentIdx = -1;
@@ -51,25 +47,6 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyAreaPostionsEnumerable GetEnumerator() => this;
-
-        /// <summary>
-        /// Converts the result of the enumerable to a <see cref="IEnumerable{T}"/>, which can be useful if you need
-        /// to use the result with LINQ.
-        /// </summary>
-        /// <remarks>
-        /// Note that this function advances the state of the enumerator, evaluating it to its fullest extent.  Also
-        /// note that it is NOT recommended to use this function in cases where performance is critical.
-        /// </remarks>
-        /// <returns>
-        /// An IEnumerable&lt;Point&gt; which iterates over all positions within the area specified to this
-        /// enumerator.
-        /// </returns>
-        public IEnumerable<Point> ToEnumerable()
-        {
-            int count = _area.Count;
-            for (int i = 0; i < count; i++)
-                yield return _area[i];
-        }
+        public ReadOnlyAreaPositionsEnumerable GetEnumerator() => this;
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerable.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// A custom enumerator used to iterate over all positions within an area with a foreach loop efficiently.
+    /// </summary>
+    /// <remarks>
+    /// This type is a struct, and as such is much more efficient than using the otherwise equivalent type of
+    /// IEnumerable&lt;Point&gt; with "yield return".  The type does contain a function <see cref="ToEnumerable"/> which
+    /// creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the returned positions to be used with
+    /// LINQ; however using this function is not recommended in situations where runtime performance is a primary
+    /// concern.
+    /// </remarks>
+    public struct ReadOnlyAreaPostionsEnumerable
+    {
+        private readonly IReadOnlyArea _area;
+
+        private readonly int _count;
+        private int _currentIdx;
+
+        /// <summary>
+        /// The current value for enumeration.
+        /// </summary>
+        public Point Current => _area[_currentIdx];
+
+        /// <summary>
+        /// Creates an enumerator which iterates over all positions in the given area.
+        /// </summary>
+        /// <param name="area">A read-only area containing the positions to iterate over.</param>
+        public ReadOnlyAreaPostionsEnumerable(IReadOnlyArea area)
+        {
+            _area = area;
+            _currentIdx = -1;
+            _count = area.Count;
+        }
+
+        /// <summary>
+        /// Advances the iterator to the next position.
+        /// </summary>
+        /// <returns>True if the a position within the area was found; false otherwise.</returns>
+        public bool MoveNext()
+        {
+            _currentIdx++;
+            return _currentIdx < _count;
+        }
+
+        /// <summary>
+        /// Returns this enumerator.
+        /// </summary>
+        /// <returns>This enumerator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlyAreaPostionsEnumerable GetEnumerator() => this;
+
+        /// <summary>
+        /// Converts the result of the enumerable to a <see cref="IEnumerable{T}"/>, which can be useful if you need
+        /// to use the result with LINQ.
+        /// </summary>
+        /// <remarks>
+        /// Note that this function advances the state of the enumerator, evaluating it to its fullest extent.  Also
+        /// note that it is NOT recommended to use this function in cases where performance is critical.
+        /// </remarks>
+        /// <returns>
+        /// An IEnumerable&lt;Point&gt; which iterates over all positions within the area specified to this
+        /// enumerator.
+        /// </returns>
+        public IEnumerable<Point> ToEnumerable()
+        {
+            int count = _area.Count;
+            for (int i = 0; i < count; i++)
+                yield return _area[i];
+        }
+    }
+}

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -1151,15 +1151,23 @@ namespace SadRogue.Primitives
         /// <returns>A list of all rectangles that add up to the original rectangle</returns>
         public IEnumerable<Rectangle> BisectRecursive(int minimumDimension)
         {
-            foreach (Rectangle child in Bisect().ToEnumerable())
-            {
-                if (child.Width < minimumDimension * 2 && child.Height < minimumDimension * 2)
-                    yield return child;
+            var children = Bisect();
 
-                else
-                    foreach (var grandChild in child.BisectRecursive(minimumDimension))
-                        yield return grandChild;
-            }
+            var child = children.Rect1;
+            if (child.Width < minimumDimension * 2 && child.Height < minimumDimension * 2)
+                yield return child;
+
+            else
+                foreach (var grandChild in child.BisectRecursive(minimumDimension))
+                    yield return grandChild;
+
+            child = children.Rect2;
+            if (child.Width < minimumDimension * 2 && child.Height < minimumDimension * 2)
+                yield return child;
+
+            else
+                foreach (var grandChild in child.BisectRecursive(minimumDimension))
+                    yield return grandChild;
         }
 
         /// <summary>

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -1046,19 +1046,16 @@ namespace SadRogue.Primitives
             for (int x = MinExtentX; x <= MaxExtentX; x++)
                 yield return new Point(x, MinExtentY); // Minimum y-side perimeter
 
-            for (int y = MinExtentY + 1;
-                y <= MaxExtentY;
-                y++) // Start offset 1, since last loop returned the corner piece
+            // Start offset 1, since last loop returned the corner piece
+            for (int y = MinExtentY + 1; y <= MaxExtentY; y++) 
                 yield return new Point(MaxExtentX, y);
 
-            for (int x = MaxExtentX - 1;
-                x >= MinExtentX;
-                x--) // Again skip 1 because last loop returned the corner piece
+            // Again skip 1 because last loop returned the corner piece
+            for (int x = MaxExtentX - 1; x >= MinExtentX; x--) 
                 yield return new Point(x, MaxExtentY);
 
-            for (int y = MaxExtentY - 1;
-                y >= MinExtentY + 1;
-                y--) // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
+            // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
+            for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--) 
                 yield return new Point(MinExtentX, y);
         }
 

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -9,16 +9,18 @@ namespace SadRogue.Primitives
     /// <summary>
     /// Structure representing the result of a rectangle bisection.
     /// </summary>
-    [Serializable]
+    [DataContract]
     public readonly struct BisectionResult : IEquatable<BisectionResult>, IMatchable<BisectionResult>
     {
         /// <summary>
         /// The first rectangle.
         /// </summary>
+        [DataMember]
         public readonly Rectangle Rect1;
         /// <summary>
         /// The second rectangle.
         /// </summary>
+        [DataMember]
         public readonly Rectangle Rect2;
 
         /// <summary>

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerable.cs
@@ -9,7 +9,7 @@ namespace SadRogue.Primitives
     /// <remarks>
     /// This type is a struct, and as such is much more efficient than using the otherwise equivalent type of
     /// IEnumerable&lt;Point&gt; with "yield return".  The type does contain a function <see cref="ToEnumerable"/> which
-    /// creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the returned layer sets to be used with
+    /// creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the returned positions to be used with
     /// LINQ; however using this function is not recommended in situations where runtime performance is a primary
     /// concern.
     /// </remarks>

--- a/TheSadRogue.Primitives/SerializedTypes/Area.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Area.cs
@@ -36,7 +36,7 @@ namespace SadRogue.Primitives.SerializedTypes
         public static implicit operator AreaSerialized(Area area)
             => new AreaSerialized
             {
-                Positions = area.Select(p => (PointSerialized)p).ToList(),
+                Positions = area.ToEnumerable().Select(p => (PointSerialized)p).ToList(),
                 PointHasher = area.PointHasher
             };
     }

--- a/TheSadRogue.Primitives/SerializedTypes/Area.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Area.cs
@@ -36,7 +36,7 @@ namespace SadRogue.Primitives.SerializedTypes
         public static implicit operator AreaSerialized(Area area)
             => new AreaSerialized
             {
-                Positions = area.ToEnumerable().Select(p => (PointSerialized)p).ToList(),
+                Positions = area.Select(p => (PointSerialized)p).ToList(),
                 PointHasher = area.PointHasher
             };
     }

--- a/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
@@ -8,7 +8,14 @@ namespace SadRogue.Primitives.SerializedTypes
     [Serializable]
     public struct BisectionResultSerialized
     {
+        /// <summary>
+        /// The first rectangle.
+        /// </summary>
         public RectangleSerialized Rect1;
+
+        /// <summary>
+        /// The second rectangle.
+        /// </summary>
         public RectangleSerialized Rect2;
 
         /// <summary>

--- a/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
+++ b/TheSadRogue.Primitives/SerializedTypes/Rectangle.cs
@@ -3,6 +3,36 @@
 namespace SadRogue.Primitives.SerializedTypes
 {
     /// <summary>
+    /// Serializable (pure-data) object representing a <see cref="BisectionResult"/>.
+    /// </summary>
+    [Serializable]
+    public struct BisectionResultSerialized
+    {
+        public RectangleSerialized Rect1;
+        public RectangleSerialized Rect2;
+
+        /// <summary>
+        /// Converts from <see cref="BisectionResult"/> to <see cref="BisectionResultSerialized"/>.
+        /// </summary>
+        /// <param name="result"/>
+        /// <returns/>
+        public static implicit operator BisectionResultSerialized(BisectionResult result) => new BisectionResultSerialized()
+        {
+            Rect1 = result.Rect1,
+            Rect2 = result.Rect2,
+            
+        };
+
+        /// <summary>
+        /// Converts from <see cref="BisectionResultSerialized"/> to <see cref="BisectionResult"/>.
+        /// </summary>
+        /// <param name="result"/>
+        /// <returns/>
+        public static implicit operator BisectionResult(BisectionResultSerialized result)
+            => new BisectionResult(result.Rect1, result.Rect2);
+    }
+
+    /// <summary>
     /// Serializable (pure-data) object representing a <see cref="Rectangle"/>.
     /// </summary>
     [Serializable]

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -21,6 +21,8 @@
             - Default implementations are provided, and the Base classes implement them as well
 		- Modified Positions() enumerable functions to use custom enumerators for improved performance with foreach loops
             - Use Positions().ToEnumerable() if you need an IEnumerable for LINQ usage or similar
+        - Modified Area Get* functions to allow the specification of a custom point hasher
+        - Added `IReadOnlyArea.FastEnumerator()` in order to allow efficient foreach iteration of arbitrary areas
 	</PackageReleaseNotes>
 	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
# Changes
- `Bisect*` functions for rectangle now return a value type of two rectangles, instead of an enumerable of rectangles, where possible (closes #72 )
    - The value type returned from these functions supports deconstruction, converts implicitly to an equivalent value tuple, and has a `ToEnumerable` function which returns an enumerable of both rectangles.
- Manually expanded outer for loop in `BisectRecursive`
- Added a `FastEnumerator()` extension method to `IReadOnlyArea`, which provides a quick way to iterate over all points in an area
    - Allows generic `IReadOnlyArea` functions to take advantage of the speed benefits of iterating via index for list-based area implmentations
- Added optional parameter to `GetIntersection`, `GetUnion`, and `GetDifference` functions which allows the use of a custom point hasher for the resulting area

# Notes
Not much compatibility breakage here, just adding a `ToEnumerable` if a user really needs an enumerable from these functions/classes.  The performance implications are fairly straightforward.

## Rectangle Bisection
Here are the performance test results.  The `BisectHorizontallyNativeEnumerable` shows the performance of the original `BisectHorizontal` implementation, for reference (the vertical function was similar).  These tests show 3x faster in the new implementation.

|                             Method | Width | Height |           Mean |         Error |        StdDev |         Median |
|----------------------------------- |------ |------- |---------------:|--------------:|--------------:|---------------:|
|                             Bisect |    10 |     10 |      11.960 ns |     0.0129 ns |     0.0121 ns |      11.954 ns |
|                   BisectVertically |    10 |     10 |      10.737 ns |     0.0414 ns |     0.0367 ns |      10.716 ns |
|                 BisectHorizontally |    10 |     10 |       9.898 ns |     0.0323 ns |     0.0302 ns |       9.889 ns |
|                    BisectRecursive |    10 |     10 |     142.001 ns |     1.9671 ns |     1.6426 ns |     141.642 ns |
|                 BisectToEnumerable |    10 |     10 |      31.704 ns |     0.6614 ns |     1.7541 ns |      31.113 ns |
|       BisectVerticallyToEnumerable |    10 |     10 |      29.138 ns |     0.5555 ns |     0.7224 ns |      29.141 ns |
|     BisectHorizontallyToEnumerable |    10 |     10 |      31.083 ns |     0.6209 ns |     0.8905 ns |      30.842 ns |
| BisectHorizontallyNativeEnumerable |    10 |     10 |      26.888 ns |     0.4518 ns |     0.8487 ns |      26.648 ns |
|                             Bisect |    10 |     50 |      11.793 ns |     0.0711 ns |     0.0555 ns |      11.781 ns |
|                   BisectVertically |    10 |     50 |      10.284 ns |     0.0334 ns |     0.0372 ns |      10.284 ns |
|                 BisectHorizontally |    10 |     50 |      10.197 ns |     0.1890 ns |     0.1578 ns |      10.140 ns |
|                    BisectRecursive |    10 |     50 |   2,266.148 ns |    21.7679 ns |    18.1772 ns |   2,267.865 ns |
|                 BisectToEnumerable |    10 |     50 |      31.041 ns |     0.6340 ns |     0.5930 ns |      30.997 ns |
|       BisectVerticallyToEnumerable |    10 |     50 |      30.692 ns |     0.5786 ns |     0.4831 ns |      30.808 ns |
|     BisectHorizontallyToEnumerable |    10 |     50 |      30.677 ns |     0.6362 ns |     1.3831 ns |      30.247 ns |
| BisectHorizontallyNativeEnumerable |    10 |     50 |      26.754 ns |     0.4856 ns |     0.4542 ns |      26.711 ns |
|                             Bisect |    10 |    100 |      11.804 ns |     0.0967 ns |     0.0808 ns |      11.778 ns |
|                   BisectVertically |    10 |    100 |      10.846 ns |     0.0631 ns |     0.0492 ns |      10.851 ns |
|                 BisectHorizontally |    10 |    100 |      10.585 ns |     0.1858 ns |     0.1647 ns |      10.544 ns |
|                    BisectRecursive |    10 |    100 |   5,424.528 ns |   107.9690 ns |   154.8459 ns |   5,368.166 ns |
|                 BisectToEnumerable |    10 |    100 |      31.556 ns |     0.6530 ns |     1.3338 ns |      31.466 ns |
|       BisectVerticallyToEnumerable |    10 |    100 |      30.464 ns |     0.7921 ns |     2.2342 ns |      29.579 ns |
|     BisectHorizontallyToEnumerable |    10 |    100 |      28.284 ns |     0.4962 ns |     0.4399 ns |      28.291 ns |
| BisectHorizontallyNativeEnumerable |    10 |    100 |      26.791 ns |     0.5583 ns |     0.6646 ns |      26.755 ns |
|                             Bisect |    50 |     10 |      11.545 ns |     0.0845 ns |     0.0660 ns |      11.537 ns |
|                   BisectVertically |    50 |     10 |      10.745 ns |     0.0411 ns |     0.0364 ns |      10.754 ns |
|                 BisectHorizontally |    50 |     10 |      10.206 ns |     0.0555 ns |     0.1147 ns |      10.189 ns |
|                    BisectRecursive |    50 |     10 |   2,319.263 ns |    45.9436 ns |   104.6367 ns |   2,289.259 ns |
|                 BisectToEnumerable |    50 |     10 |      32.432 ns |     0.6637 ns |     1.5250 ns |      32.092 ns |
|       BisectVerticallyToEnumerable |    50 |     10 |      29.696 ns |     0.6256 ns |     1.1439 ns |      29.445 ns |
|     BisectHorizontallyToEnumerable |    50 |     10 |      29.636 ns |     0.6019 ns |     0.7612 ns |      29.497 ns |
| BisectHorizontallyNativeEnumerable |    50 |     10 |      27.019 ns |     0.5648 ns |     0.5800 ns |      26.838 ns |
|                             Bisect |    50 |     50 |      12.243 ns |     0.1497 ns |     0.1250 ns |      12.240 ns |
|                   BisectVertically |    50 |     50 |      11.420 ns |     0.5300 ns |     1.5627 ns |      10.449 ns |
|                 BisectHorizontally |    50 |     50 |      10.206 ns |     0.1606 ns |     0.2251 ns |      10.128 ns |
|                    BisectRecursive |    50 |     50 |  24,490.356 ns |   214.9100 ns |   179.4596 ns |  24,436.105 ns |
|                 BisectToEnumerable |    50 |     50 |      34.794 ns |     1.6003 ns |     4.6935 ns |      32.636 ns |
|       BisectVerticallyToEnumerable |    50 |     50 |      32.724 ns |     1.8708 ns |     5.4867 ns |      29.505 ns |
|     BisectHorizontallyToEnumerable |    50 |     50 |      29.063 ns |     0.4275 ns |     0.9908 ns |      28.699 ns |
| BisectHorizontallyNativeEnumerable |    50 |     50 |      29.996 ns |     1.4358 ns |     4.2109 ns |      28.911 ns |
|                             Bisect |    50 |    100 |      12.181 ns |     0.1153 ns |     0.0962 ns |      12.163 ns |
|                   BisectVertically |    50 |    100 |      10.162 ns |     0.0737 ns |     0.0615 ns |      10.145 ns |
|                 BisectHorizontally |    50 |    100 |       9.914 ns |     0.0464 ns |     0.0387 ns |       9.911 ns |
|                    BisectRecursive |    50 |    100 |  52,368.069 ns | 1,007.3419 ns | 1,077.8446 ns |  52,037.143 ns |
|                 BisectToEnumerable |    50 |    100 |      30.221 ns |     0.3635 ns |     0.3222 ns |      30.290 ns |
|       BisectVerticallyToEnumerable |    50 |    100 |      28.996 ns |     0.4477 ns |     0.3969 ns |      29.063 ns |
|     BisectHorizontallyToEnumerable |    50 |    100 |      28.397 ns |     0.3681 ns |     0.3443 ns |      28.314 ns |
| BisectHorizontallyNativeEnumerable |    50 |    100 |      26.590 ns |     0.3960 ns |     0.3307 ns |      26.597 ns |
|                             Bisect |   100 |     10 |      12.218 ns |     0.1793 ns |     0.3936 ns |      12.124 ns |
|                   BisectVertically |   100 |     10 |      10.262 ns |     0.0399 ns |     0.0311 ns |      10.250 ns |
|                 BisectHorizontally |   100 |     10 |      10.500 ns |     0.0528 ns |     0.0441 ns |      10.480 ns |
|                    BisectRecursive |   100 |     10 |   5,310.233 ns |    64.3777 ns |    53.7583 ns |   5,316.383 ns |
|                 BisectToEnumerable |   100 |     10 |      31.569 ns |     0.5873 ns |     0.8609 ns |      31.280 ns |
|       BisectVerticallyToEnumerable |   100 |     10 |      29.221 ns |     0.6088 ns |     0.8535 ns |      29.010 ns |
|     BisectHorizontallyToEnumerable |   100 |     10 |      30.038 ns |     0.5824 ns |     1.2785 ns |      29.845 ns |
| BisectHorizontallyNativeEnumerable |   100 |     10 |      26.052 ns |     0.3928 ns |     0.3280 ns |      26.166 ns |
|                             Bisect |   100 |     50 |      11.746 ns |     0.0187 ns |     0.0146 ns |      11.748 ns |
|                   BisectVertically |   100 |     50 |      10.283 ns |     0.0505 ns |     0.0472 ns |      10.261 ns |
|                 BisectHorizontally |   100 |     50 |       9.890 ns |     0.0262 ns |     0.0233 ns |       9.893 ns |
|                    BisectRecursive |   100 |     50 |  51,831.080 ns |   236.9335 ns |   210.0354 ns |  51,763.559 ns |
|                 BisectToEnumerable |   100 |     50 |      30.176 ns |     0.2253 ns |     0.1997 ns |      30.203 ns |
|       BisectVerticallyToEnumerable |   100 |     50 |      28.489 ns |     0.4764 ns |     0.4223 ns |      28.588 ns |
|     BisectHorizontallyToEnumerable |   100 |     50 |      28.417 ns |     0.2325 ns |     0.1816 ns |      28.466 ns |
| BisectHorizontallyNativeEnumerable |   100 |     50 |      26.046 ns |     0.5336 ns |     0.4991 ns |      26.089 ns |
|                             Bisect |   100 |    100 |      11.512 ns |     0.0251 ns |     0.0223 ns |      11.511 ns |
|                   BisectVertically |   100 |    100 |       9.872 ns |     0.0263 ns |     0.0220 ns |       9.875 ns |
|                 BisectHorizontally |   100 |    100 |       9.877 ns |     0.0142 ns |     0.0119 ns |       9.880 ns |
|                    BisectRecursive |   100 |    100 | 111,830.037 ns |   866.6556 ns |   768.2677 ns | 112,161.945 ns |
|                 BisectToEnumerable |   100 |    100 |      31.524 ns |     0.6515 ns |     0.7503 ns |      31.514 ns |
|       BisectVerticallyToEnumerable |   100 |    100 |      28.466 ns |     0.2780 ns |     0.2465 ns |      28.503 ns |
|     BisectHorizontallyToEnumerable |   100 |    100 |      28.400 ns |     0.1862 ns |     0.1742 ns |      28.370 ns |
| BisectHorizontallyNativeEnumerable |   100 |    100 |      25.662 ns |     0.1236 ns |     0.1156 ns |      25.646 ns |

## Area Enumeration
Because `Area` implements `IEnumerable`, it would cause a lot of breaking changes to attempt to change the method of iteration used in the typical enumerator (and would be undesirable in a lot of circumstances either way).  Therefore, instead of changing the default enumerator, we instead provide a `FastEnumerator()` which provides a faster method to enumerate with a `foreach` loop.

However, `IReadOnlyArea` is an interface, and therefore much of the implementation is up to library consumers.  The default implementation uses a list and hash set paired together; however GoRogue, for example, provides an implementation called `MultiArea`, which takes multiple areas and exposes them as a single one, as well as `PolygonArea`, which represents polygons.  This makes it tough to determine what the "fastest" way to iterate is; for an area, it is certainly to access points by index using the area's indexer; but that is actually quite slow for GoRogue's `MultiArea` because the indexer is not nearly as efficient.

Therefore, this PR adds a flag `UseIndexEnumeration` to the area interface (with a default value of `false`, so as to avoid breaking backwards compatibility).  When this flag is set to true by implementations (such as Area), the enumerator provided will use indexing.  If it's set to false, it will default to the `IEnumerable` implementation of the interface itself.  This allows different implementations to specify proper iteration methods.


Here are the performance results of the new `FastEnumerator` function's enumerator:

|                                  Method | Size |            Mean |         Error |        StdDev |
|---------------------------------------- |----- |----------------:|--------------:|--------------:|
|                     BenchmarkEnumerable |   10 |       542.17 ns |      1.213 ns |      1.013 ns |
|           BenchmarkEnumerableAsConcrete |   10 |       401.20 ns |      2.106 ns |      1.970 ns |
|                 BenchmarkFastEnumerable |   10 |       267.44 ns |      0.887 ns |      0.692 ns |
|       BenchmarkFastEnumerableAsConcrete |   10 |       269.99 ns |      1.755 ns |      1.641 ns |
|                      BenchmarkManualFor |   10 |       362.09 ns |      3.069 ns |      2.871 ns |
|           BenchmarkManualForCachedCount |   10 |       196.27 ns |      0.795 ns |      0.705 ns |
|            BenchmarkManualForAsConcrete |   10 |        76.83 ns |      0.497 ns |      0.441 ns |
| BenchmarkManualForAsConcreteCachedCount |   10 |        76.36 ns |      0.369 ns |      0.345 ns |
|                     BenchmarkEnumerable |  100 |    52,136.04 ns |    373.036 ns |    330.686 ns |
|           BenchmarkEnumerableAsConcrete |  100 |    37,598.42 ns |    117.548 ns |    104.203 ns |
|                 BenchmarkFastEnumerable |  100 |    25,265.49 ns |    163.274 ns |    152.727 ns |
|       BenchmarkFastEnumerableAsConcrete |  100 |    25,128.46 ns |     68.585 ns |     60.798 ns |
|                      BenchmarkManualFor |  100 |    35,350.81 ns |     46.764 ns |     39.050 ns |
|           BenchmarkManualForCachedCount |  100 |    18,851.83 ns |     29.275 ns |     22.856 ns |
|            BenchmarkManualForAsConcrete |  100 |     7,127.25 ns |     10.012 ns |      8.360 ns |
| BenchmarkManualForAsConcreteCachedCount |  100 |     7,118.29 ns |     63.503 ns |     56.294 ns |
|                     BenchmarkEnumerable |  200 |   206,361.33 ns |    122.541 ns |    102.327 ns |
|           BenchmarkEnumerableAsConcrete |  200 |   150,827.81 ns |  1,164.635 ns |  1,089.400 ns |
|                 BenchmarkFastEnumerable |  200 |   100,393.31 ns |    239.670 ns |    200.135 ns |
|       BenchmarkFastEnumerableAsConcrete |  200 |   100,421.90 ns |    132.298 ns |    103.289 ns |
|                      BenchmarkManualFor |  200 |   140,725.61 ns |    221.211 ns |    172.707 ns |
|           BenchmarkManualForCachedCount |  200 |    75,417.81 ns |     82.344 ns |     72.996 ns |
|            BenchmarkManualForAsConcrete |  200 |    28,573.40 ns |     58.039 ns |     51.450 ns |
| BenchmarkManualForAsConcreteCachedCount |  200 |    28,299.78 ns |     74.319 ns |     65.882 ns |

As usual, the new enumerator is about 2x faster in some cases, and is roughly competitive with a for loop that doesn't cache the result of the `Count` property.  One notable exception here is the manual for loops do much better than anything else on a value of type `Area`, rather than `IReadOnlyArea`.  I believe this is because the compiler is able to see the underlying structure is a `List` in this case and apply optimizations.  In practice, I've found this difference in enumeration speed makes a difference only rarely, but nonetheless I was never able to make the `FastEnumerator` significantly slower than regular enumeration, so it seems to provide no downside.  I did find one test case involving GoRogue's `MultiArea` where there was a _slight_ decrease with `FastEnumerator()` however nothing significant enough to affect code in really any realistic case (and the benefits it creates with other types would seem to far outweigh that) In either case, this produces no breaking changes for users, since the initial iterator remains untouched.