### PR TITLE
Add PerimeterPositions Function to Area

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/ReadOnlyAreaExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests
+{
+    public static class AreaPerimeterPositionsExtensions
+    {
+        public static IEnumerable<Point> PerimeterPositionsLinq(this IReadOnlyArea area, AdjacencyRule rule)
+            => area.Where(pos => rule.Neighbors(pos).Any(n => !area.Contains(n)));
+
+        public static IEnumerable<Point> PerimeterPositionsNeighborsFunc(this IReadOnlyArea area, AdjacencyRule rule)
+        {
+            foreach (var pos in area.FastEnumerator())
+            {
+                foreach (var neighbor in rule.Neighbors(pos))
+                {
+                    if (!area.Contains(neighbor))
+                    {
+                        yield return pos;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    public class ReadOnlyAreaExtensions
+    {
+        [Params(10, 100, 200)]
+        public int Size;
+
+        private AdjacencyRule _rule;
+
+        private SadRogue.Primitives.Area _area = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions().ToEnumerable());
+            _rule = AdjacencyRule.Cardinals;
+        }
+
+        [Benchmark]
+        public int PerimeterPositions()
+        {
+            int sum = 0;
+            foreach (var pos in _area.PerimeterPositions(_rule))
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PerimeterPositionsNeighborsFunc()
+        {
+            int sum = 0;
+            foreach (var pos in _area.PerimeterPositionsNeighborsFunc(_rule))
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PerimeterPositionsLinq()
+        {
+            int sum = 0;
+            foreach (var pos in _area.PerimeterPositionsLinq(_rule))
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -33,13 +33,75 @@ namespace SadRogue.Primitives.UnitTests
             var l4 = new List<Point>();
             foreach (var pos in area.FastEnumerator())
                 l4.Add(pos);
-            
+
 
             Assert.Equal(expected, l1);
             Assert.Equal(expected, l2);
             Assert.Equal(expected, l3);
             Assert.Equal(expected, l4);
+        }
 
+        [Fact]
+        public void RectangleAreaPerimeterPositions()
+        {
+            var rect = new Rectangle(0, 0, 15, 15);
+            var area = new Area(rect.Positions().ToEnumerable());
+
+            var expected = rect.PerimeterPositions().ToHashSet();
+            var actual1 = area.PerimeterPositions(AdjacencyRule.Cardinals).ToHashSet();
+            var actual2 = area.PerimeterPositions(AdjacencyRule.EightWay).ToHashSet();
+
+            Assert.Equal(expected, actual1);
+            Assert.Equal(expected, actual2);
+        }
+
+        // X _not_ considered a border, by four-way adjacency
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . X .
+        // . . . . . . . #
+        [Fact]
+        public void IrregularAreaPerimeterPositionsCardinals()
+        {
+            var rect = new Rectangle(0, 0, 15, 15);
+            var area = new Area(rect.Positions().ToEnumerable());
+            area.Remove(rect.MaxExtent);
+
+            var expected = rect.PerimeterPositions().ToHashSet();
+            expected.Remove(rect.MaxExtent);
+
+            var actual = area.PerimeterPositions(AdjacencyRule.Cardinals).ToHashSet();
+
+            Assert.Equal(expected, actual);
+        }
+
+        // X _is_ considered a border, by eight-way adjacency
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . . .
+        // . . . . . . X .
+        // . . . . . . . #
+        [Fact]
+        public void IrregularAreaPerimeterPositionsEightWay()
+        {
+            var rect = new Rectangle(0, 0, 15, 15);
+            var area = new Area(rect.Positions().ToEnumerable());
+            area.Remove(rect.MaxExtent);
+
+            var expected = rect.PerimeterPositions().ToHashSet();
+            expected.Remove(rect.MaxExtent);
+            expected.Add(rect.MaxExtent - 1);
+
+            var actual = area.PerimeterPositions(AdjacencyRule.EightWay).ToHashSet();
+
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace SadRogue.Primitives
+﻿using System.Collections.Generic;
+
+namespace SadRogue.Primitives
 {
     /// <summary>
     /// Extension methods for IReadOnlyArea.
@@ -21,5 +23,21 @@
         /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible.</returns>
         public static ReadOnlyAreaPositionsEnumerable FastEnumerator(this IReadOnlyArea self)
             => new ReadOnlyAreaPositionsEnumerable(self);
+
+        public static IEnumerable<Point> PerimeterPositions(this IReadOnlyArea area, AdjacencyRule rule)
+        {
+            foreach (var pos in area.FastEnumerator())
+            {
+                foreach (var dir in rule.DirectionsOfNeighborsCache)
+                {
+                    var neighbor = pos + dir;
+                    if (!area.Contains(neighbor))
+                    {
+                        yield return pos;
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -63,9 +63,9 @@ namespace SadRogue.Primitives
         /// </example>
         /// </remarks>
         /// 
-        /// <param name="area"></param>
-        /// <param name="rule"></param>
-        /// <returns></returns>
+        /// <param name="area"/>
+        /// <param name="rule">The AdjacencyRule to use for determining adjacency to cells which are outside of the area.</param>
+        /// <returns>An enumerable of every point which is on the outer edge of the area specified.</returns>
         public static IEnumerable<Point> PerimeterPositions(this IReadOnlyArea area, AdjacencyRule rule)
         {
             foreach (var pos in area.FastEnumerator())

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -24,6 +24,48 @@ namespace SadRogue.Primitives
         public static ReadOnlyAreaPositionsEnumerable FastEnumerator(this IReadOnlyArea self)
             => new ReadOnlyAreaPositionsEnumerable(self);
 
+        /// <summary>
+        /// Returns all points that are on the border of the area, assuming the specified adjacency rule is used to determine adjacent cells
+        /// for the sake of determining border.
+        /// </summary>
+        /// <remarks>
+        /// Typically, you will want to use AdjacencyRule.EightWay as the rule; however AdjacencyRule.Cardinals is faster if you don't want
+        /// border cells adjacent to a wall ONLY diagonally to be considered border cells.
+        ///
+        /// <example>
+        /// Using AdjacencyRule.Cardinals, if "." and "x" are cells within the area and "#" are cells that are not within, X will NOT be considered
+        /// a border:
+        /// <code>
+        /// # # # # # # # #
+        /// # . . . . . # #
+        /// # . . . . X . #
+        /// # . . . . . . #
+        /// # . . . . . . #
+        /// # . . . . . . #
+        /// # . . . . . . #
+        /// # # # # # # # #
+        /// </code>
+        /// </example>
+        ///
+        /// <example>
+        /// Using AdjacencyRule.EightWay, if "." and "x" are cells within the area and "#" are cells that are not within, X WILL be considered
+        /// a border:
+        /// <code>
+        /// # # # # # # # #
+        /// # . . . . . # #
+        /// # . . . . X . #
+        /// # . . . . . . #
+        /// # . . . . . . #
+        /// # . . . . . . #
+        /// # . . . . . . #
+        /// # # # # # # # #
+        /// </code>
+        /// </example>
+        /// </remarks>
+        /// 
+        /// <param name="area"></param>
+        /// <param name="rule"></param>
+        /// <returns></returns>
         public static IEnumerable<Point> PerimeterPositions(this IReadOnlyArea area, AdjacencyRule rule)
         {
             foreach (var pos in area.FastEnumerator())


### PR DESCRIPTION
# Changes
- Adds a `PerimeterPositions` function for area which can return only the positions on the perimeter of an area

# Notes
This function is fairly easy to add to `IReadOnlyArea`, and a similar use case popped up for a SadConsole user.  It's straightforward to implement, and requires no breaking changes, so I figured why not.  In this case, the function is fairly safe to provide from a performance standpoint as well; since area implementations typically have constant-time `Contains` functions (or something close), this operation typically takes linear time with respect to the number of positions in the area.

Here are some performance tests which compare the current implementation to some others, for the sake of ensuring the implementation provided here is fairly optimal:

|                          Method | Size |         Mean |       Error |      StdDev |
|-------------------------------- |----- |-------------:|------------:|------------:|
|              PerimeterPositions |   10 |     8.297 us |   0.0347 us |   0.0307 us |
|      PerimeterPositionsArrayFor |   10 |     8.347 us |   0.0425 us |   0.0376 us |
| PerimeterPositionsNeighborsFunc |   10 |    14.643 us |   0.0669 us |   0.0558 us |
|          PerimeterPositionsLinq |   10 |    15.616 us |   0.1098 us |   0.0973 us |
|  PerimeterPositionsDirCacheLinq |   10 |    12.215 us |   0.0703 us |   0.0658 us |
|              PerimeterPositions |  100 | 1,069.416 us |   2.9171 us |   2.5860 us |
|      PerimeterPositionsArrayFor |  100 | 1,081.910 us |   4.3171 us |   4.0382 us |
| PerimeterPositionsNeighborsFunc |  100 | 1,712.031 us |  12.3815 us |  10.3391 us |
|          PerimeterPositionsLinq |  100 | 1,807.219 us |  17.1930 us |  16.0823 us |
|  PerimeterPositionsDirCacheLinq |  100 | 1,446.538 us |   6.1183 us |   5.7231 us |
|              PerimeterPositions |  200 | 4,771.322 us |  36.5624 us |  34.2005 us |
|      PerimeterPositionsArrayFor |  200 | 4,783.362 us |  13.8249 us |  11.5444 us |
| PerimeterPositionsNeighborsFunc |  200 | 7,570.990 us | 150.6277 us | 190.4959 us |
|          PerimeterPositionsLinq |  200 | 8,015.208 us | 159.6384 us | 163.9369 us |
|  PerimeterPositionsDirCacheLinq |  200 | 6,423.322 us |  78.8687 us |  61.5755 us |