### PR TITLE
Release v1.5.0 Prep

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -66,7 +66,7 @@ dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
 dotnet_naming_style.static_prefix_style.required_prefix = s_
-dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
 
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
@@ -75,7 +75,7 @@ dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:suggestion

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
     - name: Restore dependencies

--- a/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
+++ b/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
@@ -10,13 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
+++ b/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
@@ -1,32 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>8</LangVersion>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-        <RootNamespace>SadRogue.Primitives.MonoGame.UnitTests</RootNamespace>
-        
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>SadRogue.Primitives.MonoGame.UnitTests</RootNamespace>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="XUnit.ValueTuples" Version="1.0.1" />
-    </ItemGroup>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\TheSadRogue.Primitives.MonoGame\TheSadRogue.Primitives.MonoGame.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1"/>
+  </ItemGroup>
 
-    <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared" />
+  <ItemGroup>
+    <ProjectReference Include="..\TheSadRogue.Primitives.MonoGame\TheSadRogue.Primitives.MonoGame.csproj"/>
+  </ItemGroup>
+
+  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared"/>
 
 </Project>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -39,7 +39,7 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
     <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
   </ItemGroup>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -2,20 +2,20 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.1</Version>
+	<Version>1.1.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2021 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+	<Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
 
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-	<PackageReleaseNotes>Multi-targeted to .NET 6.  Updated to depend on most recent 1.x release of core primitives.</PackageReleaseNotes>
+	<PackageReleaseNotes>Multi-targeted to .NET 7.</PackageReleaseNotes>
 	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -6,47 +6,43 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.1.0</Version>
-	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
-	<Authors>Chris3606;Thraka</Authors>
-	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
-	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
-
-	<!-- More nuget package settings-->
-	<PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-	<PackageReleaseNotes>Multi-targeted to .NET 7.</PackageReleaseNotes>
-	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
-	<RepositoryType>git</RepositoryType>
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<IncludeSymbols>true</IncludeSymbols>
+    <Version>1.1.0</Version>
+    <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
+    <Authors>Chris3606;Thraka</Authors>
+    <Company>TheSadRogue</Company>
+    <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+    <Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
+  
+    <!-- More nuget package settings-->
+    <PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
+    <PackageReleaseNotes>Multi-targeted to .NET 7.</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;monogame;sadrogue;thesadrogue;extensions</PackageTags>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.MonoGame.xml</DocumentationFile>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;monogame;sadrogue;thesadrogue;extensions</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\$(Configuration)\netstandard2.0\TheSadRogue.Primitives.MonoGame.xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641"/>
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.*"/>
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
   </Target>
 </Project>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -25,6 +25,7 @@
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;monogame;sadrogue;thesadrogue;extensions</PackageTags>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
+++ b/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
+++ b/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
+++ b/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
@@ -9,13 +9,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
+++ b/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
@@ -1,31 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-        <LangVersion>8</LangVersion>
-        <RootNamespace>SadRogue.Primitives.SFML.UnitTests</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>8</LangVersion>
+    <RootNamespace>SadRogue.Primitives.SFML.UnitTests</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="XUnit.ValueTuples" Version="1.0.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\TheSadRogue.Primitives.SFML\TheSadRogue.Primitives.SFML.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TheSadRogue.Primitives.SFML\TheSadRogue.Primitives.SFML.csproj"/>
+  </ItemGroup>
 
-    <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared" />
+  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared"/>
 
 </Project>

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -28,6 +28,7 @@
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sfml;sadrogue;thesadrogue;extensions</PackageTags>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -6,51 +6,47 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.1.0</Version>
-	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
-	<Authors>Chris3606;Thraka</Authors>
-	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
-	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with SFML's equivalents.</Description>
+    <Version>1.1.0</Version>
+    <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
+    <Authors>Chris3606;Thraka</Authors>
+    <Company>TheSadRogue</Company>
+    <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+    <Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with SFML's equivalents.</Description>
 
-	<!-- More nuget package settings-->
-	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>
-		- IntRect Extensions
-		    - Conversions to and from IntRect now assign the correct values for Width/Height
-	</PackageReleaseNotes>
-	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
-	<RepositoryType>git</RepositoryType>
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<IncludeSymbols>true</IncludeSymbols>
+    <!-- More nuget package settings-->
+    <PackageId>TheSadRogue.Primitives.SFML</PackageId>
+    <PackageReleaseNotes>
+      - IntRect Extensions
+        - Conversions to and from IntRect now assign the correct values for Width/Height
+    </PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sfml;sadrogue;thesadrogue;extensions</PackageTags>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sfml;sadrogue;thesadrogue;extensions</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.SFML.xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SFML.Graphics" Version="2.5.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="SFML.Graphics" Version="2.5.0"/>
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.*"/>
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
   </Target>
 
 </Project>

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -42,7 +42,7 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SFML.Graphics" Version="2.5.0" />
     <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
   </ItemGroup>

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -2,20 +2,23 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.0.1</Version>
+	<Version>1.1.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2021 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+	<Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with SFML's equivalents.</Description>
 
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives.SFML</PackageId>
-	<PackageReleaseNotes>Multi-targeted to .NET 6.  Updated to use the most recent 1.x version of the primitives library.</PackageReleaseNotes>
+	<PackageReleaseNotes>
+		- IntRect Extensions
+		    - Conversions to and from IntRect now assign the correct values for Width/Height
+	</PackageReleaseNotes>
 	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/PointTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/PointTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -7,11 +6,6 @@ namespace SadRogue.Primitives.UnitTests
 {
     public class PointTests
     {
-
-        #region Test Data
-        private readonly Rectangle _testPositions = new Rectangle((10, 20), 39, 27);
-        #endregion
-
         #region BearingOfLine
 
         [Theory]

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
@@ -13,23 +13,23 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
-  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared" />
+  <ItemGroup>
+    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj"/>
+  </ItemGroup>
+
+  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared"/>
 
 </Project>

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
@@ -9,9 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TheSadRogue.Primitives.UnitTests/GridViews/SettableViewportTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/SettableViewportTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using SadRogue.Primitives.GridViews;
 using SadRogue.Primitives.UnitTests.Mocks;
@@ -116,6 +117,7 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             Assert.Equal(expected, result);
         }
 
+        [SuppressMessage("ReSharper", "ParameterOnlyUsedForPreconditionCheck.Local")]
         private static void CheckViewportBounds(SettableViewport<bool> viewport, Point expectedMinCorner,
                                                 Point expectedMaxCorner)
         {

--- a/TheSadRogue.Primitives.UnitTests/MathHelpersTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/MathHelpersTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Xunit;
 using XUnit.ValueTuples;
 

--- a/TheSadRogue.Primitives.UnitTests/PointTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/PointTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 using XUnit.ValueTuples;
 

--- a/TheSadRogue.Primitives.UnitTests/Serialization/SerializedTypesIndividual/DiffAwareGridViewSerializedTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/SerializedTypesIndividual/DiffAwareGridViewSerializedTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using SadRogue.Primitives.GridViews;
 using SadRogue.Primitives.SerializedTypes.GridViews;
 using Xunit;

--- a/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
+++ b/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
@@ -13,20 +13,20 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1" />
+    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj" />
+    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj"/>
   </ItemGroup>
 
-  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared" />
+  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared"/>
 
 </Project>

--- a/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
+++ b/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -1,77 +1,72 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-	<!-- Basic package info -->
+    <!-- Basic package info -->
     <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.5.0</Version>
-	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
-	<Authors>Chris3606;Thraka</Authors>
-	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
-	<Description>A collection of primitive data structures for working with a 2-dimensional grid.</Description>
+    <Version>1.5.0</Version>
+    <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
+    <Authors>Chris3606;Thraka</Authors>
+    <Company>TheSadRogue</Company>
+    <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+    <Description>A collection of primitive data structures for working with a 2-dimensional grid.</Description>
 
-	<!-- More nuget package settings-->
-	<PackageId>TheSadRogue.Primitives</PackageId>
-	<PackageReleaseNotes>
-	    - Color Changes
-		    - GetHue can no longer return 360 instead of 0 in some cases
-		    - GetHue, GetSaturation, and GetBrightness are obsolete; use GetHSVHue / GetHSLHue, GetHSVSaturation / GetHSLSaturation, etc instead as required
-		    - FromHSL now performs color translation correctly (it previously produced incorrect values in a significant number of cases)
-		    - Deconstruction of a Color object into a float now properly returns a value between 0 and 1 (it would return between 0 and 255 previously)
-		- Point Hasher Changes
-		    - Fixed off-by-one issue in point hasher calculations
-			- Renamed properties to reflect their actual values
-	    - Area Changes
-		    - Optimized Area.Intersects to avoid full comparisons for referentially equal values
-		- DiffAwareGridView Changes
-		    - Fixed serialization (implicit conversion to/from its serialized type was broken and wouldn't restore CurrentIndex properly)
-			- You can now set history index to -1 when using SetHistory
-		- Rectangle Changes
-		    - IsEmpty now returns the correct value
-			- Rectangle.PositionsOnSide now throws ArgumentException as applicable
-		- Point Changes
-		    - BearingOfLine overloads taking 2 points or 4 ints now return the correct line instead of the reciprocal one
-			- Using division operator on a Point and a value now returns a Point instead of a value tuple
-		- Gradient Changes
-		    - Gradient constructor now throws ArgumentException as applicable
-		- Palette Changes
-			- Palette now implements IReadOnlyList
-			- Removed unnecessary in-memory value duplication in some constructors
-		- IGridView Extension Changes
-			- IGridView.ExtendToString no longer adds too many element separators in overloads which take a field size
-	</PackageReleaseNotes>
-	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
-	<RepositoryType>git</RepositoryType>
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<IncludeSymbols>true</IncludeSymbols>
+    <!-- More nuget package settings-->
+    <PackageId>TheSadRogue.Primitives</PackageId>
+    <PackageReleaseNotes>
+      - **Color Changes**
+        - GetHue can no longer return 360 instead of 0 in some cases
+        - GetHue, GetSaturation, and GetBrightness are obsolete; use GetHSVHue / GetHSLHue, GetHSVSaturation / GetHSLSaturation, etc instead as required
+        - FromHSL now performs color translation correctly (it previously produced incorrect values in a significant number of cases)
+        - Deconstruction of a Color object into a float now properly returns a value between 0 and 1 (it would return between 0 and 255 previously)
+      - **Point Hasher Changes**
+        - Fixed off-by-one issue in point hasher calculations
+        - Renamed properties to reflect their actual values
+      - **Area Changes**
+        - Optimized Area.Intersects to avoid full comparisons for referentially equal values
+      - **DiffAwareGridView Changes**
+        - Fixed serialization (implicit conversion to/from its serialized type was broken and wouldn't restore CurrentIndex properly)
+        - You can now set history index to -1 when using SetHistory
+      - **Rectangle Changes**
+        - IsEmpty now returns the correct value
+        - Rectangle.PositionsOnSide now throws ArgumentException as applicable
+      - **Point Changes**
+        - BearingOfLine overloads taking 2 points or 4 ints now return the correct line instead of the reciprocal one
+        - Using division operator on a Point and a value now returns a Point instead of a value tuple
+      - **Gradient Changes**
+        - Gradient constructor now throws ArgumentException as applicable
+      - **Palette Changes**
+        - Palette now implements IReadOnlyList
+        - Removed unnecessary in-memory value duplication in some constructors
+      - **IGridView Extension Changes**
+        - IGridView.ExtendToString no longer adds too many element separators in overloads which take a field size
+    </PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sadrogue;thesadrogue</PackageTags>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.xml</DocumentationFile>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sadrogue;thesadrogue</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\$(Configuration)\netstandard2.1\TheSadRogue.Primitives.xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
   </Target>
 </Project>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -2,21 +2,46 @@
 
   <PropertyGroup>
 	<!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-	<Version>1.4.1</Version>
+	<Version>1.5.0</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
 	<Authors>Chris3606;Thraka</Authors>
 	<Company>TheSadRogue</Company>
-	<Copyright>Copyright © 2022 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+	<Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
 	<Description>A collection of primitive data structures for working with a 2-dimensional grid.</Description>
 
 	<!-- More nuget package settings-->
 	<PackageId>TheSadRogue.Primitives</PackageId>
 	<PackageReleaseNotes>
-        - Added `IReadOnlyArea.PerimeterPositions` function which returns positions on the edge of a given area.
+	    - Color Changes
+		    - GetHue can no longer return 360 instead of 0 in some cases
+		    - GetHue, GetSaturation, and GetBrightness are obsolete; use GetHSVHue / GetHSLHue, GetHSVSaturation / GetHSLSaturation, etc instead as required
+		    - FromHSL now performs color translation correctly (it previously produced incorrect values in a significant number of cases)
+		    - Deconstruction of a Color object into a float now properly returns a value between 0 and 1 (it would return between 0 and 255 previously)
+		- Point Hasher Changes
+		    - Fixed off-by-one issue in point hasher calculations
+			- Renamed properties to reflect their actual values
+	    - Area Changes
+		    - Optimized Area.Intersects to avoid full comparisons for referentially equal values
+		- DiffAwareGridView Changes
+		    - Fixed serialization (implicit conversion to/from its serialized type was broken and wouldn't restore CurrentIndex properly)
+			- You can now set history index to -1 when using SetHistory
+		- Rectangle Changes
+		    - IsEmpty now returns the correct value
+			- Rectangle.PositionsOnSide now throws ArgumentException as applicable
+		- Point Changes
+		    - BearingOfLine overloads taking 2 points or 4 ints now return the correct line instead of the reciprocal one
+			- Using division operator on a Point and a value now returns a Point instead of a value tuple
+		- Gradient Changes
+		    - Gradient constructor now throws ArgumentException as applicable
+		- Palette Changes
+			- Palette now implements IReadOnlyList
+			- Removed unnecessary in-memory value duplication in some constructors
+		- IGridView Extension Changes
+			- IGridView.ExtendToString no longer adds too many element separators in overloads which take a field size
 	</PackageReleaseNotes>
 	<RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -66,7 +66,7 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -52,6 +52,7 @@
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<PackageTags>2d;grid;primitives;point;rectangle;game;development;standard;sadrogue;thesadrogue</PackageTags>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
- Updated copyrights to 2023 in published projects
- Updated csproj files to 1.5.0 for the primitives library and 1.1.0 for the extension packages
- Reformatted csproj files to fit .editorconfig coding standards (sorry, this makes a mess of the diff)
- Set documentation generation in csproj appropriately to avoid build errors depending on build order
- Updated dependencies in non-published projects to ensure testing harnesses use the same xunit and version
- Updated SourceLink everywhere applicable