### PR TITLE
Line-Drawing Algorithms

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/LineReturnMethodTests.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/LineReturnMethodTests.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests;
+
+static class BresenhamWithFunctionPointers
+{
+    public static void BresenhamFunc(Point start, Point end, Func<Point, bool> action)
+        => BresenhamFunc(start.X, start.Y, end.X, end.Y, action);
+
+    public static void BresenhamAction(Point start, Point end, Action<Point> action)
+        => BresenhamAction(start.X, start.Y, end.X, end.Y, action);
+
+    private static void BresenhamFunc(int startX, int startY, int endX, int endY, Func<Point, bool> action)
+    {
+        int w = endX - startX;
+        int h = endY - startY;
+        int dx1 = 0, dy1 = 0, dx2 = 0, dy2 = 0;
+        if (w < 0) dx1 = -1;
+        else if (w > 0) dx1 = 1;
+        if (h < 0) dy1 = -1;
+        else if (h > 0) dy1 = 1;
+        if (w < 0) dx2 = -1;
+        else if (w > 0) dx2 = 1;
+        int longest = Math.Abs(w);
+        int shortest = Math.Abs(h);
+        if (!(longest > shortest))
+        {
+            longest = Math.Abs(h);
+            shortest = Math.Abs(w);
+            if (h < 0) dy2 = -1;
+            else if (h > 0) dy2 = 1;
+            dx2 = 0;
+        }
+
+        int numerator = longest >> 1;
+        for (int i = 0; i <= longest; i++)
+        {
+            if (!action(new Point(startX, startY)))
+                return;
+            numerator += shortest;
+            if (!(numerator < longest))
+            {
+                numerator -= longest;
+                startX += dx1;
+                startY += dy1;
+            }
+            else
+            {
+                startX += dx2;
+                startY += dy2;
+            }
+        }
+    }
+
+    private static void BresenhamAction(int startX, int startY, int endX, int endY, Action<Point> action)
+    {
+        int w = endX - startX;
+        int h = endY - startY;
+        int dx1 = 0, dy1 = 0, dx2 = 0, dy2 = 0;
+        if (w < 0) dx1 = -1;
+        else if (w > 0) dx1 = 1;
+        if (h < 0) dy1 = -1;
+        else if (h > 0) dy1 = 1;
+        if (w < 0) dx2 = -1;
+        else if (w > 0) dx2 = 1;
+        int longest = Math.Abs(w);
+        int shortest = Math.Abs(h);
+        if (!(longest > shortest))
+        {
+            longest = Math.Abs(h);
+            shortest = Math.Abs(w);
+            if (h < 0) dy2 = -1;
+            else if (h > 0) dy2 = 1;
+            dx2 = 0;
+        }
+
+        int numerator = longest >> 1;
+        for (int i = 0; i <= longest; i++)
+        {
+            action(new Point(startX, startY));
+            numerator += shortest;
+            if (!(numerator < longest))
+            {
+                numerator -= longest;
+                startX += dx1;
+                startY += dy1;
+            }
+            else
+            {
+                startX += dx2;
+                startY += dy2;
+            }
+        }
+    }
+}
+
+public class LineReturnMethodTests
+{
+    [ParamsSource(nameof(TestCases))]
+    public (Point start, Point end) LineToDraw;
+
+    [Benchmark]
+    public int BresenhamIEnumerable()
+    {
+        int sum = 0;
+        foreach (var pos in Lines.Get(LineToDraw.start, LineToDraw.end, Lines.Algorithm.Bresenham))
+            sum += pos.X + pos.Y;
+
+        return sum;
+    }
+
+    [Benchmark]
+    public int BresenhamFunc()
+    {
+        int sum = 0;
+
+        BresenhamWithFunctionPointers.BresenhamFunc(LineToDraw.start, LineToDraw.end, pos =>
+        {
+            sum += pos.X + pos.Y;
+            return true;
+        });
+
+        return sum;
+    }
+
+    [Benchmark]
+    public int BresenhamFuncLocalFunction()
+    {
+        int sum = 0;
+
+        bool Action(Point pos)
+        {
+            sum += pos.X + pos.Y;
+            return true;
+        }
+
+        BresenhamWithFunctionPointers.BresenhamFunc(LineToDraw.start, LineToDraw.end, Action);
+
+        return sum;
+    }
+
+    [Benchmark]
+    public int BresenhamAction()
+    {
+        int sum = 0;
+
+        BresenhamWithFunctionPointers.BresenhamAction(LineToDraw.start, LineToDraw.end, pos => sum += pos.X + pos.Y);
+
+        return sum;
+    }
+
+    [Benchmark]
+    public int BresenhamActionLocalFunction()
+    {
+        int sum = 0;
+
+        void Action(Point pos)
+        {
+            sum += pos.X + pos.Y;
+        }
+
+        BresenhamWithFunctionPointers.BresenhamAction(LineToDraw.start, LineToDraw.end, Action);
+
+        return sum;
+    }
+
+    public static IEnumerable<(Point start, Point end)> TestCases()
+    {
+        yield return ((1, 1), (25, 50));
+        yield return ((1, 1), (50, 25));
+        yield return ((25, 50), (1, 1));
+        yield return ((50, 25), (1, 1));
+        // These lines have manhattan distance == chebyshev distance,  These cases are useful to help prove that
+        // Orthogonal is about as fast as the others, if measured proportional to the appropriate distance calculation
+        // (eg. the length of the line)
+        yield return ((1, 1), (50, 1));
+        yield return ((1, 1), (1, 25));
+    }
+
+
+}

--- a/TheSadRogue.Primitives.PerformanceTests/LineTests.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/LineTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests;
+
+public class LineTests
+{
+    [ParamsSource(nameof(TestCases))]
+    public (Point start, Point end) LineToDraw;
+
+    private Consumer _consumer = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _consumer = new Consumer();
+    }
+
+    public static IEnumerable<(Point start, Point end)> TestCases()
+    {
+        yield return ((1, 1), (25, 50));
+        yield return ((1, 1), (50, 25));
+        yield return ((25, 50), (1, 1));
+        yield return ((50, 25), (1, 1));
+        // These lines have manhattan distance == chebyshev distance,  These cases are useful to help prove that
+        // Orthogonal is about as fast as the others, if measured proportional to the appropriate distance calculation
+        // (eg. the length of the line)
+        yield return ((1, 1), (50, 1));
+        yield return ((1, 1), (1, 25));
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(GoRogueLineAlgorithms))]
+    public void GetPointsOnLine(Lines.Algorithm algo)
+        => Lines.Get(LineToDraw.start, LineToDraw.end, algo).Consume(_consumer);
+
+    public static IEnumerable<Lines.Algorithm> GoRogueLineAlgorithms()
+        => Enum.GetValues<Lines.Algorithm>();
+}

--- a/TheSadRogue.Primitives.UnitTests/LinesTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/LinesTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using XUnit.ValueTuples;
+
+namespace SadRogue.Primitives.UnitTests
+{
+    public class LinesTests
+    {
+        #region TestData
+        // Test cases should include:
+        //    - Positive and negative x/y values
+        //    - Lines covering all octants
+        //    - Slopes which are not an integer value
+        //    - A line such that start == end
+        //    - Vertical lines
+        //    - Horizontal lines
+        private static readonly (Point start, Point End)[] s_testLines =
+        {
+            // Octant 1: 0 < dx < dy
+            ((-1, -2), (25, 40)),
+            // Octant 0: 0 < dy <= dx
+            ((-1, -2), (40, 25)),
+            // Octant 7: 0 < -dy <= dx
+            ((-1, -2), (40, -25)),
+            // Octant 6: 0 < dx < -dy
+            ((-1, -2), (25, -40)),
+            // Octant 5: 0 < -dx < -dy
+            ((-1, -2), (-25, -40)),
+            // Octant 4: 0 < -dy <= -dx
+            ((-1, -2), (-40, -25)),
+            // Octant 3: 0 < dy <= -dx
+            ((-1, -2), (-40, 25)),
+            // Octant 2: 0 < -dx < dy
+            ((-1, -2), (-25, 40)),
+            // Start == end
+            ((10, 11), (10, 11)),
+            // Vertical lines
+            ((5, 6), (5, 10)),
+            ((5, 10), (5, 6)),
+            // Horizontal lines
+            ((6, 5), (10, 5)),
+            ((10, 5), (6, 5)),
+        };
+
+        // Algorithms which are guaranteed to return items in order from start to finish.
+        private static readonly Lines.Algorithm[] s_orderedAlgorithms =
+        {
+            Lines.Algorithm.Bresenham,
+            Lines.Algorithm.DDA,
+            Lines.Algorithm.Orthogonal
+        };
+
+        // Each line algorithm paired with how it defines adjacency/distance between points.
+        private static readonly (Lines.Algorithm, Distance distanceRule)[] s_adjacency =
+        {
+            (Lines.Algorithm.Bresenham, Distance.Chebyshev),
+            (Lines.Algorithm.DDA, Distance.Chebyshev),
+            (Lines.Algorithm.Orthogonal, Distance.Manhattan)
+        };
+
+        private static readonly Lines.Algorithm[] s_allLineAlgorithms = Enum.GetValues<Lines.Algorithm>().ToArray();
+
+        public static IEnumerable<(Lines.Algorithm algo, (Point start, Point end) points)> OrderedTestCases =
+            s_orderedAlgorithms.Combinate(s_testLines);
+
+        public static IEnumerable<(Lines.Algorithm algo, Distance distanceRule, (Point start, Point end) points)>
+            AllTestCasesWithDistance =
+                s_adjacency.Combinate(s_testLines);
+
+        public static IEnumerable<(Lines.Algorithm algo, (Point start, Point end) points)> AllTestCases =
+            s_allLineAlgorithms.Combinate(s_testLines);
+
+        #endregion
+
+        [Theory]
+        [MemberDataTuple(nameof(OrderedTestCases))]
+        public void LineOrderingTests(Lines.Algorithm algo, (Point start, Point end) points)
+        {
+            var line = Lines.Get(points.start, points.end, algo).ToArray();
+            Assert.Equal(points.start, line[0]);
+            Assert.Equal(points.end, line[^1]);
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(AllTestCasesWithDistance))]
+        public void LineAdjacencyTests(Lines.Algorithm algo, Distance distanceRule, (Point start, Point end) points)
+        {
+            var line = Lines.Get(points.start, points.end, algo).ToArray();
+
+            for (int i = 1; i < line.Length; i++)
+                Assert.Equal(1, distanceRule.Calculate(line[i - 1], line[i]));
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(AllTestCases))]
+        public void LineBoundsTests(Lines.Algorithm algo, (Point start, Point end) points)
+        {
+            var min = new Point(Math.Min(points.start.X, points.end.X), Math.Min(points.start.Y, points.end.Y));
+            var max = new Point(Math.Max(points.start.X, points.end.X), Math.Max(points.start.Y, points.end.Y));
+            var expectedBounds = new Rectangle(min, max);
+
+            var line = Lines.Get(points.start, points.end, algo).ToArray();
+            foreach (var point in line)
+                Assert.True(expectedBounds.Contains(point));
+        }
+
+        [Fact]
+        public void BadAlgorithmTest()
+        {
+            Assert.Throws<ArgumentException>(() => Lines.Get((1, 2), (3, 4), (Lines.Algorithm)100));
+        }
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
+++ b/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
@@ -13,20 +13,20 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
-    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1"/>
+    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj"/>
+    <ProjectReference Include="..\TheSadRogue.Primitives\TheSadRogue.Primitives.csproj" />
   </ItemGroup>
 
-  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared"/>
+  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/TheSadRogue.Primitives/Lines.cs
+++ b/TheSadRogue.Primitives/Lines.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// Provides implementations of various (line-drawing) algorithms which are useful for
+    /// for generating points closest to a line between two points on a grid.
+    /// </summary>
+    public static class Lines
+    {
+        /// <summary>
+        /// Various supported line-drawing algorithms.
+        /// </summary>
+        public enum Algorithm
+        {
+            /// <summary>
+            /// Bresenham line algorithm.  Points are guaranteed to be in order from start to finish.
+            /// </summary>
+            Bresenham,
+
+            /// <summary>
+            /// Digital Differential Analyzer line algorithm.  It will produce slightly different lines compared to
+            /// Bresenham, and it takes approximately the same time as Bresenham (very slightly slower) for most inputs.
+            /// Points are guaranteed to be in order from start to finish.
+            /// </summary>
+            DDA,
+
+            /// <summary>
+            /// Line algorithm that takes only orthogonal steps (each grid location on the line
+            /// returned is within one cardinal direction of the previous one). Potentially useful
+            /// for LOS in games that use MANHATTAN distance. Based on the algorithm
+            /// <a href="http://www.redblobgames.com/grids/line-drawing.html#stepping">here</a>.
+            /// Points are guaranteed to be in order from start to finish.
+            /// </summary>
+            Orthogonal
+        }
+
+        private const int ModifierX = 0x7fff;
+        private const int ModifierY = 0x7fff;
+
+        /// <summary>
+        /// Returns an IEnumerable of every point, in order, closest to a line between the two points
+        /// specified, using the line drawing algorithm given. The start and end points will be included.
+        /// </summary>
+        /// <param name="start">The start point of the line.</param>
+        /// <param name="end">The end point of the line.</param>
+        /// <param name="type">The line-drawing algorithm to use to generate the line.</param>
+        /// <returns>
+        /// An IEnumerable of every point, in order, closest to a line between the two points
+        /// specified (according to the algorithm given).
+        /// </returns>
+        public static IEnumerable<Point> Get(Point start, Point end, Algorithm type = Algorithm.Bresenham)
+            => Get(start.X, start.Y, end.X, end.Y, type);
+
+        /// <summary>
+        /// Returns an IEnumerable of every point, in order, closest to a line between the two points
+        /// specified, using the line drawing algorithm given. The start and end points will be included.
+        /// </summary>
+        /// <param name="startX">X-coordinate of the starting point of the line.</param>
+        /// <param name="startY">Y-coordinate of the starting point of the line.</param>
+        /// <param name="endX">X-coordinate of the ending point of the line.</param>
+        /// ///
+        /// <param name="endY">Y-coordinate of the ending point of the line.</param>
+        /// <param name="type">The line-drawing algorithm to use to generate the line.</param>
+        /// <returns>
+        /// An IEnumerable of every point, in order, closest to a line between the two points
+        /// specified (according to the algorithm given).
+        /// </returns>
+        public static IEnumerable<Point> Get(int startX, int startY, int endX, int endY,
+                                             Algorithm type = Algorithm.Bresenham)
+        {
+            switch (type)
+            {
+                case Algorithm.Bresenham:
+                    return Bresenham(startX, startY, endX, endY);
+
+                case Algorithm.DDA:
+                    return DDA(startX, startY, endX, endY);
+
+                case Algorithm.Orthogonal:
+                    return Ortho(startX, startY, endX, endY);
+
+                default:
+                    throw new ArgumentException("Unsupported line-drawing algorithm.", nameof(type)); // Should not occur
+            }
+        }
+
+        private static IEnumerable<Point> Bresenham(int startX, int startY, int endX, int endY)
+        {
+            int w = endX - startX;
+            int h = endY - startY;
+            int dx1 = 0, dy1 = 0, dx2 = 0, dy2 = 0;
+            if (w < 0) dx1 = -1;
+            else if (w > 0) dx1 = 1;
+            if (h < 0) dy1 = -1;
+            else if (h > 0) dy1 = 1;
+            if (w < 0) dx2 = -1;
+            else if (w > 0) dx2 = 1;
+            int longest = Math.Abs(w);
+            int shortest = Math.Abs(h);
+            if (!(longest > shortest))
+            {
+                longest = Math.Abs(h);
+                shortest = Math.Abs(w);
+                if (h < 0) dy2 = -1;
+                else if (h > 0) dy2 = 1;
+                dx2 = 0;
+            }
+
+            int numerator = longest >> 1;
+            for (int i = 0; i <= longest; i++)
+            {
+                yield return new Point(startX, startY);
+                numerator += shortest;
+                if (!(numerator < longest))
+                {
+                    numerator -= longest;
+                    startX += dx1;
+                    startY += dy1;
+                }
+                else
+                {
+                    startX += dx2;
+                    startY += dy2;
+                }
+            }
+        }
+
+        private static IEnumerable<Point> DDA(int startX, int startY, int endX, int endY)
+        {
+            int dx = endX - startX;
+            int dy = endY - startY;
+
+            int nx = Math.Abs(dx);
+            int ny = Math.Abs(dy);
+
+            // Calculate octant value
+            int octant = (dy < 0 ? 4 : 0) | (dx < 0 ? 2 : 0) | (ny > nx ? 1 : 0);
+            int fraction = 0;
+            int mn = Math.Max(nx, ny);
+
+            int move;
+
+            if (mn == 0)
+            {
+                yield return new Point(startX, startY);
+                yield break;
+            }
+
+            if (ny == 0)
+            {
+                if (dx > 0)
+                    for (int x = startX; x <= endX; x++)
+                        yield return new Point(x, startY);
+                else
+                    for (int x = startX; x >= endX; x--)
+                        yield return new Point(x, startY);
+
+                yield break;
+            }
+
+            if (nx == 0)
+            {
+                if (dy > 0)
+                    for (int y = startY; y <= endY; y++)
+                        yield return new Point(startX, y);
+                else
+                    for (int y = startY; y >= endY; y--)
+                        yield return new Point(startX, y);
+
+                yield break;
+            }
+
+            switch (octant)
+            {
+                case 0: // +x, +y
+                    move = (ny << 16) / nx;
+                    for (int primary = startX; primary <= endX; primary++, fraction += move)
+                        yield return new Point(primary, startY + ((fraction + ModifierY) >> 16));
+                    break;
+
+                case 1:
+                    move = (nx << 16) / ny;
+                    for (int primary = startY; primary <= endY; primary++, fraction += move)
+                        yield return new Point(startX + ((fraction + ModifierX) >> 16), primary);
+                    break;
+
+                case 2: // -x, +y
+                    move = (ny << 16) / nx;
+                    for (int primary = startX; primary >= endX; primary--, fraction += move)
+                        yield return new Point(primary, startY + ((fraction + ModifierY) >> 16));
+                    break;
+
+                case 3:
+                    move = (nx << 16) / ny;
+                    for (int primary = startY; primary <= endY; primary++, fraction += move)
+                        yield return new Point(startX - ((fraction + ModifierX) >> 16), primary);
+                    break;
+
+                case 6: // -x, -y
+                    move = (ny << 16) / nx;
+                    for (int primary = startX; primary >= endX; primary--, fraction += move)
+                        yield return new Point(primary, startY - ((fraction + ModifierY) >> 16));
+                    break;
+
+                case 7:
+                    move = (nx << 16) / ny;
+                    for (int primary = startY; primary >= endY; primary--, fraction += move)
+                        yield return new Point(startX - ((fraction + ModifierX) >> 16), primary);
+                    break;
+
+                case 4: // +x, -y
+                    move = (ny << 16) / nx;
+                    for (int primary = startX; primary <= endX; primary++, fraction += move)
+                        yield return new Point(primary, startY - ((fraction + ModifierY) >> 16));
+                    break;
+
+                case 5:
+                    move = (nx << 16) / ny;
+                    for (int primary = startY; primary >= endY; primary--, fraction += move)
+                        yield return new Point(startX + ((fraction + ModifierX) >> 16), primary);
+                    break;
+            }
+        }
+
+        private static IEnumerable<Point> Ortho(int startX, int startY, int endX, int endY)
+        {
+            int dx = endX - startX;
+            int dy = endY - startY;
+
+            int nx = Math.Abs(dx);
+            int ny = Math.Abs(dy);
+
+            int signX = dx > 0 ? 1 : -1;
+            int signY = dy > 0 ? 1 : -1;
+
+            int workX = startX;
+            int workY = startY;
+
+            yield return new Point(startX, startY);
+
+            for (int ix = 0, iy = 0; ix < nx || iy < ny;)
+            {
+                // Optimized version of `if ((0.5 + ix) / nx < (0.5 + iy) / ny)`
+                if ((1 + ix + ix) * ny < (1 + iy + iy) * nx)
+                {
+                    workX += signX;
+                    ix++;
+                }
+                else
+                {
+                    workY += signY;
+                    iy++;
+                }
+
+                yield return new Point(workX, workY);
+            }
+        }
+    }
+}

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -61,12 +61,12 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget"/>
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
+    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).snupkg" DestinationFolder="$(OutputPath)..\..\..\nuget" />
   </Target>
 </Project>


### PR DESCRIPTION
# Changes
This adds basic line drawing algorithms for 2D grids.

# Notes
Bresenham is functionally equivalent to the `Algorithms.Line` function in SadConsole 9 (except for it properly implements lazy evaluation); and the algorithms are generally equivalent to their GoRogue counterparts (which will be removed after this release).

These should be fairly optimized, although line drawing is generally quite fast to begin with.  For convenience, I use `IEnumerable` as the return value, instead of taking some sort of `Action` or `Func` in as a parameter to "plot" points.  This generally makes the user's code simpler, makes it more obvious how to gain the benefit of lazy evaluation, and did not appear to affect performance by more than 20-30 ns in testing.

# Benchmarks
Benchmarks run using the .NET 7 runtime.

Here is the results for the performance tests of the line algorithms:
|          Method |       LineToDraw |       algo |     Mean |   Error |  StdDev |
|---------------- |----------------- |----------- |---------:|--------:|--------:|
| GetPointsOnLine |  ((1,1), (1,25)) |  Bresenham | 186.7 ns | 1.04 ns | 0.87 ns |
| GetPointsOnLine |  ((1,1), (1,25)) |        DDA | 185.4 ns | 0.82 ns | 0.73 ns |
| GetPointsOnLine |  ((1,1), (1,25)) | Orthogonal | 189.4 ns | 1.10 ns | 0.97 ns |
| GetPointsOnLine | ((1,1), (25,50)) |  Bresenham | 364.1 ns | 6.95 ns | 6.82 ns |
| GetPointsOnLine | ((1,1), (25,50)) |        DDA | 378.9 ns | 3.68 ns | 3.26 ns |
| GetPointsOnLine | ((1,1), (25,50)) | Orthogonal | 529.7 ns | 2.81 ns | 2.49 ns |
| GetPointsOnLine |  ((1,1), (50,1)) |  Bresenham | 356.1 ns | 3.74 ns | 3.50 ns |
| GetPointsOnLine |  ((1,1), (50,1)) |        DDA | 357.6 ns | 3.56 ns | 3.33 ns |
| GetPointsOnLine |  ((1,1), (50,1)) | Orthogonal | 373.7 ns | 5.67 ns | 5.03 ns |
| GetPointsOnLine | ((1,1), (50,25)) |  Bresenham | 358.7 ns | 3.27 ns | 2.73 ns |
| GetPointsOnLine | ((1,1), (50,25)) |        DDA | 363.7 ns | 1.54 ns | 1.28 ns |
| GetPointsOnLine | ((1,1), (50,25)) | Orthogonal | 532.4 ns | 5.24 ns | 4.38 ns |
| GetPointsOnLine | ((25,50), (1,1)) |  Bresenham | 357.2 ns | 1.93 ns | 1.50 ns |
| GetPointsOnLine | ((25,50), (1,1)) |        DDA | 374.1 ns | 0.62 ns | 0.55 ns |
| GetPointsOnLine | ((25,50), (1,1)) | Orthogonal | 525.5 ns | 1.85 ns | 1.55 ns |
| GetPointsOnLine | ((50,25), (1,1)) |  Bresenham | 358.3 ns | 2.36 ns | 1.84 ns |
| GetPointsOnLine | ((50,25), (1,1)) |        DDA | 366.1 ns | 1.55 ns | 1.45 ns |
| GetPointsOnLine | ((50,25), (1,1)) | Orthogonal | 531.4 ns | 3.76 ns | 3.51 ns |

Bresenham and DDA are approximately equivalent, and Ortho is roughly equivalent as well so long as the manhattan distance is the same as the chebyshev distance of the line (otherwise the ortho line is slower since it has to take more steps to get from point a to point b).

Additionally, here is a sampling of using Bresenham in its currently implemented form, vs using an Action or a Func to plot points and avoid `IEnumerable`:

|                       Method |       LineToDraw |     Mean |   Error |  StdDev |
|----------------------------- |----------------- |---------:|--------:|--------:|
|         BresenhamIEnumerable |  ((1,1), (1,25)) | 191.2 ns | 0.99 ns | 0.87 ns |
|                BresenhamFunc |  ((1,1), (1,25)) | 179.2 ns | 0.41 ns | 0.39 ns |
|   BresenhamFuncLocalFunction |  ((1,1), (1,25)) | 179.0 ns | 0.48 ns | 0.40 ns |
|              BresenhamAction |  ((1,1), (1,25)) | 179.1 ns | 1.35 ns | 1.27 ns |
| BresenhamActionLocalFunction |  ((1,1), (1,25)) | 176.9 ns | 0.63 ns | 0.56 ns |
|         BresenhamIEnumerable | ((1,1), (25,50)) | 364.1 ns | 1.51 ns | 1.26 ns |
|                BresenhamFunc | ((1,1), (25,50)) | 349.6 ns | 0.98 ns | 0.82 ns |
|   BresenhamFuncLocalFunction | ((1,1), (25,50)) | 350.3 ns | 1.01 ns | 0.85 ns |
|              BresenhamAction | ((1,1), (25,50)) | 344.3 ns | 0.94 ns | 0.73 ns |
| BresenhamActionLocalFunction | ((1,1), (25,50)) | 343.8 ns | 0.36 ns | 0.30 ns |
|         BresenhamIEnumerable |  ((1,1), (50,1)) | 361.1 ns | 1.31 ns | 1.16 ns |
|                BresenhamFunc |  ((1,1), (50,1)) | 343.4 ns | 0.61 ns | 0.54 ns |
|   BresenhamFuncLocalFunction |  ((1,1), (50,1)) | 342.2 ns | 0.27 ns | 0.23 ns |
|              BresenhamAction |  ((1,1), (50,1)) | 343.3 ns | 0.90 ns | 0.80 ns |
| BresenhamActionLocalFunction |  ((1,1), (50,1)) | 341.7 ns | 1.68 ns | 1.57 ns |
|         BresenhamIEnumerable | ((1,1), (50,25)) | 362.8 ns | 1.62 ns | 1.35 ns |
|                BresenhamFunc | ((1,1), (50,25)) | 346.0 ns | 1.74 ns | 1.54 ns |
|   BresenhamFuncLocalFunction | ((1,1), (50,25)) | 347.4 ns | 0.51 ns | 0.45 ns |
|              BresenhamAction | ((1,1), (50,25)) | 342.5 ns | 0.45 ns | 0.35 ns |
| BresenhamActionLocalFunction | ((1,1), (50,25)) | 343.2 ns | 1.23 ns | 1.15 ns |
|         BresenhamIEnumerable | ((25,50), (1,1)) | 367.5 ns | 0.66 ns | 0.55 ns |
|                BresenhamFunc | ((25,50), (1,1)) | 349.3 ns | 0.74 ns | 0.62 ns |
|   BresenhamFuncLocalFunction | ((25,50), (1,1)) | 349.0 ns | 0.34 ns | 0.30 ns |
|              BresenhamAction | ((25,50), (1,1)) | 344.8 ns | 0.82 ns | 0.69 ns |
| BresenhamActionLocalFunction | ((25,50), (1,1)) | 345.1 ns | 1.17 ns | 1.03 ns |
|         BresenhamIEnumerable | ((50,25), (1,1)) | 365.4 ns | 0.58 ns | 0.48 ns |
|                BresenhamFunc | ((50,25), (1,1)) | 348.3 ns | 0.69 ns | 0.62 ns |
|   BresenhamFuncLocalFunction | ((50,25), (1,1)) | 348.5 ns | 0.60 ns | 0.50 ns |
|              BresenhamAction | ((50,25), (1,1)) | 342.6 ns | 0.88 ns | 0.78 ns |
| BresenhamActionLocalFunction | ((50,25), (1,1)) | 342.3 ns | 0.27 ns | 0.21 ns |

The func/action versions are only about 20 nanoseconds faster at best, which seems unlikely to cause a significant difference in practice.  If absolute maximum performance is strictly needed to replace some of the usages of the equivalent SadConsole functions, we can provide both functions, but the enumerable version seems like a reasonable default that doesn't trade much in terms of performance.