### PR TITLE
Add Support for DirectX MonoGame to the MonoGame Extension

### DIFF
--- a/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
+++ b/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -20,13 +21,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1"/>
+    <PackageReference Include="XUnit.ValueTuples" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TheSadRogue.Primitives.MonoGame\TheSadRogue.Primitives.MonoGame.csproj"/>
+    <ProjectReference Include="..\TheSadRogue.Primitives.MonoGame\TheSadRogue.Primitives.MonoGame.csproj" />
   </ItemGroup>
 
-  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared"/>
+  <Import Project="..\TheSadRogue.Primitives.UnitTests.Shared\TheSadRogue.Primitives.UnitTests.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Chris3606;Thraka</Authors>
     <Company>TheSadRogue</Company>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -12,10 +12,14 @@
     <Company>TheSadRogue</Company>
     <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
     <Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
-  
+
     <!-- More nuget package settings-->
     <PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
-    <PackageReleaseNotes>Multi-targeted to .NET 7.</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      - Changed MonoGame dependency to use the PrivateAssets tag.
+        - MonoGame is no longer implicitly installed when this NuGet package is.
+        - However, you can select the DX or OpenGL versions of MonoGame.
+    </PackageReleaseNotes>
     <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -36,7 +40,7 @@
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641"/>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" PrivateAssets="All"/>
     <PackageReference Include="TheSadRogue.Primitives" Version="1.*"/>
   </ItemGroup>
 


### PR DESCRIPTION
# Changes
- Changes the MonoGame extension package to mark the MonoGame dependency as "PrivateAssets".  This has the following side effects:
    - MonoGame is no longer installed implicitly into a project if this package is installed
    - When installing MonoGame, a user may select any package matching MonoGame's assembly name and public API.  This includes both the DesktopGL and DirectX versions

