### PR TITLE
Test a wider range of Point hashes.

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/BareMinimumAlgorithm.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/BareMinimumAlgorithm.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests.PointHashing.Algorithms
+{
+    /// <summary>
+    /// Algorithm using the simplest function I could think of.
+    /// </summary>
+    public sealed class BareMinimumAlgorithm : EqualityComparer<Point>
+    {
+        public static readonly IEqualityComparer<Point> Instance = new BareMinimumAlgorithm();
+
+        public override bool Equals(Point x, Point y) => x.Equals(y);
+
+        public override int GetHashCode(Point p)
+        {
+            uint x = (uint)p.X, y = (uint)p.Y;
+            return (int)(x + (y << 16 | y >> 16));
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/CantorPureAlgorithm.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/CantorPureAlgorithm.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests.PointHashing.Algorithms
+{
+    /// <summary>
+    /// Algorithm using the exact Cantor pairing function.
+    /// This does not provide special treatment for negative inputs.
+    /// </summary>
+    public sealed class CantorPureAlgorithm : EqualityComparer<Point>
+    {
+        public static readonly IEqualityComparer<Point> Instance = new CantorPureAlgorithm();
+
+        public override bool Equals(Point x, Point y) => x.Equals(y);
+
+        public override int GetHashCode(Point p)
+        {
+            int x = p.X, y = p.Y;
+            return y + ((x + y) * (x + y + 1) >> 1);
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/MultiplySumAlgorithm.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/MultiplySumAlgorithm.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests.PointHashing.Algorithms
+{
+    /// <summary>
+    /// Algorithm that multiplies each component of the point by a different number, then adds them all up.
+    /// </summary>
+    public sealed class MultiplySumAlgorithm : EqualityComparer<Point>
+    {
+        public static readonly IEqualityComparer<Point> Instance = new MultiplySumAlgorithm();
+
+        public override bool Equals(Point x, Point y) => x.Equals(y);
+
+        public override int GetHashCode(Point p)
+        {
+            // The multipliers are the top 32 bits of constants used by Martin Roberts,
+            // http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+            return -1052792407 * p.X + -1847521883 * p.Y;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/RosenbergStrongPureAlgorithm.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/Algorithms/RosenbergStrongPureAlgorithm.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests.PointHashing.Algorithms
+{
+    /// <summary>
+    /// Algorithm using the exact Rosenberg-Strong pairing function.
+    /// This does not provide special treatment for negative inputs.
+    /// </summary>
+    public sealed class RosenbergStrongPureAlgorithm : EqualityComparer<Point>
+    {
+        public static readonly IEqualityComparer<Point> Instance = new RosenbergStrongPureAlgorithm();
+
+        public override bool Equals(Point x, Point y) => x.Equals(y);
+
+        public override int GetHashCode(Point p)
+        {
+            int x = p.X, y = p.Y;
+            return (x >= y ? x * (x + 2) - y : y * y + x);
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/PointDictionaryAdd.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/PointDictionaryAdd.cs
@@ -62,6 +62,18 @@ namespace TheSadRogue.Primitives.PerformanceTests.PointHashing
         [Benchmark]
         public Dictionary<Point, int> RosenbergStrongBasedMinusMultiply() => CreateAndPopulate(RosenbergStrongBasedMinusMultiplyAlgorithm.Instance);
 
+        [Benchmark]
+        public Dictionary<Point, int> RosenbergStrongPure() => CreateAndPopulate(RosenbergStrongPureAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> CantorPure() => CreateAndPopulate(CantorPureAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> BareMinimum() => CreateAndPopulate(BareMinimumAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> MultiplySum() => CreateAndPopulate(MultiplySumAlgorithm.Instance);
+
         private Dictionary<Point, int> CreateAndPopulate(IEqualityComparer<Point> algorithm)
         {
             var dict = new Dictionary<Point, int>(algorithm);

--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/PointDictionaryAddGaussian.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/PointDictionaryAddGaussian.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.VisualBasic;
+using SadRogue.Primitives;
+using SadRogue.Primitives.PointHashers;
+using TheSadRogue.Primitives.PerformanceTests.PointHashing.Algorithms;
+
+namespace TheSadRogue.Primitives.PerformanceTests.PointHashing
+{
+    /// <summary>
+    /// A series of benchmarks that measure the amount of time it takes to add Points to a dictionary,
+    /// where Points are being used as the key, when the dictionary is being passed different hashing algorithms to use.
+    /// </summary>
+    /// <remarks>
+    /// Although dictionary add operations generally have more overhead than just the calls to GetHashCode they perform,
+    /// the operation is affected by both the time it takes to compute a hash, and the number of collisions
+    /// that hash generates.  This makes it a fairly well-rounded case which allows us to measure more real-world
+    /// performance, which will take into account collisions as well as raw speed.
+    /// </remarks>
+    public class PointDictionaryAddGaussian
+    {
+        public IEnumerable<int> SizeData => SharedTestParams.Sizes;
+
+        /// <summary>
+        /// An area of Size x Size will be used for the purposes of determining the series of points to add.
+        /// </summary>
+        [ParamsSource(nameof(SizeData))]
+        public int Size;
+
+        private Point[] _points = null!;
+        private IEqualityComparer<Point> _sizeHasher = null!;
+        private IEqualityComparer<Point> _rangeHasher = null!;
+        /// <summary>
+        /// Given a double between 0 and 1, gets a Gaussian-distributed (also called normal-distributed) double with range from -38.5 to 38.5 .
+        /// </summary>
+        /// <remarks>
+        /// This uses an algorithm by Peter John Acklam, as implemented by Sherali Karimov.
+        /// <a href = "https://web.archive.org/web/20150910002142/http://home.online.no/~pjacklam/notes/invnorm/impl/karimov/StatUtil.java" > Original source</a>.
+        /// <a href = "https://web.archive.org/web/20151030215612/http://home.online.no/~pjacklam/notes/invnorm/" > Information on the algorithm</a>.
+        /// <a href = "https://en.wikipedia.org/wiki/Probit_function" > Wikipedia's page on the probit function</a> may help, also.
+        /// </remarks>
+        /// <param name="d"></param>
+        /// <returns></returns>
+        public static double Probit(double d)
+        {
+            if (d <= 0 || d >= 1)
+            {
+                return Math.CopySign(38.5, d - 0.5);
+            }
+            else if (d < 0.02425)
+            {
+                double q = Math.Sqrt(-2.0 * Math.Log(d));
+                return (((((-7.784894002430293e-03 * q - 3.223964580411365e-01) * q - 2.400758277161838e+00) * q - 2.549732539343734e+00) * q + 4.374664141464968e+00) * q + 2.938163982698783e+00) / (
+                        (((7.784695709041462e-03 * q + 3.224671290700398e-01) * q + 2.445134137142996e+00) * q + 3.754408661907416e+00) * q + 1.0);
+            }
+            else if (0.97575 < d)
+            {
+                double q = Math.Sqrt(-2.0 * Math.Log(1 - d));
+                return -(((((-7.784894002430293e-03 * q - 3.223964580411365e-01) * q - 2.400758277161838e+00) * q - 2.549732539343734e+00) * q + 4.374664141464968e+00) * q + 2.938163982698783e+00) / (
+                        (((7.784695709041462e-03 * q + 3.224671290700398e-01) * q + 2.445134137142996e+00) * q + 3.754408661907416e+00) * q + 1.0);
+            }
+            else
+            {
+                double q = d - 0.5;
+                double r = q * q;
+                return (((((-3.969683028665376e+01 * r + 2.209460984245205e+02) * r - 2.759285104469687e+02) * r + 1.383577518672690e+02) * r - 3.066479806614716e+01) * r + 2.506628277459239e+00) * q / (
+                        ((((-5.447609879822406e+01 * r + 1.615858368580409e+02) * r - 1.556989798598866e+02) * r + 6.680131188771972e+01) * r - 1.328068155288572e+01) * r + 1.0);
+            }
+        }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            int totalSize = Size * Size;
+            // Create cached list of points
+            _points = new Point[totalSize];
+            ulong xc = 1UL, yc = 2UL;
+            HashSet<Point> pts = new HashSet<Point>(totalSize);
+            unchecked
+            {
+                while(pts.Count < totalSize)
+                {
+                    // R2 sequence, sub-random with lots of space between nearby points
+                    xc += 0xC13FA9A902A6328FUL;
+                    yc += 0x91E10DA5C79E7B1DUL;
+                    // Using well-spread inputs to Probit() gives points that shouldn't overlap as often.
+                    // 1.1102230246251565E-16 is 2 to the -53 .
+                    pts.Add(new Point((int)(Probit((xc >> 11) * 1.1102230246251565E-16) * 256.0),
+                            (int)(Probit((yc >> 11) * 1.1102230246251565E-16) * 256.0)));
+                }
+                pts.CopyTo(_points);
+            }
+
+            // Create equality comparers now to ensure that the creation time isn't factored into benchmark
+            // (since it is not for any other algorithms)
+            _sizeHasher = new KnownSizeHasher(Size);
+            _rangeHasher = new KnownRangeHasher(new Point(0, 0), new Point(Size, Size));
+        }
+
+        [Benchmark]
+        public Dictionary<Point, int> CurrentPrimitives() => CreateAndPopulate(EqualityComparer<Point>.Default);
+
+        [Benchmark]
+        public Dictionary<Point, int> OriginalGoRogue() => CreateAndPopulate(OriginalGoRogueAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> KnownSize() => CreateAndPopulate(_sizeHasher);
+
+        [Benchmark]
+        public Dictionary<Point, int> KnownRange() => CreateAndPopulate(_rangeHasher);
+
+        [Benchmark]
+        public Dictionary<Point, int> RosenbergStrongBased() => CreateAndPopulate(RosenbergStrongBasedAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> RosenbergStrongBasedMinusMultiply() => CreateAndPopulate(RosenbergStrongBasedMinusMultiplyAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> RosenbergStrongPure() => CreateAndPopulate(RosenbergStrongPureAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> CantorPure() => CreateAndPopulate(CantorPureAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> BareMinimum() => CreateAndPopulate(BareMinimumAlgorithm.Instance);
+
+        [Benchmark]
+        public Dictionary<Point, int> MultiplySum() => CreateAndPopulate(MultiplySumAlgorithm.Instance);
+
+        private Dictionary<Point, int> CreateAndPopulate(IEqualityComparer<Point> algorithm)
+        {
+            var dict = new Dictionary<Point, int>(algorithm);
+            for (int i = 0; i < _points.Length; i++)
+                dict[_points[i]] = i;
+
+            return dict;
+        }
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/PointHashing/PointDictionaryGet.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PointHashing/PointDictionaryGet.cs
@@ -34,6 +34,10 @@ namespace TheSadRogue.Primitives.PerformanceTests.PointHashing
         private Dictionary<Point, int> _knownRangeHashing = null!;
         private Dictionary<Point, int> _rosenbergStrong = null!;
         private Dictionary<Point, int> _rosenbergStrongMinusMultiply = null!;
+        private Dictionary<Point, int> _rosenbergStrongPure = null!;
+        private Dictionary<Point, int> _cantorPure = null!;
+        private Dictionary<Point, int> _bareMinimum = null!;
+        private Dictionary<Point, int> _multiplySum = null!;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -55,6 +59,10 @@ namespace TheSadRogue.Primitives.PerformanceTests.PointHashing
             _knownRangeHashing = CreateAndPopulate(_rangeHasher);
             _rosenbergStrong = CreateAndPopulate(RosenbergStrongBasedAlgorithm.Instance);
             _rosenbergStrongMinusMultiply = CreateAndPopulate(RosenbergStrongBasedMinusMultiplyAlgorithm.Instance);
+            _rosenbergStrongPure = CreateAndPopulate(RosenbergStrongPureAlgorithm.Instance);
+            _cantorPure = CreateAndPopulate(CantorPureAlgorithm.Instance);
+            _bareMinimum = CreateAndPopulate(BareMinimumAlgorithm.Instance);
+            _multiplySum = CreateAndPopulate(MultiplySumAlgorithm.Instance);
         }
 
         [Benchmark]
@@ -74,6 +82,18 @@ namespace TheSadRogue.Primitives.PerformanceTests.PointHashing
 
         [Benchmark]
         public int RosenbergStrongBasedMinusMultiply() => GetAllFrom(_rosenbergStrongMinusMultiply);
+
+        [Benchmark]
+        public int RosenbergStrongPure() => GetAllFrom(_rosenbergStrongPure);
+
+        [Benchmark]
+        public int CantorPure() => GetAllFrom(_cantorPure);
+
+        [Benchmark]
+        public int BareMinimum() => GetAllFrom(_bareMinimum);
+
+        [Benchmark]
+        public int MultiplySum() => GetAllFrom(_multiplySum);
 
         private int GetAllFrom(Dictionary<Point, int> dict)
         {


### PR DESCRIPTION
I left comments in each commit that might be helpful. The important thing is that the simplest hash here, BareMinimum, gets very close to KnownSize hashing in terms of speed, and like KnownSizeHasher, it is not very random-seeming. I have the speed benchmarks for PointDictionaryAdd:

```
|                            Method | Size |         Mean |      Error |     StdDev |       Median |
|---------------------------------- |----- |-------------:|-----------:|-----------:|-------------:|
|                 CurrentPrimitives |   10 |     2.473 us |  0.0290 us |  0.0257 us |     2.479 us |
|                   OriginalGoRogue |   10 |     3.172 us |  0.0610 us |  0.0571 us |     3.172 us |
|                         KnownSize |   10 |     2.735 us |  0.0208 us |  0.0173 us |     2.736 us |
|                        KnownRange |   10 |     2.811 us |  0.0560 us |  0.1464 us |     2.759 us |
|              RosenbergStrongBased |   10 |     3.144 us |  0.0327 us |  0.0273 us |     3.141 us |
| RosenbergStrongBasedMinusMultiply |   10 |     2.610 us |  0.0511 us |  0.0502 us |     2.599 us |
|               RosenbergStrongPure |   10 |     2.363 us |  0.0213 us |  0.0199 us |     2.359 us |
|                        CantorPure |   10 |     2.565 us |  0.0437 us |  0.0788 us |     2.576 us |
|                       BareMinimum |   10 |     2.338 us |  0.0465 us |  0.0571 us |     2.313 us |
|                       MultiplySum |   10 |     2.590 us |  0.0446 us |  0.0417 us |     2.602 us |
|                 CurrentPrimitives |   50 |    72.201 us |  1.4406 us |  1.4149 us |    72.200 us |
|                   OriginalGoRogue |   50 |    74.035 us |  1.4328 us |  2.1881 us |    73.053 us |
|                         KnownSize |   50 |    51.915 us |  1.0200 us |  1.8906 us |    50.856 us |
|                        KnownRange |   50 |    53.373 us |  1.0602 us |  1.5540 us |    54.220 us |
|              RosenbergStrongBased |   50 |    79.562 us |  1.5893 us |  1.8303 us |    78.729 us |
| RosenbergStrongBasedMinusMultiply |   50 |    77.804 us |  1.5400 us |  1.5125 us |    78.168 us |
|               RosenbergStrongPure |   50 |    61.285 us |  1.1992 us |  2.7553 us |    62.390 us |
|                        CantorPure |   50 |    65.949 us |  0.8372 us |  0.7422 us |    65.753 us |
|                       BareMinimum |   50 |    57.722 us |  0.7113 us |  0.5940 us |    57.565 us |
|                       MultiplySum |   50 |    64.055 us |  0.8987 us |  0.7504 us |    63.891 us |
|                 CurrentPrimitives |  100 |   379.739 us |  7.5152 us |  7.3809 us |   376.895 us |
|                   OriginalGoRogue |  100 |   385.661 us |  6.4697 us |  6.0518 us |   388.087 us |
|                         KnownSize |  100 |   233.832 us |  1.8599 us |  1.7398 us |   234.354 us |
|                        KnownRange |  100 |   238.968 us |  2.1470 us |  1.9033 us |   238.501 us |
|              RosenbergStrongBased |  100 |   365.246 us |  7.2428 us |  6.7749 us |   362.101 us |
| RosenbergStrongBasedMinusMultiply |  100 |   366.542 us |  7.2905 us | 16.0028 us |   370.190 us |
|               RosenbergStrongPure |  100 |   268.963 us |  5.3067 us |  6.7112 us |   270.808 us |
|                        CantorPure |  100 |   278.829 us |  5.5601 us |  5.9493 us |   276.739 us |
|                       BareMinimum |  100 |   249.940 us |  4.8344 us |  4.9645 us |   247.455 us |
|                       MultiplySum |  100 |   277.260 us |  5.4827 us |  5.8664 us |   274.367 us |
|                 CurrentPrimitives |  175 | 1,138.365 us |  6.2221 us | 11.5330 us | 1,136.530 us |
|                   OriginalGoRogue |  175 | 1,178.871 us |  8.9898 us |  8.4090 us | 1,178.890 us |
|                         KnownSize |  175 |   668.405 us |  5.8477 us |  5.1839 us |   667.583 us |
|                        KnownRange |  175 |   676.898 us |  8.2646 us |  7.7307 us |   678.762 us |
|              RosenbergStrongBased |  175 | 1,218.810 us | 10.7955 us | 10.0981 us | 1,215.942 us |
| RosenbergStrongBasedMinusMultiply |  175 | 1,179.085 us | 10.0739 us |  8.9303 us | 1,179.886 us |
|               RosenbergStrongPure |  175 |   760.599 us |  6.3940 us |  4.9920 us |   760.856 us |
|                        CantorPure |  175 |   834.900 us |  9.0003 us |  8.4189 us |   834.617 us |
|                       BareMinimum |  175 |   697.848 us | 13.1751 us | 12.3240 us |   696.240 us |
|                       MultiplySum |  175 |   785.984 us | 13.6117 us | 12.7324 us |   785.394 us |
|                 CurrentPrimitives |  256 | 2,934.451 us | 27.1371 us | 25.3841 us | 2,925.226 us |
|                   OriginalGoRogue |  256 | 3,019.435 us | 17.9357 us | 27.3897 us | 3,017.546 us |
|                         KnownSize |  256 | 1,660.725 us | 26.2639 us | 24.5672 us | 1,667.402 us |
|                        KnownRange |  256 | 1,681.399 us | 32.6702 us | 34.9567 us | 1,679.994 us |
|              RosenbergStrongBased |  256 | 3,069.717 us | 23.6231 us | 20.9413 us | 3,073.564 us |
| RosenbergStrongBasedMinusMultiply |  256 | 3,050.202 us | 33.6965 us | 31.5197 us | 3,051.733 us |
|               RosenbergStrongPure |  256 | 1,896.973 us | 24.1849 us | 26.8815 us | 1,895.791 us |
|                        CantorPure |  256 | 2,168.527 us | 42.9730 us | 44.1301 us | 2,166.936 us |
|                       BareMinimum |  256 | 1,759.347 us | 24.8700 us | 23.2635 us | 1,747.685 us |
|                       MultiplySum |  256 | 2,210.841 us | 25.1394 us | 20.9926 us | 2,215.512 us |
```