### PR TITLE
Enumerator Refactor

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -18,10 +18,10 @@ namespace TheSadRogue.Primitives.PerformanceTests
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions().ToEnumerable());
+            _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions());
             _areaInterface = _area;
 
-            _area2 = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size / 2, Size / 2).Positions().ToEnumerable());
+            _area2 = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size / 2, Size / 2).Positions());
         }
 
         [Benchmark]

--- a/TheSadRogue.Primitives.PerformanceTests/Area.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Area.cs
@@ -48,7 +48,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public int BenchmarkFastEnumerable()
         {
             int sum = 0;
-            foreach (var pos in _areaInterface.FastEnumerator())
+            foreach (var pos in new ReadOnlyAreaPositionsEnumerator(_areaInterface))
                 sum += pos.X + pos.Y;
 
             return sum;
@@ -58,7 +58,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public int BenchmarkFastEnumerableAsConcrete()
         {
             int sum = 0;
-            foreach (var pos in _area.FastEnumerator())
+            foreach (var pos in new ReadOnlyAreaPositionsEnumerator(_area))
                 sum += pos.X + pos.Y;
 
             return sum;

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
@@ -24,9 +24,9 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
                     yield return new Point(x, y);
         }
 
-        public static IEnumerable<Point> ToEnumerableShortcut(this RectanglePositionsEnumerable enumerable)
+        public static IEnumerable<Point> ToEnumerableShortcut(this RectanglePositionsEnumerator enumerator)
         {
-            foreach (var pos in enumerable)
+            foreach (var pos in enumerator)
                 yield return pos;
         }
     }

--- a/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/GridViews/PositionsEnumeration.cs
@@ -77,7 +77,7 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
                 var pos = Point.FromIndex(i, _gridView.Width);
                 sum += pos.X + pos.Y;
             }
-                
+
 
             return sum;
         }
@@ -131,7 +131,7 @@ namespace TheSadRogue.Primitives.PerformanceTests.GridViews
         public int PositionsToEnumerableIteration()
         {
             int sum = 0;
-            foreach (var pos in _gridView.Positions().ToEnumerable())
+            foreach (var pos in _gridView.Positions())
                 sum += pos.X + pos.Y;
 
             return sum;

--- a/TheSadRogue.Primitives.PerformanceTests/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/ReadOnlyAreaExtensions.cs
@@ -57,7 +57,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions().ToEnumerable());
+            _area = new SadRogue.Primitives.Area(new SadRogue.Primitives.Rectangle(0, 0, Size, Size).Positions());
             _rule = AdjacencyRule.Cardinals;
         }
 

--- a/TheSadRogue.Primitives.PerformanceTests/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/ReadOnlyAreaExtensions.cs
@@ -15,7 +15,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
 
         public static IEnumerable<Point> PerimeterPositionsNeighborsFunc(this IReadOnlyArea area, AdjacencyRule rule)
         {
-            foreach (var pos in area.FastEnumerator())
+            foreach (var pos in area)
             {
                 foreach (var neighbor in rule.Neighbors(pos))
                 {
@@ -31,7 +31,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public static IEnumerable<Point> PerimeterPositionsArrayFor(this IReadOnlyArea area, AdjacencyRule rule)
         {
             var count = rule.DirectionsOfNeighborsCache.Length;
-            foreach (var pos in area.FastEnumerator())
+            foreach (var pos in area)
             {
                 for (int i = 0; i < count; i++)
                 {

--- a/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
@@ -84,7 +84,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public int BisectToEnumerable()
         {
             int sum = 0;
-            foreach (var rect in _rectangle.Bisect().ToEnumerable())
+            foreach (var rect in _rectangle.Bisect())
                 sum += rect.Width + rect.Height;
 
             return sum;
@@ -94,7 +94,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public int BisectVerticallyToEnumerable()
         {
             int sum = 0;
-            foreach (var rect in _rectangle.BisectVertically().ToEnumerable())
+            foreach (var rect in _rectangle.BisectVertically())
                 sum += rect.Width + rect.Height;
 
             return sum;
@@ -104,7 +104,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
         public int BisectHorizontallyToEnumerable()
         {
             int sum = 0;
-            foreach (var rect in _rectangle.BisectHorizontally().ToEnumerable())
+            foreach (var rect in _rectangle.BisectHorizontally())
                 sum += rect.Width + rect.Height;
 
             return sum;

--- a/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
@@ -17,6 +17,46 @@ namespace TheSadRogue.Primitives.PerformanceTests
             yield return new SadRogue.Primitives.Rectangle(new Point(startX, startY), new Point(stopX, bisection));
             yield return new SadRogue.Primitives.Rectangle(new Point(startX, bisection + 1), new Point(stopX, stopY));
         }
+
+        public static IEnumerable<Point> PerimeterPositionsNativeEnumerable(this SadRogue.Primitives.Rectangle self)
+        {
+            for (int x = self.MinExtentX; x <= self.MaxExtentX; x++)
+                yield return new Point(x, self.MinExtentY); // Minimum y-side perimeter
+
+            // Start offset 1, since last loop returned the corner piece
+            for (int y = self.MinExtentY + 1; y <= self.MaxExtentY; y++)
+                yield return new Point(self.MaxExtentX, y);
+
+            // Again skip 1 because last loop returned the corner piece
+            for (int x = self.MaxExtentX - 1; x >= self.MinExtentX; x--)
+                yield return new Point(x, self.MaxExtentY);
+
+            // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
+            for (int y = self.MaxExtentY - 1; y >= self.MinExtentY + 1; y--)
+                yield return new Point(self.MinExtentX, y);
+        }
+
+        public static IEnumerable<Point> PerimeterPositionsNativeEnumerableCachedEnds(this SadRogue.Primitives.Rectangle self)
+        {
+            int minX = self.MinExtentX;
+            int minY = self.MinExtentY;
+            int maxX = self.MaxExtentX;
+            int maxY = self.MaxExtentY;
+            for (int x = minX; x <= maxX; x++)
+                yield return new Point(x, minY); // Minimum y-side perimeter
+
+            // Start offset 1, since last loop returned the corner piece
+            for (int y = minY + 1; y <= maxY; y++)
+                yield return new Point(maxX, y);
+
+            // Again skip 1 because last loop returned the corner piece
+            for (int x = maxX - 1; x >= minX; x--)
+                yield return new Point(x, maxY);
+
+            // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
+            for (int y = maxY - 1; y >= minY + 1; y--)
+                yield return new Point(minX, y);
+        }
     }
 
     /// <summary>
@@ -119,6 +159,36 @@ namespace TheSadRogue.Primitives.PerformanceTests
             int sum = 0;
             foreach (var rect in _rectangle.BisectHorizontallyNativeEnumerator())
                 sum += rect.Width + rect.Height;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PerimeterPositions()
+        {
+            int sum = 0;
+            foreach (var pos in _rectangle.PerimeterPositions())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PerimeterPositionsNativeEnumerable()
+        {
+            int sum = 0;
+            foreach (var pos in _rectangle.PerimeterPositionsNativeEnumerable())
+                sum += pos.X + pos.Y;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int PerimeterPositionsNativeEnumerableCachedEnds()
+        {
+            int sum = 0;
+            foreach (var pos in _rectangle.PerimeterPositionsNativeEnumerableCachedEnds())
+                sum += pos.X + pos.Y;
 
             return sum;
         }

--- a/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/Rectangle.cs
@@ -6,7 +6,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
 {
     public static class RectangleTestingExtensions
     {
-        public static IEnumerable<SadRogue.Primitives.Rectangle> BisectHorizontallyNativeEnumerator(this SadRogue.Primitives.Rectangle rectangle)
+        public static IEnumerable<SadRogue.Primitives.Rectangle> BisectHorizontallyNoCustomIterator(this SadRogue.Primitives.Rectangle rectangle)
         {
             int startX = rectangle.MinExtentX;
             int stopY = rectangle.MaxExtentY;
@@ -18,7 +18,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
             yield return new SadRogue.Primitives.Rectangle(new Point(startX, bisection + 1), new Point(stopX, stopY));
         }
 
-        public static IEnumerable<Point> PerimeterPositionsNativeEnumerable(this SadRogue.Primitives.Rectangle self)
+        public static IEnumerable<Point> PerimeterPositionsNoCustomIterator(this SadRogue.Primitives.Rectangle self)
         {
             for (int x = self.MinExtentX; x <= self.MaxExtentX; x++)
                 yield return new Point(x, self.MinExtentY); // Minimum y-side perimeter
@@ -36,7 +36,7 @@ namespace TheSadRogue.Primitives.PerformanceTests
                 yield return new Point(self.MinExtentX, y);
         }
 
-        public static IEnumerable<Point> PerimeterPositionsNativeEnumerableCachedEnds(this SadRogue.Primitives.Rectangle self)
+        public static IEnumerable<Point> PerimeterPositionsNoCustomIteratorCachedEnds(this SadRogue.Primitives.Rectangle self)
         {
             int minX = self.MinExtentX;
             int minY = self.MinExtentY;
@@ -154,10 +154,10 @@ namespace TheSadRogue.Primitives.PerformanceTests
         #region IEnumerable Implementations
 
         [Benchmark]
-        public int BisectHorizontallyNativeEnumerable()
+        public int BisectHorizontallyNoCustomIterator()
         {
             int sum = 0;
-            foreach (var rect in _rectangle.BisectHorizontallyNativeEnumerator())
+            foreach (var rect in _rectangle.BisectHorizontallyNoCustomIterator())
                 sum += rect.Width + rect.Height;
 
             return sum;
@@ -174,20 +174,20 @@ namespace TheSadRogue.Primitives.PerformanceTests
         }
 
         [Benchmark]
-        public int PerimeterPositionsNativeEnumerable()
+        public int PerimeterPositionsNoCustomIterator()
         {
             int sum = 0;
-            foreach (var pos in _rectangle.PerimeterPositionsNativeEnumerable())
+            foreach (var pos in _rectangle.PerimeterPositionsNoCustomIterator())
                 sum += pos.X + pos.Y;
 
             return sum;
         }
 
         [Benchmark]
-        public int PerimeterPositionsNativeEnumerableCachedEnds()
+        public int PerimeterPositionsNoCustomIteratorCachedEnds()
         {
             int sum = 0;
-            foreach (var pos in _rectangle.PerimeterPositionsNativeEnumerableCachedEnds())
+            foreach (var pos in _rectangle.PerimeterPositionsNoCustomIteratorCachedEnds())
                 sum += pos.X + pos.Y;
 
             return sum;

--- a/TheSadRogue.Primitives.PerformanceTests/ShapeTests.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/ShapeTests.cs
@@ -106,7 +106,7 @@ public class CircleTests
     public int PrimitivesToEnumerable()
     {
         int sum = 0;
-        foreach (var point in Shapes.GetCircle(Center, Radius))
+        foreach (var point in (IEnumerable<Point>)Shapes.GetCircle(Center, Radius))
             sum += point.X + point.Y;
 
         return sum;
@@ -156,7 +156,7 @@ public class EllipseTests
     public int PrimitivesToEnumerable()
     {
         int sum = 0;
-        foreach (var point in Shapes.GetEllipse(Ellipse.f1, Ellipse.f2))
+        foreach (var point in (IEnumerable<Point>)Shapes.GetEllipse(Ellipse.f1, Ellipse.f2))
             sum += point.X + point.Y;
 
         return sum;

--- a/TheSadRogue.Primitives.PerformanceTests/ShapeTests.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/ShapeTests.cs
@@ -106,7 +106,7 @@ public class CircleTests
     public int PrimitivesToEnumerable()
     {
         int sum = 0;
-        foreach (var point in Shapes.GetCircle(Center, Radius).ToEnumerable())
+        foreach (var point in Shapes.GetCircle(Center, Radius))
             sum += point.X + point.Y;
 
         return sum;
@@ -156,7 +156,7 @@ public class EllipseTests
     public int PrimitivesToEnumerable()
     {
         int sum = 0;
-        foreach (var point in Shapes.GetEllipse(Ellipse.f1, Ellipse.f2).ToEnumerable())
+        foreach (var point in Shapes.GetEllipse(Ellipse.f1, Ellipse.f2))
             sum += point.X + point.Y;
 
         return sum;

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -71,6 +71,30 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
         }
 
+        [Theory]
+        [MemberDataTuple(nameof(TestRectanglesWithYIncreasesUpwards))]
+        public void GenericEnumeratorCurrentIsEquivalent(Rectangle rect, bool yIncreaseUpwards)
+        {
+            Direction.SetYIncreasesUpwardsUnsafe(yIncreaseUpwards);
+
+            var list = rect.PerimeterPositions().ToArray();
+            Assert.Equal(rect.PerimeterPositions(), list);
+
+            Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
+        }
+
+        [Fact]
+        public void PerimeterPositionsReset()
+        {
+            var enumerator = new Rectangle(1, 2, 3, 4).PerimeterPositions();
+
+            var list = enumerator.ToList();
+            ((IEnumerator<Point>)enumerator).Reset();
+            var list2 = enumerator.ToList();
+
+            Assert.Equal(list, list2);
+        }
+
         [Fact]
         public void PerimeterPositionsEmptyRectangle()
         {

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -71,6 +71,19 @@ namespace SadRogue.Primitives.UnitTests
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
         }
 
+        [Fact]
+        public void PerimeterPositionsEmptyRectangle()
+        {
+            var rect = Rectangle.Empty;
+            Assert.Empty(rect.PerimeterPositions());
+
+            rect = new Rectangle(1, 2, 0, 1);
+            Assert.Empty(rect.PerimeterPositions());
+
+            rect = new Rectangle(1, 2, 1, 0);
+            Assert.Empty(rect.PerimeterPositions());
+        }
+
         // Ensure we use the custom iterator directly, in case that and its GetEnumerator definition for IEnumerable
         // differ.
         private static HashSet<Point> PerimeterPositionsToHashSetDirect(RectanglePerimeterPositionsEnumerator enumerator)

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -40,7 +40,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.Y == yToCheck).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.Y == yToCheck).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
@@ -60,7 +60,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.X == rect.MaxExtentX).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.X == rect.MaxExtentX).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
@@ -82,7 +82,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.Y == yToCheck).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.Y == yToCheck).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
@@ -102,7 +102,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(edgePoints.Length, hashSet.Count);
 
             // Verify correct points
-            HashSet<Point> expectedHash = rect.Positions().ToEnumerable().Where(pos => pos.X == rect.MinExtentX).ToHashSet();
+            HashSet<Point> expectedHash = rect.Positions().Where(pos => pos.X == rect.MinExtentX).ToHashSet();
             Assert.Equal(expectedHash, hashSet);
 
             Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/RectangleTests.cs
@@ -22,6 +22,68 @@ namespace SadRogue.Primitives.UnitTests
                 .ToArray();
         #endregion
 
+        #region Test Perimeter Positions
+
+        [Theory]
+        [MemberDataTuple(nameof(TestRectanglesWithYIncreasesUpwards))]
+        public void PerimeterPositions(Rectangle rect, bool yIncreaseUpwards)
+        {
+            Direction.SetYIncreasesUpwardsUnsafe(yIncreaseUpwards);
+
+            var expected = new HashSet<Point>();
+            foreach (var pos in rect.Positions())
+                if (pos.X == rect.MinExtentX || pos.X == rect.MaxExtentX || pos.Y == rect.MinExtentY ||
+                    pos.Y == rect.MaxExtentY)
+                    expected.Add(pos);
+
+            var actual = PerimeterPositionsToHashSetDirect(rect.PerimeterPositions());
+
+            Assert.Equal(expected, actual);
+
+            Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(TestRectanglesWithYIncreasesUpwards))]
+        public void PerimeterPositionsEnumerableIsEquivalent(Rectangle rect, bool yIncreaseUpwards)
+        {
+            Direction.SetYIncreasesUpwardsUnsafe(yIncreaseUpwards);
+
+            var expected = PerimeterPositionsToHashSetDirect(rect.PerimeterPositions());
+            var actual = rect.PerimeterPositions().ToHashSet();
+
+            Assert.Equal(expected, actual);
+
+            Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(TestRectanglesWithYIncreasesUpwards))]
+        public void PerimeterPositionsNoDuplicates(Rectangle rect, bool yIncreaseUpwards)
+        {
+            Direction.SetYIncreasesUpwardsUnsafe(yIncreaseUpwards);
+
+            int expected = rect.PerimeterPositions().ToHashSet().Count;
+            int actual = rect.PerimeterPositions().ToList().Count;
+
+            Assert.Equal(expected, actual);
+
+            Direction.SetYIncreasesUpwardsUnsafe(false); // Ensure we reset to false for next test
+        }
+
+        // Ensure we use the custom iterator directly, in case that and its GetEnumerator definition for IEnumerable
+        // differ.
+        private static HashSet<Point> PerimeterPositionsToHashSetDirect(RectanglePerimeterPositionsEnumerator enumerator)
+        {
+            var list = new HashSet<Point>();
+            foreach (var pos in enumerator)
+                list.Add(pos);
+
+            return list;
+        }
+
+        #endregion
+
         #region Test Side Points
 
         [Theory]

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -387,14 +387,19 @@ namespace SadRogue.Primitives.UnitTests
                 l3.Add(pos);
 
             var l4 = new List<Point>();
-            foreach (var pos in area.FastEnumerator())
+            foreach (var pos in new ReadOnlyAreaPositionsEnumerator(area))
                 l4.Add(pos);
+
+            var l5 = new List<Point>();
+            foreach (var pos in (IEnumerable<Point>)area)
+                l5.Add(pos);
 
 
             Assert.Equal(expected, l1);
             Assert.Equal(expected, l2);
             Assert.Equal(expected, l3);
             Assert.Equal(expected, l4);
+            Assert.Equal(expected, l5);
         }
         #endregion
         #region Perimeter Positions

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -133,7 +133,7 @@ namespace SadRogue.Primitives.UnitTests
             area.Add(rect);
 
             Assert.Equal(rect.Width * rect.Height, area.Count);
-            Assert.Equal(rect.Positions().ToEnumerable(), area);
+            Assert.Equal(rect.Positions(), area);
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace SadRogue.Primitives.UnitTests
         public void RemoveRectangle()
         {
             var rect = new Rectangle(1, 2, 15, 12);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
 
             var bisection = rect.BisectVertically();
             _output.WriteLine($"Bisection:\n    Rect1: {bisection.Rect1}\n    Rect2: {bisection.Rect2}");
@@ -210,7 +210,7 @@ namespace SadRogue.Primitives.UnitTests
             _output.WriteLine($"Left: {left}");
             _output.WriteLine($"Area: {area.Bounds}");
             Assert.Equal(left.Width * left.Height, area.Count);
-            Assert.Equal(left.Positions().ToEnumerable().ToHashSet(), area.ToHashSet());
+            Assert.Equal(left.Positions().ToHashSet(), area.ToHashSet());
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace SadRogue.Primitives.UnitTests
         public void ContainsPosition()
         {
             var rect = new Rectangle(1, 2, 15, 12);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
 
             // Contains all points inside rectangle
             foreach (var pos in rect.Positions())
@@ -299,14 +299,14 @@ namespace SadRogue.Primitives.UnitTests
         public void ContainsArea()
         {
             var rect = new Rectangle(1, 2, 15, 12);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
 
             // Contains proper subset
-            var subArea = new Area(rect.Expand(-1, -1).Positions().ToEnumerable());
+            var subArea = new Area(rect.Expand(-1, -1).Positions());
             Assert.True(area.Contains(subArea));
 
             // Contains equivalent
-            subArea = new Area(rect.Positions().ToEnumerable());
+            subArea = new Area(rect.Positions());
             Assert.True(area.Contains(subArea));
 
             // Doesn't contain anything outside
@@ -369,7 +369,7 @@ namespace SadRogue.Primitives.UnitTests
         public void EnumerableCorrect()
         {
             var rect = new Rectangle(0, 0, 15, 15);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
             IReadOnlyArea areaInterface = area;
 
             var expected = new List<Point>();
@@ -402,7 +402,7 @@ namespace SadRogue.Primitives.UnitTests
         public void RectangleAreaPerimeterPositions()
         {
             var rect = new Rectangle(0, 0, 15, 15);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
 
             var expected = rect.PerimeterPositions().ToHashSet();
             var actual1 = area.PerimeterPositions(AdjacencyRule.Cardinals).ToHashSet();
@@ -425,7 +425,7 @@ namespace SadRogue.Primitives.UnitTests
         public void IrregularAreaPerimeterPositionsCardinals()
         {
             var rect = new Rectangle(0, 0, 15, 15);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
             area.Remove(rect.MaxExtent);
 
             var expected = rect.PerimeterPositions().ToHashSet();
@@ -449,7 +449,7 @@ namespace SadRogue.Primitives.UnitTests
         public void IrregularAreaPerimeterPositionsEightWay()
         {
             var rect = new Rectangle(0, 0, 15, 15);
-            var area = new Area(rect.Positions().ToEnumerable());
+            var area = new Area(rect.Positions());
             area.Remove(rect.MaxExtent);
 
             var expected = rect.PerimeterPositions().ToHashSet();

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -394,12 +396,25 @@ namespace SadRogue.Primitives.UnitTests
             foreach (var pos in (IEnumerable<Point>)area)
                 l5.Add(pos);
 
+            var l6 = new List<Point>();
+            foreach (var pos in (IEnumerable<Point>)new ReadOnlyAreaPositionsEnumerator(area))
+                l6.Add(pos);
+
+            var l7 = new List<Point>();
+            foreach (var pos in (IEnumerable)new ReadOnlyAreaPositionsEnumerator(area))
+                l7.Add((Point)pos);
+
+            Assert.Throws<NotSupportedException>(()
+                => ((IEnumerator<Point>)new ReadOnlyAreaPositionsEnumerator(area)).Reset());
+
 
             Assert.Equal(expected, l1);
             Assert.Equal(expected, l2);
             Assert.Equal(expected, l3);
             Assert.Equal(expected, l4);
             Assert.Equal(expected, l5);
+            Assert.Equal(expected, l6);
+            Assert.Equal(expected, l7);
         }
         #endregion
         #region Perimeter Positions

--- a/TheSadRogue.Primitives.UnitTests/BisectionResultTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/BisectionResultTests.cs
@@ -24,7 +24,7 @@ namespace SadRogue.Primitives.UnitTests
 
             var result = new BisectionResult(rect1, rect2);
 
-            var rects = result.ToEnumerable().ToArray();
+            var rects = result.ToArray();
             Assert.Equal(2, rects.Length);
 
             Assert.Equal(rect1, rects[0]);

--- a/TheSadRogue.Primitives.UnitTests/GridViews/GridViewExtensionTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/GridViewExtensionTests.cs
@@ -73,7 +73,7 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             const int gridHeight = 61;
 
             IGridView<bool> view = new ArrayView<bool>(gridWidth, gridHeight);
-            var set = view.Positions().ToEnumerable().ToHashSet();
+            var set = view.Positions().ToHashSet();
 
             Assert.Equal(view.Count, set.Count);
             for (int i = 0; i < view.Count; i++)
@@ -92,7 +92,7 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             foreach (var pos in view.Positions())
                 l1.Add(pos);
 
-            var l2 = view.Positions().ToEnumerable().ToList();
+            var l2 = view.Positions().ToList();
 
             Assert.Equal((IEnumerable<Point>)l1, l2);
         }

--- a/TheSadRogue.Primitives.UnitTests/Mocks/MockReadOnlyArea.cs
+++ b/TheSadRogue.Primitives.UnitTests/Mocks/MockReadOnlyArea.cs
@@ -30,6 +30,12 @@ namespace SadRogue.Primitives.UnitTests.Mocks
             return Points.GetEnumerator();
         }
 
+        ReadOnlyAreaPositionsEnumerator IReadOnlyArea.GetEnumerator()
+        {
+            GetEnumeratorCount++;
+            return new ReadOnlyAreaPositionsEnumerator(this);
+        }
+
         public Rectangle Bounds => throw new System.NotImplementedException();
 
         public int Count => Points.Count;

--- a/TheSadRogue.Primitives.UnitTests/PointTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/PointTests.cs
@@ -109,7 +109,7 @@ namespace SadRogue.Primitives.UnitTests
         public void IndicesAreUnique()
         {
             var rect = _testPositions.WithPosition((0, 0));
-            Assert.Equal(rect.Area, rect.Positions().ToEnumerable().Select(i => i.ToIndex(rect.Width)).ToHashSet().Count);
+            Assert.Equal(rect.Area, rect.Positions().Select(i => i.ToIndex(rect.Width)).ToHashSet().Count);
         }
 
         #endregion
@@ -142,9 +142,9 @@ namespace SadRogue.Primitives.UnitTests
         [Fact]
         public void EuclideanDistanceMagnitudeSameAsEuclideanMagnitude()
         {
-            var positionsByDistance = _testPositions.Positions().ToEnumerable()
+            var positionsByDistance = _testPositions.Positions()
                 .OrderBy(i => Distance.Euclidean.Calculate(_testPositions.Center, i)).ToArray();
-            var positionsByMagnitude = _testPositions.Positions().ToEnumerable()
+            var positionsByMagnitude = _testPositions.Positions()
                 .OrderBy(i => Point.EuclideanDistanceMagnitude(_testPositions.Center, i)).ToArray();
 
             Assert.Equal((IEnumerable<Point>)positionsByDistance, positionsByMagnitude);

--- a/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RadiusTests.cs
@@ -146,7 +146,7 @@ namespace SadRogue.Primitives.UnitTests
 
             // Positions returned should be exactly the ones within the radius
             var positionsHashExpected =
-                area.Positions().ToEnumerable().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
+                area.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
             Assert.Equal(positionsHashExpected, positionsHash);
         }
 
@@ -173,7 +173,7 @@ namespace SadRogue.Primitives.UnitTests
 
             // Positions returned should be exactly the ones within the radius
             var positionsHashExpected =
-                bounds.Positions().ToEnumerable().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
+                bounds.Positions().Where(pos => dist.Calculate(pos, center) <= radius).ToHashSet();
             Assert.Equal(positionsHashExpected, positionsHash);
         }
 

--- a/TheSadRogue.Primitives.UnitTests/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives.UnitTests/ReadOnlyAreaExtensions.cs
@@ -30,7 +30,7 @@ namespace SadRogue.Primitives.UnitTests
             // Iteration should take place using the GetEnumerator function
             area.ClearCounts();
             var list = new List<Point>();
-            foreach (var pos in area.FastEnumerator())
+            foreach (var pos in new ReadOnlyAreaPositionsEnumerator(area))
                 list.Add(pos);
             Assert.Equal(area.Points, list);
             Assert.Equal(0, area.GetIndexCount);
@@ -40,7 +40,7 @@ namespace SadRogue.Primitives.UnitTests
             list.Clear();
             area.ClearCounts();
             area.UseIndexEnumeration = true;
-            foreach (var pos in area.FastEnumerator())
+            foreach (var pos in new ReadOnlyAreaPositionsEnumerator(area))
                 list.Add(pos);
 
             Assert.Equal(area.Points, list);

--- a/TheSadRogue.Primitives.UnitTests/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives.UnitTests/ReadOnlyAreaExtensions.cs
@@ -47,5 +47,33 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(area.Points.Count, area.GetIndexCount);
             Assert.Equal(0, area.GetEnumeratorCount);
         }
+
+        [Fact]
+        public void DeprecatedFastEnumeratorFunctionTriggersCorrectEnumerator()
+        {
+            var area = new ReadOnlyAreaCountEnumerations { UseIndexEnumeration = false };
+
+            // Iteration should take place using the GetEnumerator function
+            area.ClearCounts();
+            var list = new List<Point>();
+#pragma warning disable CS0618
+            foreach (var pos in area.FastEnumerator())
+#pragma warning restore CS0618
+                list.Add(pos);
+            Assert.Equal(area.Points, list);
+            Assert.Equal(0, area.GetIndexCount);
+            Assert.Equal(1, area.GetEnumeratorCount);
+
+            // Iteration should take place using the indexers
+            list.Clear();
+            area.ClearCounts();
+            area.UseIndexEnumeration = true;
+            foreach (var pos in new ReadOnlyAreaPositionsEnumerator(area))
+                list.Add(pos);
+
+            Assert.Equal(area.Points, list);
+            Assert.Equal(area.Points.Count, area.GetIndexCount);
+            Assert.Equal(0, area.GetEnumeratorCount);
+        }
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -181,7 +181,7 @@ namespace SadRogue.Primitives.UnitTests
         public void BisectInHalfTest()
         {
             Rectangle rectangle = new Rectangle(0, 0, 5, 13);
-            List<Rectangle> rectangles = rectangle.Bisect().ToEnumerable().ToList();
+            List<Rectangle> rectangles = rectangle.Bisect().ToList();
             foreach (Point c in rectangles[0].Positions())
             {
                 Assert.True(rectangle.Contains(c));
@@ -202,7 +202,7 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(5, rectangles[1].Width);
 
             rectangle = new Rectangle(0, 0, 13, 5);
-            rectangles.AddRange(rectangle.Bisect().ToEnumerable());
+            rectangles.AddRange(rectangle.Bisect());
             foreach (Point c in rectangles[2].Positions())
             {
                 Assert.True(rectangle.Contains(c));
@@ -227,7 +227,7 @@ namespace SadRogue.Primitives.UnitTests
         public void BisectHorizontallyTest()
         {
             Rectangle rectangle = new Rectangle(0, 0, 5, 13);
-            List<Rectangle> rectangles = rectangle.BisectHorizontally().ToEnumerable().ToList();
+            List<Rectangle> rectangles = rectangle.BisectHorizontally().ToList();
             foreach (Point c in rectangles[0].Positions())
             {
                 Assert.True(rectangle.Contains(c));
@@ -247,7 +247,7 @@ namespace SadRogue.Primitives.UnitTests
         public void BisectVerticallyTest()
         {
             Rectangle rectangle = new Rectangle(0, 0, 13, 5);
-            List<Rectangle> rectangles = rectangle.BisectVertically().ToEnumerable().ToList();
+            List<Rectangle> rectangles = rectangle.BisectVertically().ToList();
             foreach (Point c in rectangles[0].Positions())
             {
                 Assert.True(rectangle.Contains(c));

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -553,13 +553,13 @@ namespace SadRogue.Primitives.UnitTests
             var rect2 = new Rectangle(1, 2, 0, 1);
             var rect3 = new Rectangle(1, 2, 0, 0);
 
-            var set1 = rect1.Positions().ToEnumerable().ToHashSet();
+            var set1 = rect1.Positions().ToHashSet();
             Assert.Empty(set1);
 
-            var set2 = rect2.Positions().ToEnumerable().ToHashSet();
+            var set2 = rect2.Positions().ToHashSet();
             Assert.Empty(set2);
 
-            var set3 = rect3.Positions().ToEnumerable().ToHashSet();
+            var set3 = rect3.Positions().ToHashSet();
             Assert.Empty(set3);
         }
 

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -262,6 +262,40 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(5, rectangles[1].Height);
         }
 
+        [Fact]
+        public void BisectReset()
+        {
+            var result = new Rectangle(0, 0, 5, 13).BisectHorizontally();
+            using IEnumerator<Rectangle> enumerator = result.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(result.Rect1, enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(result.Rect2, enumerator.Current);
+            Assert.False(enumerator.MoveNext());
+
+            enumerator.Reset();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(result.Rect1, enumerator.Current);
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(result.Rect2, enumerator.Current);
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void BisectDeprecatedToEnumerable()
+        {
+            var result = new Rectangle(0, 0, 5, 13).BisectHorizontally();
+
+            var expected = result.ToList();
+#pragma warning disable CS0618
+            var actual = result.ToEnumerable().ToList();
+#pragma warning restore CS0618
+
+            Assert.Equal(expected, actual);
+        }
+
         #endregion
 
         #region Division
@@ -561,6 +595,32 @@ namespace SadRogue.Primitives.UnitTests
 
             var set3 = rect3.Positions().ToHashSet();
             Assert.Empty(set3);
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(MiscTestRectangles))]
+        public void PositionsEnumeratorDeprecatedToEnumerableEquivalent(Rectangle rect)
+        {
+#pragma warning disable CS0618
+            Assert.Equal(rect.Positions(), rect.Positions().ToEnumerable());
+#pragma warning restore CS0618
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(MiscTestRectangles))]
+        public void PositionsEnumeratorReset(Rectangle rect)
+        {
+            using IEnumerator<Point> positions = ((IEnumerable<Point>)rect.Positions()).GetEnumerator();
+            var list = new List<Point>();
+            while (positions.MoveNext())
+                list.Add(positions.Current);
+
+            positions.Reset();
+            var list2 = new List<Point>();
+            while (positions.MoveNext())
+                list2.Add(positions.Current);
+
+            Assert.Equal(list, list2);
         }
 
         private static void CheckRect(Rectangle rect, Point position, int width, int height)

--- a/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
+++ b/TheSadRogue.Primitives.UnitTests/Serialization/TestData.cs
@@ -176,8 +176,6 @@ namespace SadRogue.Primitives.UnitTests.Serialization
         {
             // AdjacencyRules
             AdjacencyRule.Cardinals, AdjacencyRule.EightWay,
-            // BisectionResult
-            new BisectionResult(new Rectangle(1, 2, 5, 7), new Rectangle(7, 8, 10, 19)),
             // BoundedRectangle
             new BoundedRectangle(new Rectangle(1, 4, 10, 14), new Rectangle(-10, -9, 100, 101)),
             // Colors
@@ -300,6 +298,8 @@ namespace SadRogue.Primitives.UnitTests.Serialization
             new ArrayView<int>(new[] { 1, 2, 3, 4 }, 2),
             // ArrayView2D
             MockGridViews.RectangleArrayView2D(50, 40),
+            // BisectionResult
+            new BisectionResult(new Rectangle(1, 2, 5, 7), new Rectangle(7, 8, 10, 19)),
             // Diff
             new Diff<int>
             {

--- a/TheSadRogue.Primitives.UnitTests/ShapesTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/ShapesTests.cs
@@ -100,7 +100,7 @@ namespace SadRogue.Primitives.UnitTests
             foreach (var point in Shapes.GetCircle(s_center, radius))
                 points.Add(point);
 
-            var enumerable = Shapes.GetCircle(s_center, radius).ToEnumerable().ToList();
+            var enumerable = Shapes.GetCircle(s_center, radius).ToList();
             Assert.Equal((IEnumerable<Point>)points, enumerable);
         }
 
@@ -108,7 +108,7 @@ namespace SadRogue.Primitives.UnitTests
         public void ZeroRadiusCircle()
         {
             var points = CircleToHashSetDirect(Shapes.GetCircle(s_center, 0));
-            var enumerable = Shapes.GetCircle(s_center, 0).ToEnumerable().ToHashSet();
+            var enumerable = Shapes.GetCircle(s_center, 0).ToHashSet();
 
             Assert.Single(points);
             Assert.Contains(s_center, points);
@@ -166,7 +166,7 @@ namespace SadRogue.Primitives.UnitTests
             foreach (var point in Shapes.GetEllipse(f1, f2))
                 points.Add(point);
 
-            var enumerable = Shapes.GetEllipse(f1, f2).ToEnumerable().ToList();
+            var enumerable = Shapes.GetEllipse(f1, f2).ToList();
             Assert.Equal((IEnumerable<Point>)points, enumerable);
         }
 

--- a/TheSadRogue.Primitives.UnitTests/ShapesTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/ShapesTests.cs
@@ -115,12 +115,12 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal(points, enumerable);
         }
 
-        private HashSet<Point> CircleToHashSetDirect(CirclePositionsEnumerable enumerable)
+        private HashSet<Point> CircleToHashSetDirect(CirclePositionsEnumerator enumerator)
         {
             // We don't use ToEnumerable or LINQ to ensure we invoke the MoveNext implementation even if GetEnumerable
             // is implemented differently
             var points = new HashSet<Point>();
-            foreach (var point in enumerable)
+            foreach (var point in enumerator)
                 points.Add(point);
 
             return points;
@@ -170,12 +170,12 @@ namespace SadRogue.Primitives.UnitTests
             Assert.Equal((IEnumerable<Point>)points, enumerable);
         }
 
-        private HashSet<Point> EllipseToHashSetDirect(EllipsePositionsEnumerable enumerable)
+        private HashSet<Point> EllipseToHashSetDirect(EllipsePositionsEnumerator enumerator)
         {
             // We don't use ToEnumerable or LINQ to ensure we invoke the MoveNext implementation even if GetEnumerable
             // is implemented differently
             var points = new HashSet<Point>();
-            foreach (var point in enumerable)
+            foreach (var point in enumerator)
                 points.Add(point);
 
             return points;

--- a/TheSadRogue.Primitives.UnitTests/ShapesTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/ShapesTests.cs
@@ -102,8 +102,34 @@ namespace SadRogue.Primitives.UnitTests
             foreach (var point in Shapes.GetCircle(s_center, radius))
                 points.Add(point);
 
-            var enumerable = Shapes.GetCircle(s_center, radius).ToList();
-            Assert.Equal((IEnumerable<Point>)points, enumerable);
+            var enumerable = Shapes.GetCircle(s_center, radius);
+            Assert.Equal(points, enumerable);
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(RadiusCases))]
+        public void CircleEnumerableEquivalentToDeprecatedToEnumerable(int radius)
+        {
+            IEnumerable<Point> expected = Shapes.GetCircle(s_center, radius);
+#pragma warning disable CS0618
+            IEnumerable<Point> actual = Shapes.GetCircle(s_center, radius).ToEnumerable();
+#pragma warning restore CS0618
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(RadiusCases))]
+        public void CircleEnumerator(int radius)
+        {
+            var list = new List<Point>();
+            using IEnumerator<Point> enumerator = ((IEnumerable<Point>)Shapes.GetCircle(s_center, radius)).GetEnumerator();
+            while (enumerator.MoveNext())
+                list.Add(enumerator.Current);
+
+            Assert.Equal(Shapes.GetCircle(s_center, radius), list);
+
+            Assert.Throws<NotSupportedException>(() => enumerator.Reset());
         }
 
         [Fact]
@@ -168,9 +194,36 @@ namespace SadRogue.Primitives.UnitTests
             foreach (var point in Shapes.GetEllipse(f1, f2))
                 points.Add(point);
 
-            var enumerable = Shapes.GetEllipse(f1, f2).ToList();
-            Assert.Equal((IEnumerable<Point>)points, enumerable);
+            var enumerable = Shapes.GetEllipse(f1, f2);
+            Assert.Equal(points, enumerable);
         }
+
+        [Theory]
+        [MemberDataTuple(nameof(EllipseCases))]
+        public void EllipseEnumerableEquivalentToDeprecatedToEnumerable(Point f1, Point f2)
+        {
+            IEnumerable<Point> expected = Shapes.GetEllipse(f1, f2);
+#pragma warning disable CS0618
+            IEnumerable<Point> actual = Shapes.GetEllipse(f1, f2).ToEnumerable();
+#pragma warning restore CS0618
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(EllipseCases))]
+        public void EllipseEnumerator(Point f1, Point f2)
+        {
+            var list = new List<Point>();
+            using IEnumerator<Point> enumerator = ((IEnumerable<Point>)Shapes.GetEllipse(f1, f2)).GetEnumerator();
+            while (enumerator.MoveNext())
+                list.Add(enumerator.Current);
+
+            Assert.Equal(Shapes.GetEllipse(f1, f2), list);
+
+            Assert.Throws<NotSupportedException>(() => enumerator.Reset());
+        }
+
 
         private HashSet<Point> EllipseToHashSetDirect(EllipsePositionsEnumerator enumerator)
         {

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -475,13 +475,12 @@ namespace SadRogue.Primitives
         /// Returns an enumerator that iterates through all positions in the Area, in the order they were added.
         /// </summary>
         /// <returns>An enumerator that iterates through all the positions in the Area, in the order they were added.</returns>
-        public IEnumerator<Point> GetEnumerator() => _positions.GetEnumerator();
+        public List<Point>.Enumerator GetEnumerator() => _positions.GetEnumerator();
 
-        /// <summary>
-        /// Returns an enumerator that iterates through all positions in the Area, in the order they were added.
-        /// </summary>
-        /// <returns>An enumerator that iterates through all the positions in the Area, in the order they were added.</returns>
+        #region Explicit Interface Implementations
+        IEnumerator<Point> IEnumerable<Point>.GetEnumerator() => _positions.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_positions).GetEnumerator();
+        #endregion
 
         private void RecalculateBounds()
         {

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -445,7 +445,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="rectangle">Rectangle containing positions to remove.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Remove(Rectangle rectangle) => Remove(rectangle.Positions().ToEnumerable());
+        public void Remove(Rectangle rectangle) => Remove(rectangle.Positions());
 
         /// <summary>
         /// Returns the string of each position in the area, in a square-bracket enclosed list,

--- a/TheSadRogue.Primitives/Area.cs
+++ b/TheSadRogue.Primitives/Area.cs
@@ -108,7 +108,7 @@ namespace SadRogue.Primitives
         {
             Area retVal = new Area(pointHasher);
 
-            foreach (Point pos in area1.FastEnumerator())
+            foreach (Point pos in area1)
             {
                 if (area2.Contains(pos))
                     continue;
@@ -139,7 +139,7 @@ namespace SadRogue.Primitives
             if (area1.Count > area2.Count)
                 (area2, area1) = (area1, area2);
 
-            foreach (Point pos in area1.FastEnumerator())
+            foreach (Point pos in area1)
                 if (area2.Contains(pos))
                     retVal.Add(pos);
 
@@ -178,7 +178,7 @@ namespace SadRogue.Primitives
         {
             Area retVal = new Area(lhs.PointHasher);
 
-            foreach (Point pos in lhs.FastEnumerator())
+            foreach (Point pos in lhs)
                 retVal.Add(pos + rhs);
 
             return retVal;
@@ -281,7 +281,7 @@ namespace SadRogue.Primitives
         /// <param name="area">Area containing positions to add.</param>
         public void Add(IReadOnlyArea area)
         {
-            foreach (Point pos in area.FastEnumerator())
+            foreach (Point pos in area)
                 Add(pos);
         }
 
@@ -314,7 +314,7 @@ namespace SadRogue.Primitives
             if (!Bounds.Contains(area.Bounds))
                 return false;
 
-            foreach (Point pos in area.FastEnumerator())
+            foreach (Point pos in area)
                 if (!Contains(pos))
                     return false;
 
@@ -346,7 +346,7 @@ namespace SadRogue.Primitives
                 return false;
             }
 
-            foreach (Point pos in area.FastEnumerator())
+            foreach (Point pos in area)
                 if (Contains(pos))
                     return true;
 

--- a/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
+++ b/TheSadRogue.Primitives/GridViews/IGridViewExtensions.cs
@@ -171,7 +171,7 @@ namespace SadRogue.Primitives.GridViews
         /// <typeparam name="T" />
         /// <param name="gridView" />
         /// <returns>All positions in the IGridView.</returns>
-        public static RectanglePositionsEnumerable Positions<T>(this IGridView<T> gridView)
+        public static RectanglePositionsEnumerator Positions<T>(this IGridView<T> gridView)
             => gridView.Bounds().Positions();
     }
 }

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -10,7 +10,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Whether or not it is more efficient for this implementation to use enumeration by index,
         /// rather than generic IEnumerable, when iterating over positions using <see cref="ReadOnlyAreaExtensions.FastEnumerator"/>
-        /// or <see cref="ReadOnlyAreaPositionsEnumerable"/>.
+        /// or <see cref="ReadOnlyAreaPositionsEnumerator"/>.
         /// </summary>
         /// <remarks>
         /// Set this to true if your indexer implementation scales well (constant time), and is relatively fast.  Implementations with

--- a/TheSadRogue.Primitives/IReadOnlyArea.cs
+++ b/TheSadRogue.Primitives/IReadOnlyArea.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace SadRogue.Primitives
 {
@@ -9,14 +10,16 @@ namespace SadRogue.Primitives
     {
         /// <summary>
         /// Whether or not it is more efficient for this implementation to use enumeration by index,
-        /// rather than generic IEnumerable, when iterating over positions using <see cref="ReadOnlyAreaExtensions.FastEnumerator"/>
-        /// or <see cref="ReadOnlyAreaPositionsEnumerator"/>.
+        /// rather than generic IEnumerable, when iterating over positions using <see cref="ReadOnlyAreaPositionsEnumerator"/>.
         /// </summary>
         /// <remarks>
         /// Set this to true if your indexer implementation scales well (constant time), and is relatively fast.  Implementations with
         /// more complex indexers should set this to false.
         ///
         /// The default interface implementation returns false, in order to preserve backwards compatibility with previous versions.
+        ///
+        /// If you set this to false, your IEnumerable.GetEnumerator() implementations must NOT call return a ReadOnlyAreaPositionsEnumerator,
+        /// as this will create an infinite loop.
         /// </remarks>
         public bool UseIndexEnumeration => false;
         /// <summary>
@@ -68,5 +71,26 @@ namespace SadRogue.Primitives
         /// <param name="area">The area to check.</param>
         /// <returns>True if the given area intersects the current one, false otherwise.</returns>
         bool Intersects(IReadOnlyArea area);
+
+        /// <summary>
+        /// Returns an enumerator which can be used to iterate over the positions in this area in the most efficient
+        /// manner possible via a generic interface.
+        /// </summary>
+        /// <remarks>
+        /// The enumerator returned will use the area's indexer to iterate over the positions (like you might a list),
+        /// if the area's <see cref="IReadOnlyArea.UseIndexEnumeration"/> is true.  Otherwise, it uses the typical IEnumerator
+        /// implementation for that area.
+        ///
+        /// This may be significantly faster than the typical IEnumerable/IEnumerator usage for implementations which have
+        /// <see cref="IReadOnlyArea.UseIndexEnumeration"/> set to true; however it won't have much benefit otherwise.
+        ///
+        /// If you have a value of a concrete type rather than an interface, and the GetEnumerator implementation for that
+        /// given type is particularly fast or a non-boxed type (like <see cref="Area"/>, you will probably get faster performance
+        /// out of that than by using this; however this will provide better performance if you are working with an interface
+        /// and thus don't know the type of area.  Use cases for this function are generally for iteration via IReadOnlyArea.
+        ///
+        /// </remarks>
+        /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible via a generic interface.</returns>
+        new ReadOnlyAreaPositionsEnumerator GetEnumerator() => new ReadOnlyAreaPositionsEnumerator(this);
     }
 }

--- a/TheSadRogue.Primitives/Lines.cs
+++ b/TheSadRogue.Primitives/Lines.cs
@@ -18,7 +18,7 @@ namespace SadRogue.Primitives
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct BresenhamEnumerable : IEnumerator<Point>, IEnumerable<Point>
+    public struct BresenhamEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
         // characteristics.
@@ -51,7 +51,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="start">Starting point for the line.</param>
         /// <param name="end">Ending point for the line.</param>
-        public BresenhamEnumerable(Point start, Point end)
+        public BresenhamEnumerator(Point start, Point end)
         {
             _current = Point.None;
 
@@ -118,7 +118,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public BresenhamEnumerable GetEnumerator() => this;
+        public BresenhamEnumerator GetEnumerator() => this;
 
         /// <summary>
         /// Obsolete.
@@ -156,7 +156,7 @@ namespace SadRogue.Primitives
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct DDAEnumerable : IEnumerator<Point>, IEnumerable<Point>
+    public struct DDAEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
         // characteristics.
@@ -188,7 +188,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="start">Starting point for the line.</param>
         /// <param name="end">Ending point for the line.</param>
-        public DDAEnumerable(Point start, Point end)
+        public DDAEnumerator(Point start, Point end)
         {
             (_startX, _startY) = (start.X, start.Y);
             (_endX, _endY) = (end.X, end.Y);
@@ -383,7 +383,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public DDAEnumerable GetEnumerator() => this;
+        public DDAEnumerator GetEnumerator() => this;
 
         /// <summary>
         /// Obsolete.
@@ -421,7 +421,7 @@ namespace SadRogue.Primitives
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct OrthogonalEnumerable : IEnumerator<Point>, IEnumerable<Point>
+    public struct OrthogonalEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
         // characteristics.
@@ -451,7 +451,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="start">Starting point for the line.</param>
         /// <param name="end">Ending point for the line.</param>
-        public OrthogonalEnumerable(Point start, Point end)
+        public OrthogonalEnumerator(Point start, Point end)
         {
             _current = Point.None;
 
@@ -512,7 +512,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public OrthogonalEnumerable GetEnumerator() => this;
+        public OrthogonalEnumerator GetEnumerator() => this;
 
         /// <summary>
         /// Obsolete.
@@ -598,11 +598,11 @@ namespace SadRogue.Primitives
             switch (type)
             {
                 case Algorithm.Bresenham:
-                    return new BresenhamEnumerable(start, end);
+                    return new BresenhamEnumerator(start, end);
                 case Algorithm.DDA:
-                    return new DDAEnumerable(start, end);
+                    return new DDAEnumerator(start, end);
                 case Algorithm.Orthogonal:
-                    return new OrthogonalEnumerable(start, end);
+                    return new OrthogonalEnumerator(start, end);
 
 
                 default:
@@ -656,8 +656,8 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Every point, in order, closest to a line between the two points specified (according to Bresenham's line algorithm).
         /// </returns>
-        public static BresenhamEnumerable GetBresenhamLine(Point start, Point end)
-            => new BresenhamEnumerable(start, end);
+        public static BresenhamEnumerator GetBresenhamLine(Point start, Point end)
+            => new BresenhamEnumerator(start, end);
 
         /// <summary>
         /// Returns all points on the given line using the <see cref="Algorithm.Bresenham"/> line algorithm.
@@ -678,7 +678,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Every point, in order, closest to a line between the two points specified (according to Bresenham's line algorithm).
         /// </returns>
-        public static BresenhamEnumerable GetBresenhamLine(int startX, int startY, int endX, int endY)
+        public static BresenhamEnumerator GetBresenhamLine(int startX, int startY, int endX, int endY)
             => GetBresenhamLine(new Point(startX, startY), new Point(endX, endY));
 
         /// <summary>
@@ -698,8 +698,8 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Every point, in order, closest to a line between the two points specified (according to the DDA line algorithm).
         /// </returns>
-        public static DDAEnumerable GetDDALine(Point start, Point end)
-            => new DDAEnumerable(start, end);
+        public static DDAEnumerator GetDDALine(Point start, Point end)
+            => new DDAEnumerator(start, end);
 
         /// <summary>
         /// Returns all points on the given line using the <see cref="Algorithm.DDA"/> line algorithm.
@@ -720,7 +720,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Every point, in order, closest to a line between the two points specified (according to the DDA line algorithm).
         /// </returns>
-        public static DDAEnumerable GetDDALine(int startX, int startY, int endX, int endY)
+        public static DDAEnumerator GetDDALine(int startX, int startY, int endX, int endY)
             => GetDDALine(new Point(startX, startY), new Point(endX, endY));
 
         /// <summary>
@@ -740,8 +740,8 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Every point, in order, closest to a line between the two points specified (according to the "orthogonal" line algorithm).
         /// </returns>
-        public static OrthogonalEnumerable GetOrthogonalLine(Point start, Point end)
-            => new OrthogonalEnumerable(start, end);
+        public static OrthogonalEnumerator GetOrthogonalLine(Point start, Point end)
+            => new OrthogonalEnumerator(start, end);
 
         /// <summary>
         /// Returns all points on the given line using the <see cref="Algorithm.Orthogonal"/> line algorithm.
@@ -762,7 +762,7 @@ namespace SadRogue.Primitives
         /// <returns>
         /// Every point, in order, closest to a line between the two points specified (according to the "orthogonal" line algorithm).
         /// </returns>
-        public static OrthogonalEnumerable GetOrthogonalLine(int startX, int startY, int endX, int endY)
+        public static OrthogonalEnumerator GetOrthogonalLine(int startX, int startY, int endX, int endY)
             => GetOrthogonalLine(new Point(startX, startY), new Point(endX, endY));
     }
 }

--- a/TheSadRogue.Primitives/Lines.cs
+++ b/TheSadRogue.Primitives/Lines.cs
@@ -14,7 +14,7 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does implement <see cref="IEnumerable{Point}"/>,
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
@@ -152,7 +152,7 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does implement <see cref="IEnumerable{Point}"/>,
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
@@ -417,7 +417,7 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does implement <see cref="IEnumerable{Point}"/>,
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -8,8 +8,8 @@ namespace SadRogue.Primitives
     public static class ReadOnlyAreaExtensions
     {
         /// <summary>
-        /// Returns an enumerator which can be used to iterate over the positions in this area with a foreach loop
-        /// in the most efficient manner possible.
+        /// Returns an enumerator which can be used to iterate over the positions in this area in the most efficient
+        /// manner possible via a generic interface.
         /// </summary>
         /// <remarks>
         /// The enumerator returned will use the area's indexer to iterate over the positions (like you might a list),
@@ -21,8 +21,8 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="self"/>
         /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible.</returns>
-        public static ReadOnlyAreaPositionsEnumerable FastEnumerator(this IReadOnlyArea self)
-            => new ReadOnlyAreaPositionsEnumerable(self);
+        public static ReadOnlyAreaPositionsEnumerator FastEnumerator(this IReadOnlyArea self)
+            => new ReadOnlyAreaPositionsEnumerator(self);
 
         /// <summary>
         /// Returns all points that are on the border of the area, assuming the specified adjacency rule is used to determine adjacent cells
@@ -62,7 +62,7 @@ namespace SadRogue.Primitives
         /// </code>
         /// </example>
         /// </remarks>
-        /// 
+        ///
         /// <param name="area"/>
         /// <param name="rule">The AdjacencyRule to use for determining adjacency to cells which are outside of the area.</param>
         /// <returns>An enumerable of every point which is on the outer edge of the area specified.</returns>

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace SadRogue.Primitives
 {
@@ -8,25 +9,11 @@ namespace SadRogue.Primitives
     public static class ReadOnlyAreaExtensions
     {
         /// <summary>
-        /// Returns an enumerator which can be used to iterate over the positions in this area in the most efficient
-        /// manner possible via a generic interface.
+        /// Obsolete.
         /// </summary>
-        /// <remarks>
-        /// The enumerator returned will use the area's indexer to iterate over the positions (like you might a list),
-        /// if the area's <see cref="IReadOnlyArea.UseIndexEnumeration"/> is true.  Otherwise, it uses the typical IEnumerator
-        /// implementation for that area.
-        ///
-        /// This may be significantly faster than the typical IEnumerable/IEnumerator usage for implementations which have
-        /// <see cref="IReadOnlyArea.UseIndexEnumeration"/> set to true; however it won't have much benefit otherwise.
-        ///
-        /// If you have a value of a concrete type rather than an interface, and the GetEnumerator implementation for that
-        /// given type is particularly fast or a non-boxed type (like <see cref="Area"/>, you will probably get faster performance
-        /// out of that than by using this; however this will provide better performance if you are working with an interface
-        /// and thus don't know the type of area.  Use cases for this function are generally for iteration via IReadOnlyArea.
-        ///
-        /// </remarks>
-        /// <param name="self"/>
-        /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible via a generic interface.</returns>
+        /// <returns/>
+        [Obsolete(
+            "This method is obsolete; IReadOnlyArea implements GetEnumerator and provides equivalent behavior, so you should no longer call this function; instead just use your area in a foreach loop directly.")]
         public static ReadOnlyAreaPositionsEnumerator FastEnumerator(this IReadOnlyArea self)
             => new ReadOnlyAreaPositionsEnumerator(self);
 
@@ -74,7 +61,7 @@ namespace SadRogue.Primitives
         /// <returns>An enumerable of every point which is on the outer edge of the area specified.</returns>
         public static IEnumerable<Point> PerimeterPositions(this IReadOnlyArea area, AdjacencyRule rule)
         {
-            foreach (var pos in area.FastEnumerator())
+            foreach (var pos in area)
             {
                 foreach (var dir in rule.DirectionsOfNeighborsCache)
                 {

--- a/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaExtensions.cs
@@ -18,9 +18,15 @@ namespace SadRogue.Primitives
         ///
         /// This may be significantly faster than the typical IEnumerable/IEnumerator usage for implementations which have
         /// <see cref="IReadOnlyArea.UseIndexEnumeration"/> set to true; however it won't have much benefit otherwise.
+        ///
+        /// If you have a value of a concrete type rather than an interface, and the GetEnumerator implementation for that
+        /// given type is particularly fast or a non-boxed type (like <see cref="Area"/>, you will probably get faster performance
+        /// out of that than by using this; however this will provide better performance if you are working with an interface
+        /// and thus don't know the type of area.  Use cases for this function are generally for iteration via IReadOnlyArea.
+        ///
         /// </remarks>
         /// <param name="self"/>
-        /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible.</returns>
+        /// <returns>A custom enumerator that iterates over the positions in the area in the most efficient manner possible via a generic interface.</returns>
         public static ReadOnlyAreaPositionsEnumerator FastEnumerator(this IReadOnlyArea self)
             => new ReadOnlyAreaPositionsEnumerator(self);
 

--- a/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerator.cs
@@ -53,7 +53,7 @@ namespace SadRogue.Primitives
             else
             {
                 _currentIdx = _count = 0;
-                _enumerator = _area.GetEnumerator();
+                _enumerator = ((IEnumerable<Point>)_area).GetEnumerator();
             }
         }
 

--- a/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerator.cs
@@ -11,7 +11,7 @@ namespace SadRogue.Primitives
     /// the area's <see cref="IReadOnlyArea.UseIndexEnumeration"/> value.  Therefore, it will provide the quickest way of iterating
     /// over positions in an area with a for-each loop.
     /// </remarks>
-    public struct ReadOnlyAreaPositionsEnumerable
+    public struct ReadOnlyAreaPositionsEnumerator
     {
         private readonly IReadOnlyArea _area;
         private readonly bool _useIndexEnumeration;
@@ -30,7 +30,7 @@ namespace SadRogue.Primitives
         /// Creates an enumerator which iterates over all positions in the given area.
         /// </summary>
         /// <param name="area">A read-only area containing the positions to iterate over.</param>
-        public ReadOnlyAreaPositionsEnumerable(IReadOnlyArea area)
+        public ReadOnlyAreaPositionsEnumerator(IReadOnlyArea area)
         {
             _area = area;
             _useIndexEnumeration = _area.UseIndexEnumeration;
@@ -68,6 +68,6 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyAreaPositionsEnumerable GetEnumerator() => this;
+        public ReadOnlyAreaPositionsEnumerator GetEnumerator() => this;
     }
 }

--- a/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/ReadOnlyAreaPositionsEnumerator.cs
@@ -47,7 +47,7 @@ namespace SadRogue.Primitives
             if (_useIndexEnumeration)
             {
                 _currentIdx = -1;
-                _count = area.Count;
+                _count = _area.Count;
                 _enumerator = null;
             }
             else

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -137,9 +137,11 @@ namespace SadRogue.Primitives
         #region To Enumerables
 
         /// <summary>
-        /// Returns an enumerable containing Rect1, then Rect 2.
+        /// Obsolete.
         /// </summary>
-        /// <returns>An enumerable containing Rect1, then Rect 2.</returns>
+        /// <returns/>
+        [Obsolete(
+            "This method is obsolete; this structure itself implements IEnumerable directly and provides equivalent behavior, so you should no longer call this function.")]
         public IEnumerable<Rectangle> ToEnumerable()
         {
             yield return Rect1;
@@ -688,7 +690,7 @@ namespace SadRogue.Primitives
         /// <returns>All positions in the rectangle.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public RectanglePositionsEnumerable Positions() => new RectanglePositionsEnumerable(this);
+        public RectanglePositionsEnumerator Positions() => new RectanglePositionsEnumerator(this);
 
         /// <summary>
         /// Creates and returns a new rectangle that has the same position and width as the current

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -1122,23 +1121,8 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>IEnumerable of all positions that reside on the inner perimeter of the rectangle.</returns>
         [Pure]
-        public IEnumerable<Point> PerimeterPositions()
-        {
-            for (int x = MinExtentX; x <= MaxExtentX; x++)
-                yield return new Point(x, MinExtentY); // Minimum y-side perimeter
-
-            // Start offset 1, since last loop returned the corner piece
-            for (int y = MinExtentY + 1; y <= MaxExtentY; y++)
-                yield return new Point(MaxExtentX, y);
-
-            // Again skip 1 because last loop returned the corner piece
-            for (int x = MaxExtentX - 1; x >= MinExtentX; x--)
-                yield return new Point(x, MaxExtentY);
-
-            // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
-            for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--)
-                yield return new Point(MinExtentX, y);
-        }
+        public RectanglePerimeterPositionsEnumerator PerimeterPositions()
+            => new RectanglePerimeterPositionsEnumerator(this);
 
         /// <summary>
         /// Returns whether or not the given position lines on the given edge of the rectangle.

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -65,11 +65,11 @@ namespace SadRogue.Primitives
             }
         }
 
-        /// <summary>
-        /// This iterator does not support resetting.
-        /// </summary>
-        /// <exception cref="NotSupportedException"/>
-        void IEnumerator.Reset() => throw new NotSupportedException();
+        void IEnumerator.Reset()
+        {
+            _current = Rectangle.Empty;
+            _state = 0;
+        }
         void IDisposable.Dispose()
         { }
     }

--- a/TheSadRogue.Primitives/Rectangle.cs
+++ b/TheSadRogue.Primitives/Rectangle.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -7,20 +9,83 @@ using System.Runtime.Serialization;
 namespace SadRogue.Primitives
 {
     /// <summary>
+    /// A custom enumerator used to iterate over all rectangles in the given bisection result efficiently.  Generally,
+    /// you should simply use a <see cref="BisectionResult"/> in a foreach loop, rather than creating one of these
+    /// manually.
+    /// </summary>
+    /// <remarks>
+    /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
+    /// IEnumerable&lt;Point&gt; by using "yield return".
+    /// </remarks>
+    public struct BisectionResultEnumerator : IEnumerator<Rectangle>
+    {
+        // Suppress warning stating to use auto-property because we want to guarantee micro-performance
+        // characteristics.
+        #pragma warning disable IDE0032 // Use auto property
+        private Rectangle _current;
+        #pragma warning restore IDE0032 // Use auto property
+
+        /// <summary>
+        /// The current value for enumeration.
+        /// </summary>
+        public Rectangle Current => _current;
+
+        private int _state;
+        private readonly BisectionResult _result;
+        object IEnumerator.Current => _current;
+
+        /// <summary>
+        /// Creates an enumerator which iterates over all rectangles in the given bisection result.
+        /// </summary>
+        /// <param name="result">The bisection result to enumerate.</param>
+        public BisectionResultEnumerator(BisectionResult result)
+        {
+            _current = Rectangle.Empty;
+            _state = 0;
+            _result = result;
+        }
+
+        /// <summary>
+        /// Advances the iterator to the next position.
+        /// </summary>
+        /// <returns>True if there is a new Rectangle; false otherwise.</returns>
+        public bool MoveNext()
+        {
+            switch (_state)
+            {
+                case 0:
+                    _current = _result.Rect1;
+                    _state++;
+                    return true;
+                case 1:
+                    _current = _result.Rect2;
+                    _state++;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// This iterator does not support resetting.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        void IEnumerator.Reset() => throw new NotSupportedException();
+        void IDisposable.Dispose()
+        { }
+    }
+    /// <summary>
     /// Structure representing the result of a rectangle bisection.
     /// </summary>
-    [DataContract]
-    public readonly struct BisectionResult : IEquatable<BisectionResult>, IMatchable<BisectionResult>
+    public readonly struct BisectionResult : IEquatable<BisectionResult>, IMatchable<BisectionResult>, IEnumerable<Rectangle>
     {
         /// <summary>
         /// The first rectangle.
         /// </summary>
-        [DataMember]
         public readonly Rectangle Rect1;
         /// <summary>
         /// The second rectangle.
         /// </summary>
-        [DataMember]
         public readonly Rectangle Rect2;
 
         /// <summary>
@@ -134,7 +199,21 @@ namespace SadRogue.Primitives
         public static bool operator !=(BisectionResult left, BisectionResult right) => !(left == right);
         #endregion
 
-        #region To Enumerables
+        #region Enumerable Implementation
+
+        /// <summary>
+        /// Gets an enumerator that iterates over the rectangles in this result; first Rect1, then Rect2.
+        /// </summary>
+        /// <returns>An enumerator that iterates over the rectangles in this result; first Rect1, then Rect2</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public BisectionResultEnumerator GetEnumerator() => new BisectionResultEnumerator(this);
+
+        IEnumerator<Rectangle> IEnumerable<Rectangle>.GetEnumerator() => new BisectionResultEnumerator(this);
+        IEnumerator IEnumerable.GetEnumerator() => new BisectionResultEnumerator(this);
+
+        #endregion
+
+        #region To Enumerables (obsoleted)
 
         /// <summary>
         /// Obsolete.

--- a/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
@@ -5,6 +5,18 @@ using System.Runtime.CompilerServices;
 
 namespace SadRogue.Primitives
 {
+    /// <summary>
+    /// A custom enumerator used to iterate over all positions on the outside edges of a rectangle efficiently.
+    ///
+    /// Generally, you should use <see cref="Rectangle.PerimeterPositions"/> to get an instance of this, rather than creating one
+    /// yourself.
+    /// </summary>
+    /// <remarks>
+    /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does implement <see cref="IEnumerable{Point}"/>,
+    /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
+    /// performance due to boxing of the iterator.
+    /// </remarks>
     public struct RectanglePerimeterPositionsEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
@@ -34,7 +46,7 @@ namespace SadRogue.Primitives
             _minExtent = rectangle.MinExtent;
             _maxExtent = rectangle.MaxExtent;
             _current = Point.None;
-            _state = 0;
+            _state = rectangle.IsEmpty ? 4 : 0;
             _changingValue = _minExtent.X;
         }
 
@@ -44,22 +56,6 @@ namespace SadRogue.Primitives
         /// <returns>True if the a new position on the outside of the rectangle was found; false otherwise.</returns>
         public bool MoveNext()
         {
-            // for (int x = MinExtentX; x <= MaxExtentX; x++)
-            //     yield return new Point(x, MinExtentY); // Minimum y-side perimeter
-            //
-            // // Start offset 1, since last loop returned the corner piece
-            // for (int y = MinExtentY + 1; y <= MaxExtentY; y++)
-            //     yield return new Point(MaxExtentX, y);
-            //
-            // // Again skip 1 because last loop returned the corner piece
-            // for (int x = MaxExtentX - 1; x >= MinExtentX; x--)
-            //     yield return new Point(x, MaxExtentY);
-            //
-            // // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
-            // for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--)
-            //     yield return new Point(MinExtentX, y);
-
-            // TODO: Eliminate property accesses?
             switch (_state)
             {
                 case 0:

--- a/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
@@ -20,7 +20,8 @@ namespace SadRogue.Primitives
 
         object IEnumerator.Current => _current;
 
-        private readonly Rectangle _rectangle;
+        private readonly Point _minExtent;
+        private readonly Point _maxExtent;
         private int _changingValue;
         private int _state;
 
@@ -30,10 +31,11 @@ namespace SadRogue.Primitives
         /// <param name="rectangle">A rectangle defining the area to iterate over perimeter for.</param>
         public RectanglePerimeterPositionsEnumerator(Rectangle rectangle)
         {
-            _rectangle = rectangle;
+            _minExtent = rectangle.MinExtent;
+            _maxExtent = rectangle.MaxExtent;
             _current = Point.None;
             _state = 0;
-            _changingValue = _rectangle.MinExtentX;
+            _changingValue = _minExtent.X;
         }
 
         /// <summary>
@@ -61,39 +63,39 @@ namespace SadRogue.Primitives
             switch (_state)
             {
                 case 0:
-                    _current = new Point(_changingValue, _rectangle.MinExtentY);
+                    _current = new Point(_changingValue, _minExtent.Y);
                     _changingValue++;
-                    if (_changingValue > _rectangle.MaxExtentX)
+                    if (_changingValue > _maxExtent.X)
                     {
                         _state++;
                         // Start offset 1, since last loop returned the corner piece
-                        _changingValue = _rectangle.MinExtentY + 1;
+                        _changingValue = _minExtent.Y + 1;
                     }
                     return true;
                 case 1:
-                    _current = new Point(_rectangle.MaxExtentX,_changingValue);
+                    _current = new Point(_maxExtent.X,_changingValue);
                     _changingValue++;
-                    if (_changingValue > _rectangle.MaxExtentY)
+                    if (_changingValue > _maxExtent.Y)
                     {
                         _state++;
                         // Again skip 1 because last loop returned the corner piece
-                        _changingValue = _rectangle.MaxExtentX - 1;
+                        _changingValue = _maxExtent.X - 1;
                     }
                     return true;
                 case 2:
-                    _current = new Point(_changingValue, _rectangle.MaxExtentY);
+                    _current = new Point(_changingValue, _maxExtent.Y);
                     _changingValue--;
-                    if (_changingValue < _rectangle.MinExtentX)
+                    if (_changingValue < _minExtent.X)
                     {
                         _state++;
                         // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
-                        _changingValue = _rectangle.MaxExtentY - 1;
+                        _changingValue = _maxExtent.Y - 1;
                     }
                     return true;
                 case 3:
-                    _current = new Point(_rectangle.MinExtentX, _changingValue);
+                    _current = new Point(_minExtent.X, _changingValue);
                     _changingValue--;
-                    if (_changingValue <= _rectangle.MinExtentY)
+                    if (_changingValue <= _minExtent.Y)
                         _state++;
                     return true;
                 default:

--- a/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
@@ -36,6 +36,7 @@ namespace SadRogue.Primitives
         private readonly Point _maxExtent;
         private int _changingValue;
         private int _state;
+        private bool _isEmpty;
 
         /// <summary>
         /// Creates an enumerator which iterates over all positions on the outside edges of the given rectangle.
@@ -46,8 +47,10 @@ namespace SadRogue.Primitives
             _minExtent = rectangle.MinExtent;
             _maxExtent = rectangle.MaxExtent;
             _current = Point.None;
-            _state = rectangle.IsEmpty ? 4 : 0;
+            _isEmpty = rectangle.IsEmpty;
+            _state = _isEmpty ? 4 : 0;
             _changingValue = _minExtent.X;
+
         }
 
         /// <summary>
@@ -108,11 +111,14 @@ namespace SadRogue.Primitives
 
         // Explicitly implemented to ensure we prefer the non-boxing versions where possible
         #region Explicit Interface Implementations
-        /// <summary>
-        /// This iterator does not support resetting.
-        /// </summary>
-        /// <exception cref="NotSupportedException"/>
-        void IEnumerator.Reset() => throw new NotSupportedException();
+
+        void IEnumerator.Reset()
+        {
+            _current = Point.None;
+            _state = _isEmpty ? 4 : 0;
+            _changingValue = _minExtent.X;
+        }
+
         IEnumerator<Point> IEnumerable<Point>.GetEnumerator() => this;
         IEnumerator IEnumerable.GetEnumerator() => this;
 

--- a/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/RectanglePerimeterPositionsEnumerator.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace SadRogue.Primitives
+{
+    public struct RectanglePerimeterPositionsEnumerator : IEnumerator<Point>, IEnumerable<Point>
+    {
+        // Suppress warning stating to use auto-property because we want to guarantee micro-performance
+        // characteristics.
+#pragma warning disable IDE0032 // Use auto property
+        private Point _current;
+#pragma warning restore IDE0032 // Use auto property
+
+        /// <summary>
+        /// The current value for enumeration.
+        /// </summary>
+        public Point Current => _current;
+
+        object IEnumerator.Current => _current;
+
+        private readonly Rectangle _rectangle;
+        private int _changingValue;
+        private int _state;
+
+        /// <summary>
+        /// Creates an enumerator which iterates over all positions on the outside edges of the given rectangle.
+        /// </summary>
+        /// <param name="rectangle">A rectangle defining the area to iterate over perimeter for.</param>
+        public RectanglePerimeterPositionsEnumerator(Rectangle rectangle)
+        {
+            _rectangle = rectangle;
+            _current = Point.None;
+            _state = 0;
+            _changingValue = _rectangle.MinExtentX;
+        }
+
+        /// <summary>
+        /// Advances the iterator to the next position.
+        /// </summary>
+        /// <returns>True if the a new position on the outside of the rectangle was found; false otherwise.</returns>
+        public bool MoveNext()
+        {
+            // for (int x = MinExtentX; x <= MaxExtentX; x++)
+            //     yield return new Point(x, MinExtentY); // Minimum y-side perimeter
+            //
+            // // Start offset 1, since last loop returned the corner piece
+            // for (int y = MinExtentY + 1; y <= MaxExtentY; y++)
+            //     yield return new Point(MaxExtentX, y);
+            //
+            // // Again skip 1 because last loop returned the corner piece
+            // for (int x = MaxExtentX - 1; x >= MinExtentX; x--)
+            //     yield return new Point(x, MaxExtentY);
+            //
+            // // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
+            // for (int y = MaxExtentY - 1; y >= MinExtentY + 1; y--)
+            //     yield return new Point(MinExtentX, y);
+
+            // TODO: Eliminate property accesses?
+            switch (_state)
+            {
+                case 0:
+                    _current = new Point(_changingValue, _rectangle.MinExtentY);
+                    _changingValue++;
+                    if (_changingValue > _rectangle.MaxExtentX)
+                    {
+                        _state++;
+                        // Start offset 1, since last loop returned the corner piece
+                        _changingValue = _rectangle.MinExtentY + 1;
+                    }
+                    return true;
+                case 1:
+                    _current = new Point(_rectangle.MaxExtentX,_changingValue);
+                    _changingValue++;
+                    if (_changingValue > _rectangle.MaxExtentY)
+                    {
+                        _state++;
+                        // Again skip 1 because last loop returned the corner piece
+                        _changingValue = _rectangle.MaxExtentX - 1;
+                    }
+                    return true;
+                case 2:
+                    _current = new Point(_changingValue, _rectangle.MaxExtentY);
+                    _changingValue--;
+                    if (_changingValue < _rectangle.MinExtentX)
+                    {
+                        _state++;
+                        // Skip 1 on both ends, because last loop returned one corner, first loop returned the other
+                        _changingValue = _rectangle.MaxExtentY - 1;
+                    }
+                    return true;
+                case 3:
+                    _current = new Point(_rectangle.MinExtentX, _changingValue);
+                    _changingValue--;
+                    if (_changingValue <= _rectangle.MinExtentY)
+                        _state++;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns this enumerator.
+        /// </summary>
+        /// <returns>This enumerator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RectanglePerimeterPositionsEnumerator GetEnumerator() => this;
+
+        // Explicitly implemented to ensure we prefer the non-boxing versions where possible
+        #region Explicit Interface Implementations
+        /// <summary>
+        /// This iterator does not support resetting.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        void IEnumerator.Reset() => throw new NotSupportedException();
+        IEnumerator<Point> IEnumerable<Point>.GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+
+        void IDisposable.Dispose()
+        { }
+        #endregion
+    }
+}

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerator.cs
@@ -39,7 +39,7 @@ namespace SadRogue.Primitives
         {
             _positions = positions;
 
-            _current = (_positions.Width * _positions.Height > 0) ? positions.MinExtent - new Point(1, 0) : _positions.MaxExtent;
+            _current = (_positions.Width * _positions.Height > 0) ? _positions.MinExtent - new Point(1, 0) : _positions.MaxExtent;
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace SadRogue.Primitives
 
         // Explicitly implemented to ensure we prefer the non-boxing versions where possible
         #region Explicit Interface Implementations
-        /// <summary>
-        /// This iterator does not support resetting.
-        /// </summary>
-        /// <exception cref="NotSupportedException"/>
-        void IEnumerator.Reset() => throw new NotSupportedException();
+
+        void IEnumerator.Reset()
+        {
+            _current = (_positions.Width * _positions.Height > 0) ? _positions.MinExtent - new Point(1, 0) : _positions.MaxExtent;
+        }
         IEnumerator<Point> IEnumerable<Point>.GetEnumerator() => this;
         IEnumerator IEnumerable.GetEnumerator() => this;
 

--- a/TheSadRogue.Primitives/RectanglePositionsEnumerator.cs
+++ b/TheSadRogue.Primitives/RectanglePositionsEnumerator.cs
@@ -14,7 +14,7 @@ namespace SadRogue.Primitives
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct RectanglePositionsEnumerable : IEnumerator<Point>, IEnumerable<Point>
+    public struct RectanglePositionsEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
         // characteristics.
@@ -35,7 +35,7 @@ namespace SadRogue.Primitives
         /// Creates an enumerator which iterates over all positions in the given rectangle.
         /// </summary>
         /// <param name="positions">A rectangle containing the positions to iterate over.</param>
-        public RectanglePositionsEnumerable(Rectangle positions)
+        public RectanglePositionsEnumerator(Rectangle positions)
         {
             _positions = positions;
 
@@ -68,7 +68,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public RectanglePositionsEnumerable GetEnumerator() => this;
+        public RectanglePositionsEnumerator GetEnumerator() => this;
 
         /// <summary>
         /// Obsolete.

--- a/TheSadRogue.Primitives/Shapes.cs
+++ b/TheSadRogue.Primitives/Shapes.cs
@@ -13,7 +13,7 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does implement <see cref="IEnumerable{Point}"/>,
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
@@ -137,7 +137,7 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does implement <see cref="IEnumerable{Point}"/>,
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>

--- a/TheSadRogue.Primitives/Shapes.cs
+++ b/TheSadRogue.Primitives/Shapes.cs
@@ -303,6 +303,7 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="center">Center of the circle.</param>
         /// <param name="radius">The radius of the circle.</param>
+        /// <returns>Every point on the outer edges of the circle specified.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CirclePositionsEnumerator GetCircle(Point center, int radius)
             => new CirclePositionsEnumerator(center, radius);
@@ -317,8 +318,23 @@ namespace SadRogue.Primitives
         /// </remarks>
         /// <param name="f1">The first focus point of the ellipse.</param>
         /// <param name="f2">The second focus point of the ellipse.</param>
+        /// <returns>Every point on the outer edges of the ellipse specified.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static EllipsePositionsEnumerator GetEllipse(Point f1, Point f2)
             => new EllipsePositionsEnumerator(f1, f2);
+
+        /// <summary>
+        /// Gets the points on the outside of a box defined by the outer edges of the given rectangle.
+        /// </summary>
+        /// <remarks>
+        /// This function returns a custom iterator which is very fast when used in a foreach loop.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// </remarks>
+        /// <param name="rectangle">A rectangle whose outer edges define the box to iterate over.</param>
+        /// <returns>Every point on the outer edges of the box specified.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RectanglePerimeterPositionsEnumerator GetBox(Rectangle rectangle)
+            => rectangle.PerimeterPositions();
     }
 }

--- a/TheSadRogue.Primitives/Shapes.cs
+++ b/TheSadRogue.Primitives/Shapes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -12,12 +13,11 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain a function <see cref="ToEnumerable"/>
-    /// which creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the
-    /// returned positions to be used with LINQ; however using this function is not recommended in situations where
-    /// runtime performance is a primary concern.
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
+    /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct CirclePositionsEnumerable
+    public struct CirclePositionsEnumerable : IEnumerator<Point>, IEnumerable<Point>
     {
         private readonly Point _center;
         private int _radius;
@@ -38,6 +38,8 @@ namespace SadRogue.Primitives
         public Point Current => _current;
 
         private int _state;
+
+        object IEnumerator.Current => _current;
 
         /// <summary>
         /// Creates an enumerator which iterates over all positions on the outside of the given circle.
@@ -105,41 +107,26 @@ namespace SadRogue.Primitives
         public CirclePositionsEnumerable GetEnumerator() => this;
 
         /// <summary>
-        /// Converts the result of the enumerable to a <see cref="IEnumerable{T}"/>, which can be useful if you need
-        /// to use the result with LINQ.
+        /// Obsolete.
         /// </summary>
-        /// <remarks>
-        /// Note that this function advances the state of the enumerator, evaluating it to its fullest extent.  Also
-        /// note that it is NOT recommended to use this function in cases where performance is critical.
-        /// </remarks>
-        /// <returns>
-        /// An IEnumerable&lt;Point&gt; which iterates over all positions on the outside of the circle specified to this
-        /// enumerator.
-        /// </returns>
-        public IEnumerable<Point> ToEnumerable()
-        {
-            // This is a re-implementation of the circle algorithm implemented in MoveNext above, and is equivalent to:
-            // foreach (var pos in this)
-            //    yield return pos
-            //
-            // However, this is notably faster.
-            do
-            {
-                yield return new Point(_center.X - _xi, _center.Y + _yi); /*   I. Quadrant */
-                yield return new Point(_center.X - _yi, _center.Y - _xi); /*  II. Quadrant */
-                yield return new Point(_center.X + _xi, _center.Y - _yi); /* III. Quadrant */
-                yield return new Point(_center.X + _yi, _center.Y + _xi); /*  IV. Quadrant */
-                _radius = _err;
-                if (_radius <= _yi)
-                    _err += ++_yi * 2 + 1;           /* e_xy+e_y < 0 */
+        /// <returns/>
+        [Obsolete(
+            "This method is obsolete; this structure itself implements IEnumerable directly and provides equivalent behavior, so you should no longer call this function.")]
+        public IEnumerable<Point> ToEnumerable() => this;
 
-                if (_radius > _xi || _err > _yi)
-                    _err += ++_xi * 2 + 1; /* e_xy+e_x > 0 or no 2nd y-step */
+        // Explicitly implemented to ensure we prefer the non-boxing versions where possible
+        #region Explicit Interface Implementations
+        /// <summary>
+        /// This iterator does not support resetting.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        void IEnumerator.Reset() => throw new NotSupportedException();
+        IEnumerator<Point> IEnumerable<Point>.GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
 
-            } while (_xi < 0);
-
-            _terminate = true;
-        }
+        void IDisposable.Dispose()
+        { }
+        #endregion
     }
 
     /// <summary>
@@ -150,12 +137,11 @@ namespace SadRogue.Primitives
     /// </summary>
     /// <remarks>
     /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain a function <see cref="ToEnumerable"/>
-    /// which creates an IEnumerable&lt;Point&gt;, which can be convenient for allowing the
-    /// returned positions to be used with LINQ; however using this function is not recommended in situations where
-    /// runtime performance is a primary concern.
+    /// IEnumerable&lt;Point&gt; by using "yield return".  This type does contain implement <see cref="IEnumerable{Point}"/>,
+    /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
+    /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct EllipsePositionsEnumerable
+    public struct EllipsePositionsEnumerable : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
         // characteristics.
@@ -180,6 +166,8 @@ namespace SadRogue.Primitives
         private int _state;
         private bool _terminate;
         private long _err;
+
+        object IEnumerator.Current => _current;
 
         /// <summary>
         /// Creates an enumerator which iterates over all positions on the outside of the given ellipse.
@@ -277,43 +265,26 @@ namespace SadRogue.Primitives
         public EllipsePositionsEnumerable GetEnumerator() => this;
 
         /// <summary>
-        /// Converts the result of the enumerable to a <see cref="IEnumerable{T}"/>, which can be useful if you need
-        /// to use the result with LINQ.
+        /// Obsolete.
         /// </summary>
-        /// <remarks>
-        /// Note that this function advances the state of the enumerator, evaluating it to its fullest extent.  Also
-        /// note that it is NOT recommended to use this function in cases where performance is critical.
-        /// </remarks>
-        /// <returns>
-        /// An IEnumerable&lt;Point&gt; which iterates over all positions on the outside of the ellipse specified to this
-        /// enumerator.
-        /// </returns>
-        public IEnumerable<Point> ToEnumerable()
-        {
-            // This is a re-implementation of the ellipse algorithm implemented in MoveNext above, and is equivalent to:
-            // foreach (var pos in this)
-            //    yield return pos
-            //
-            // However, this is notably faster.
-            do
-            {
-                yield return new Point(_x1, _y0); /*   I. Quadrant */
-                yield return new Point(_x0, _y0); /*  II. Quadrant */
-                yield return new Point(_x0, _y1); /* III. Quadrant */
-                yield return new Point(_x1, _y1); /*  IV. Quadrant */
-                long e2 = 2 * _err;
-                if (e2 <= _dy) { _y0++; _y1--; _err += _dy += _a; }  /* y step */
-                if (e2 >= _dx || 2 * _err > _dy) { _x0++; _x1--; _err += _dx += _b1; } /* x step */
-            } while (_x0 <= _x1);
+        /// <returns/>
+        [Obsolete(
+            "This method is obsolete; this structure itself implements IEnumerable directly and provides equivalent behavior, so you should no longer call this function.")]
+        public IEnumerable<Point> ToEnumerable() => this;
 
-            while (_y0 - _y1 < _b)
-            {  /* too early stop of flat ellipses a=1 */
-                yield return new Point(_x0 - 1, _y0); /* -> finish tip of ellipse */
-                yield return new Point(_x1 + 1, _y0++);
-                yield return new Point(_x0 - 1, _y1);
-                yield return new Point(_x1 + 1, _y1--);
-            }
-        }
+        // Explicitly implemented to ensure we prefer the non-boxing versions where possible
+        #region Explicit Interface Implementations
+        /// <summary>
+        /// This iterator does not support resetting.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        void IEnumerator.Reset() => throw new NotSupportedException();
+        IEnumerator<Point> IEnumerable<Point>.GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+
+        void IDisposable.Dispose()
+        { }
+        #endregion
     }
 
     /// <summary>
@@ -327,9 +298,8 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <remarks>
         /// This function returns a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, you can take the result of this function and
-        /// call <see cref="CirclePositionsEnumerable.ToEnumerable()"/> on it; however note that iterating over
-        /// that will not perform as well as iterating directly over this object.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
         /// </remarks>
         /// <param name="center">Center of the circle.</param>
         /// <param name="radius">The radius of the circle.</param>
@@ -342,9 +312,8 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <remarks>
         /// This function returns a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, you can take the result of this function and
-        /// call <see cref="CirclePositionsEnumerable.ToEnumerable()"/> on it; however note that iterating over
-        /// that will not perform as well as iterating directly over this object.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
         /// </remarks>
         /// <param name="f1">The first focus point of the ellipse.</param>
         /// <param name="f2">The second focus point of the ellipse.</param>

--- a/TheSadRogue.Primitives/Shapes.cs
+++ b/TheSadRogue.Primitives/Shapes.cs
@@ -17,7 +17,7 @@ namespace SadRogue.Primitives
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct CirclePositionsEnumerable : IEnumerator<Point>, IEnumerable<Point>
+    public struct CirclePositionsEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         private readonly Point _center;
         private int _radius;
@@ -46,7 +46,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="center">Center of the circle.</param>
         /// <param name="radius">The radius of the circle.</param>
-        public CirclePositionsEnumerable(Point center, int radius)
+        public CirclePositionsEnumerator(Point center, int radius)
         {
             _center = center;
             _radius = radius;
@@ -104,7 +104,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public CirclePositionsEnumerable GetEnumerator() => this;
+        public CirclePositionsEnumerator GetEnumerator() => this;
 
         /// <summary>
         /// Obsolete.
@@ -141,7 +141,7 @@ namespace SadRogue.Primitives
     /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
     /// performance due to boxing of the iterator.
     /// </remarks>
-    public struct EllipsePositionsEnumerable : IEnumerator<Point>, IEnumerable<Point>
+    public struct EllipsePositionsEnumerator : IEnumerator<Point>, IEnumerable<Point>
     {
         // Suppress warning stating to use auto-property because we want to guarantee micro-performance
         // characteristics.
@@ -174,7 +174,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <param name="f1">The first focus point of the ellipse.</param>
         /// <param name="f2">The second focus point of the ellipse.</param>
-        public EllipsePositionsEnumerable(Point f1, Point f2)
+        public EllipsePositionsEnumerator(Point f1, Point f2)
         {
             (_x0, _y0) = f1;
             (_x1, _y1) = f2;
@@ -262,7 +262,7 @@ namespace SadRogue.Primitives
         /// </summary>
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EllipsePositionsEnumerable GetEnumerator() => this;
+        public EllipsePositionsEnumerator GetEnumerator() => this;
 
         /// <summary>
         /// Obsolete.
@@ -304,8 +304,8 @@ namespace SadRogue.Primitives
         /// <param name="center">Center of the circle.</param>
         /// <param name="radius">The radius of the circle.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CirclePositionsEnumerable GetCircle(Point center, int radius)
-            => new CirclePositionsEnumerable(center, radius);
+        public static CirclePositionsEnumerator GetCircle(Point center, int radius)
+            => new CirclePositionsEnumerator(center, radius);
 
         /// <summary>
         /// Gets the points on the outside of an ellipse.
@@ -318,7 +318,7 @@ namespace SadRogue.Primitives
         /// <param name="f1">The first focus point of the ellipse.</param>
         /// <param name="f2">The second focus point of the ellipse.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EllipsePositionsEnumerable GetEllipse(Point f1, Point f2)
-            => new EllipsePositionsEnumerable(f1, f2);
+        public static EllipsePositionsEnumerator GetEllipse(Point f1, Point f2)
+            => new EllipsePositionsEnumerator(f1, f2);
     }
 }


### PR DESCRIPTION
# Overview
This PR primarily aims to refactor the patterns with which the library uses custom enumerators, in order to provide the easiest and most performant experience possible.

Currently, the library uses structures as custom enumerators for certain segments of code.  The pattern typically followed is this:
1. A `GetEnumerator()` function returns `this`, with a concrete type, in the enumerator
2. These enumerators are returned from a function (like `Rectangle.Positions()`)
3. To use these iterators with LINQ or as `IEnumerator`, you typically have to call a `ToEnumerator()` function, which in practice often ends up re-implementing the functionality of the iterator itself for performance reasons.

This PR aims to change this, with 3 goals in mind:
1. Be more similar to how the iterator pattern is implemented in the C# standard library
2. Provide increased performance for as many scenarios as possible
3. Provide the most intuitive user experience feasible

In order to accomplish these goals, the following broad changes are made:
1. `ToEnumerator()` functions  have been obsoleted
2. The custom enumerators themselves (explicitly) implement `IEnumerable<T>` and `IEnumerator<T>`

Functionally, this simply means that you no longer need to call `ToEnumerator()` to get an `IEnumerable`; you can simply pass the iterator to it directly (eg. `rect.Positions().ToEnumerable().ToList()` becomes simply `rect.Positions().ToList()`); but no performance is lost when the result is used directly in a foreach loop.  These are, in a nutshell, just ways to get the same performance and flexibility but with a more traditional API that the user doesn't have to think about.

Additionally, the library changes the `Area` enumeration system in a similar fashion, and adds a few features that are easy to derive as a result of these changes.

Note that some of the enumerators will support the `Reset` function, and some do not.  In practice, this is usually only used for interoperability with COM APIs, so I didn't bother to implement it where it was infeasible or had a performance cost associated with doing so.

Also; the enumerator functions which are no longer needed have been obsoleted such that they will generate only a warning, not an error, if used (this is the default setting for the `Obsolete` attribute.  There is no actual harm in calling these functions; you just get identical performance without doing so, so there's no need to anymore.  Therefore, I felt that warnings were the best way to convey that.  If reasons come up to make them error, I can happily do that as well.

# Changes
- Line enumerators, shape enumerators, area's `ReadOnlyAreaPositionsEnumerator`, and rectangle's `Positions()` enumerator now all implement `IEnumerable<Point>` and `IEnumerator<Point>`
    - Similarly, their `ToEnumerable()` functions have been deprecated, since they now implement `IEnumerable<Point>` directly.
- `IReadOnlyArea.FastEnumerator()` has been deprecated
    - If you iterate over an area using a foreach loop with a reference of type `IReadOnlyArea`, `ReadOnlyAreaPositionsEnumerator` is automatically used, so you get the performance gains without using this function
- `Area` implements a specific `GetEnumerator` function that returns a concretely typed version of the underlying list's enumerator, which makes iterating over area _much_ faster if you do so via a reference to type `Area` rather than via an interface
- `Rectangle.PerimeterPositions` now uses a custom enumerator with the same characteristics as the others
- a `Shape.GetBox` function has been added to provide the ability to get a box defined based on a rectangle (closes #109  )
- `BisectionResult` now implements `IEnumerable<Rectangle>` via a custom enumerator
- Renamed enumerators to have `Enumerator` rather than `Enumerable` at the end of the name to avoid confusion

# Benchmarks
The following summarizes some benchmark runs of various operations affected by these changes:

## Area
Before changes (cut down to only iteration-centered tests):
|                                  Method | Size |            Mean |         Error |        StdDev |
|---------------------------------------- |----- |----------------:|--------------:|--------------:|
|                     BenchmarkEnumerable |   10 |       544.27 ns |      4.156 ns |      3.888 ns |
|           BenchmarkEnumerableAsConcrete |   10 |       404.82 ns |      6.437 ns |      6.021 ns |
|                 BenchmarkFastEnumerable |   10 |       274.35 ns |      4.460 ns |      3.954 ns |
|       BenchmarkFastEnumerableAsConcrete |   10 |       271.50 ns |      0.853 ns |      0.798 ns |
|                      BenchmarkManualFor |   10 |       359.07 ns |      1.770 ns |      1.478 ns |
|           BenchmarkManualForCachedCount |   10 |       197.31 ns |      2.222 ns |      1.970 ns |
|            BenchmarkManualForAsConcrete |   10 |        76.05 ns |      0.870 ns |      0.726 ns |
| BenchmarkManualForAsConcreteCachedCount |   10 |        75.84 ns |      0.377 ns |      0.335 ns |
|                     BenchmarkEnumerable |  100 |    51,449.31 ns |    301.603 ns |    282.120 ns |
|           BenchmarkEnumerableAsConcrete |  100 |    37,526.76 ns |    140.845 ns |    124.856 ns |
|                 BenchmarkFastEnumerable |  100 |    25,804.81 ns |    135.912 ns |    120.483 ns |
|       BenchmarkFastEnumerableAsConcrete |  100 |    25,800.90 ns |     90.848 ns |     75.862 ns |
|                      BenchmarkManualFor |  100 |    35,052.15 ns |     94.643 ns |     83.899 ns |
|           BenchmarkManualForCachedCount |  100 |    18,774.91 ns |     92.773 ns |     82.241 ns |
|            BenchmarkManualForAsConcrete |  100 |     7,097.65 ns |     50.098 ns |     46.862 ns |
| BenchmarkManualForAsConcreteCachedCount |  100 |     7,029.60 ns |     40.240 ns |     37.640 ns |
|                     BenchmarkEnumerable |  200 |   215,967.03 ns |    900.981 ns |    798.697 ns |
|           BenchmarkEnumerableAsConcrete |  200 |   150,328.67 ns |    750.329 ns |    701.858 ns |
|                 BenchmarkFastEnumerable |  200 |   103,486.10 ns |    748.047 ns |    699.724 ns |
|       BenchmarkFastEnumerableAsConcrete |  200 |    99,676.44 ns |    293.478 ns |    245.067 ns |
|                      BenchmarkManualFor |  200 |   131,299.63 ns |    413.663 ns |    386.941 ns |
|           BenchmarkManualForCachedCount |  200 |   102,266.76 ns |    426.266 ns |    398.730 ns |
|            BenchmarkManualForAsConcrete |  200 |    28,317.11 ns |    204.480 ns |    170.750 ns |
| BenchmarkManualForAsConcreteCachedCount |  200 |    28,494.78 ns |    497.887 ns |    465.724 ns |

After:
|                                  Method | Size |            Mean |         Error |        StdDev |
|---------------------------------------- |----- |----------------:|--------------:|--------------:|
|                     BenchmarkEnumerable |   10 |       291.37 ns |      0.572 ns |      0.507 ns |
|           BenchmarkEnumerableAsConcrete |   10 |       199.37 ns |      0.747 ns |      0.699 ns |
|                 BenchmarkFastEnumerable |   10 |       267.17 ns |      0.488 ns |      0.381 ns |
|       BenchmarkFastEnumerableAsConcrete |   10 |       266.90 ns |      0.307 ns |      0.240 ns |
|                      BenchmarkManualFor |   10 |       362.34 ns |      1.031 ns |      0.914 ns |
|           BenchmarkManualForCachedCount |   10 |       197.09 ns |      1.261 ns |      1.180 ns |
|            BenchmarkManualForAsConcrete |   10 |        76.42 ns |      0.223 ns |      0.198 ns |
| BenchmarkManualForAsConcreteCachedCount |   10 |        76.22 ns |      0.642 ns |      0.569 ns |
|                     BenchmarkEnumerable |  100 |    27,281.31 ns |    100.026 ns |     93.564 ns |
|           BenchmarkEnumerableAsConcrete |  100 |    20,767.27 ns |    112.733 ns |    105.451 ns |
|                 BenchmarkFastEnumerable |  100 |    25,934.76 ns |    130.290 ns |    108.798 ns |
|       BenchmarkFastEnumerableAsConcrete |  100 |    25,072.35 ns |    102.775 ns |     91.107 ns |
|                      BenchmarkManualFor |  100 |    33,030.90 ns |    172.587 ns |    152.993 ns |
|           BenchmarkManualForCachedCount |  100 |    19,478.83 ns |     20.217 ns |     16.883 ns |
|            BenchmarkManualForAsConcrete |  100 |     7,162.09 ns |     33.834 ns |     31.649 ns |
| BenchmarkManualForAsConcreteCachedCount |  100 |     7,105.23 ns |     41.687 ns |     36.954 ns |
|                     BenchmarkEnumerable |  200 |   110,678.22 ns |  1,043.884 ns |    925.376 ns |
|           BenchmarkEnumerableAsConcrete |  200 |    74,875.35 ns |    808.065 ns |    716.328 ns |
|                 BenchmarkFastEnumerable |  200 |   104,205.97 ns |    861.838 ns |    763.997 ns |
|       BenchmarkFastEnumerableAsConcrete |  200 |   104,040.53 ns |    731.736 ns |    684.466 ns |
|                      BenchmarkManualFor |  200 |   131,959.03 ns |    127.286 ns |     99.377 ns |
|           BenchmarkManualForCachedCount |  200 |   103,260.86 ns |    219.076 ns |    194.205 ns |
|            BenchmarkManualForAsConcrete |  200 |    28,486.04 ns |     75.652 ns |     63.173 ns |
| BenchmarkManualForAsConcreteCachedCount |  200 |    28,239.93 ns |     64.248 ns |     56.954 ns |

First, note that `BenchmarkEnumerable` is basically as fast as `BenchmarkFastEnumerable` now; this is because it is, in fact, automatically using the same enumerator that `FastEnumerator` does.  Second, note that `BenchmarkEnumerableAsConcrete` is significantly faster (nearly 2x) than other methods of enumeration; this is because the concrete type of the reference in these test cases is `Area`, which means C#'s `List<Point>.Enumerator` is being used and thus optimizations are enabled.

So, users no longer have to call `FastEnumerator()`; they get that performance boost automatically based on the type.  If the value they are iterating over is of type `Area`, the super-fast list iterator is automatically used for foreach and LINQ calls.  If the type is instead only known to be `IReadOnlyArea`, the same enumerator `FastEnumerator()` returns is automatically used for foreach and LINQ calls.  This should get more users the performance benefits, and prevent them from having to think about it.

## Rectangle
Two main components of rectangle were affected; `PerimeterPositions`, and `BisectionResult` enumeration.

### PerimeterPositions
|                                       Method | Width | Height |        Mean |     Error |    StdDev |
|--------------------------------------------- |------ |------- |------------:|----------:|----------:|
|                           PerimeterPositions |    10 |     10 |    98.02 ns |  1.220 ns |  1.019 ns |
|           PerimeterPositionsNoCustomIterator |    10 |     10 |   252.10 ns |  1.018 ns |  0.952 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |    10 |     10 |   243.66 ns |  0.973 ns |  0.812 ns |
|                           PerimeterPositions |    10 |     50 |   330.36 ns |  0.955 ns |  0.893 ns |
|           PerimeterPositionsNoCustomIterator |    10 |     50 |   798.63 ns |  5.153 ns |  4.303 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |    10 |     50 |   761.94 ns |  8.664 ns |  8.105 ns |
|                           PerimeterPositions |    10 |    100 |   595.86 ns |  6.649 ns |  6.220 ns |
|           PerimeterPositionsNoCustomIterator |    10 |    100 | 1,458.04 ns |  3.600 ns |  3.192 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |    10 |    100 | 1,393.34 ns |  2.215 ns |  1.730 ns |
|                           PerimeterPositions |    50 |     10 |   301.22 ns |  3.944 ns |  3.689 ns |
|           PerimeterPositionsNoCustomIterator |    50 |     10 |   779.13 ns |  2.737 ns |  2.137 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |    50 |     10 |   751.89 ns |  1.207 ns |  1.008 ns |
|                           PerimeterPositions |    50 |     50 |   558.93 ns |  3.680 ns |  3.443 ns |
|           PerimeterPositionsNoCustomIterator |    50 |     50 | 1,311.18 ns |  2.231 ns |  1.978 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |    50 |     50 | 1,262.66 ns |  2.940 ns |  2.606 ns |
|                           PerimeterPositions |    50 |    100 |   792.70 ns |  2.958 ns |  2.622 ns |
|           PerimeterPositionsNoCustomIterator |    50 |    100 | 1,983.00 ns |  5.039 ns |  4.467 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |    50 |    100 | 1,900.49 ns |  5.127 ns |  4.281 ns |
|                           PerimeterPositions |   100 |     10 |   685.65 ns |  4.663 ns |  4.133 ns |
|           PerimeterPositionsNoCustomIterator |   100 |     10 | 1,445.20 ns | 10.313 ns |  9.142 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |   100 |     10 | 1,394.60 ns |  4.837 ns |  4.039 ns |
|                           PerimeterPositions |   100 |     50 |   932.71 ns |  5.791 ns |  5.133 ns |
|           PerimeterPositionsNoCustomIterator |   100 |     50 | 1,975.82 ns |  5.186 ns |  4.331 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |   100 |     50 | 1,904.45 ns |  3.157 ns |  2.636 ns |
|                           PerimeterPositions |   100 |    100 | 1,089.18 ns |  8.190 ns |  7.661 ns |
|           PerimeterPositionsNoCustomIterator |   100 |    100 | 2,640.32 ns |  3.391 ns |  2.831 ns |
| PerimeterPositionsNoCustomIteratorCachedEnds |   100 |    100 | 2,544.92 ns | 12.775 ns | 11.325 ns |

"*NoCustomIterator" represents the `PerimeterPositions()` function as implemented on the main branch; `PerimeterPositions()` indicates the implementation in this PR.  The new implementation is generally a bit over 2x faster in these test cases.

### BisectionResultEnumeration
Before:
|                             Method | Width | Height |           Mean |       Error |      StdDev |         Median |
|----------------------------------- |------ |------- |---------------:|------------:|------------:|---------------:|
|                    BisectRecursive |    10 |     10 |     144.086 ns |   0.9710 ns |   0.8607 ns |     144.367 ns |
|                 BisectToEnumerable |    10 |     10 |      29.907 ns |   0.2296 ns |   0.2036 ns |      29.863 ns |
|       BisectVerticallyToEnumerable |    10 |     10 |      42.232 ns |   0.2852 ns |   0.2667 ns |      42.223 ns |
|     BisectHorizontallyToEnumerable |    10 |     10 |      28.262 ns |   0.2813 ns |   0.2349 ns |      28.164 ns |
| BisectHorizontallyNativeEnumerable |    10 |     10 |      28.501 ns |   0.5936 ns |   1.1854 ns |      28.251 ns |
|                    BisectRecursive |   100 |    100 | 110,959.338 ns | 389.7785 ns | 304.3134 ns | 111,048.334 ns |
|                 BisectToEnumerable |   100 |    100 |      30.304 ns |   0.2894 ns |   0.2707 ns |      30.308 ns |
|       BisectVerticallyToEnumerable |   100 |    100 |      32.542 ns |   0.6686 ns |   1.3041 ns |      32.834 ns |
|     BisectHorizontallyToEnumerable |   100 |    100 |      28.745 ns |   0.3931 ns |   0.3283 ns |      28.788 ns |
| BisectHorizontallyNativeEnumerable |   100 |    100 |      26.326 ns |   0.3193 ns |   0.2831 ns |      26.374 ns |

After:
|                             Method | Width | Height |          Mean |        Error |       StdDev |
|----------------------------------- |------ |------- |--------------:|-------------:|-------------:|
|                    BisectRecursive |    10 |     10 |     142.21 ns |     1.789 ns |     1.397 ns |
|                 BisectToEnumerable |    10 |     10 |      24.28 ns |     0.043 ns |     0.040 ns |
|       BisectVerticallyToEnumerable |    10 |     10 |      22.60 ns |     0.037 ns |     0.033 ns |
|     BisectHorizontallyToEnumerable |    10 |     10 |      22.30 ns |     0.030 ns |     0.025 ns |
| BisectHorizontallyNoCustomIterator |    10 |     10 |      27.87 ns |     0.584 ns |     0.909 ns |
|                    BisectRecursive |   100 |    100 | 112,353.96 ns | 1,413.894 ns | 1,253.380 ns |
|                 BisectToEnumerable |   100 |    100 |      24.22 ns |     0.045 ns |     0.042 ns |
|       BisectVerticallyToEnumerable |   100 |    100 |      22.41 ns |     0.011 ns |     0.010 ns |
|     BisectHorizontallyToEnumerable |   100 |    100 |      21.80 ns |     0.022 ns |     0.020 ns |
| BisectHorizontallyNoCustomIterator |   100 |    100 |      26.32 ns |     0.134 ns |     0.112 ns |

Most of the new versions are slightly faster, though not by the same margin as the others.  In the case of `BisectRecursive`, this is because the function has not changed; it may be possible to use a custom iterator for this in the future.

## Lines
|                           Method |       LineToDraw |      Mean |    Error |   StdDev |
|--------------------------------- |----------------- |----------:|---------:|---------:|
|  BresenhamPrimitivesToEnumerable |  ((1,1), (1,25)) | 187.98 ns | 2.635 ns | 2.201 ns |
|                    BresenhamFunc |  ((1,1), (1,25)) | 182.84 ns | 2.925 ns | 2.736 ns |
|              BresenhamPrimitives |  ((1,1), (1,25)) |  84.16 ns | 0.487 ns | 0.456 ns |
|             BresenhamYieldReturn |  ((1,1), (1,25)) | 193.89 ns | 3.759 ns | 3.691 ns |
|        DDAPrimitivesToEnumerable |  ((1,1), (1,25)) | 194.69 ns | 3.848 ns | 4.118 ns |
|                    DDAPrimitives |  ((1,1), (1,25)) |  78.56 ns | 0.385 ns | 0.341 ns |
|                   DDAYieldReturn |  ((1,1), (1,25)) | 189.95 ns | 2.078 ns | 1.944 ns |
| OrthogonalPrimitivesToEnumerable |  ((1,1), (1,25)) | 208.12 ns | 2.110 ns | 1.974 ns |
|             OrthogonalPrimitives |  ((1,1), (1,25)) |  74.77 ns | 0.057 ns | 0.045 ns |
|            OrthogonalYieldReturn |  ((1,1), (1,25)) | 195.08 ns | 0.481 ns | 0.426 ns |
|  BresenhamPrimitivesToEnumerable | ((1,1), (25,50)) | 355.79 ns | 1.827 ns | 1.709 ns |
|                    BresenhamFunc | ((1,1), (25,50)) | 349.45 ns | 0.758 ns | 0.672 ns |
|              BresenhamPrimitives | ((1,1), (25,50)) | 146.55 ns | 0.783 ns | 0.654 ns |
|             BresenhamYieldReturn | ((1,1), (25,50)) | 365.41 ns | 1.277 ns | 1.067 ns |
|        DDAPrimitivesToEnumerable | ((1,1), (25,50)) | 367.88 ns | 1.586 ns | 1.406 ns |
|                    DDAPrimitives | ((1,1), (25,50)) | 149.45 ns | 0.232 ns | 0.206 ns |
|                   DDAYieldReturn | ((1,1), (25,50)) | 375.34 ns | 1.083 ns | 0.845 ns |
| OrthogonalPrimitivesToEnumerable | ((1,1), (25,50)) | 572.93 ns | 5.690 ns | 4.751 ns |
|             OrthogonalPrimitives | ((1,1), (25,50)) | 209.65 ns | 1.463 ns | 1.221 ns |
|            OrthogonalYieldReturn | ((1,1), (25,50)) | 545.99 ns | 2.703 ns | 2.396 ns |
|  BresenhamPrimitivesToEnumerable |  ((1,1), (50,1)) | 339.71 ns | 2.008 ns | 1.677 ns |
|                    BresenhamFunc |  ((1,1), (50,1)) | 343.41 ns | 0.720 ns | 0.601 ns |
|              BresenhamPrimitives |  ((1,1), (50,1)) | 140.36 ns | 0.625 ns | 0.554 ns |
|             BresenhamYieldReturn |  ((1,1), (50,1)) | 363.79 ns | 1.442 ns | 1.278 ns |
|        DDAPrimitivesToEnumerable |  ((1,1), (50,1)) | 361.07 ns | 5.386 ns | 5.038 ns |
|                    DDAPrimitives |  ((1,1), (50,1)) | 133.45 ns | 1.375 ns | 1.148 ns |
|                   DDAYieldReturn |  ((1,1), (50,1)) | 362.10 ns | 1.251 ns | 0.977 ns |
| OrthogonalPrimitivesToEnumerable |  ((1,1), (50,1)) | 394.65 ns | 0.889 ns | 0.742 ns |
|             OrthogonalPrimitives |  ((1,1), (50,1)) | 146.44 ns | 0.758 ns | 0.709 ns |
|            OrthogonalYieldReturn |  ((1,1), (50,1)) | 372.34 ns | 2.020 ns | 1.790 ns |
|  BresenhamPrimitivesToEnumerable | ((1,1), (50,25)) | 358.05 ns | 2.290 ns | 1.788 ns |
|                    BresenhamFunc | ((1,1), (50,25)) | 350.71 ns | 2.553 ns | 2.263 ns |
|              BresenhamPrimitives | ((1,1), (50,25)) | 149.77 ns | 3.022 ns | 2.968 ns |
|             BresenhamYieldReturn | ((1,1), (50,25)) | 366.19 ns | 1.717 ns | 1.434 ns |
|        DDAPrimitivesToEnumerable | ((1,1), (50,25)) | 369.80 ns | 2.013 ns | 1.572 ns |
|                    DDAPrimitives | ((1,1), (50,25)) | 151.11 ns | 0.979 ns | 0.868 ns |
|                   DDAYieldReturn | ((1,1), (50,25)) | 377.65 ns | 0.980 ns | 0.765 ns |
| OrthogonalPrimitivesToEnumerable | ((1,1), (50,25)) | 572.21 ns | 4.595 ns | 4.073 ns |
|             OrthogonalPrimitives | ((1,1), (50,25)) | 223.32 ns | 4.376 ns | 4.093 ns |
|            OrthogonalYieldReturn | ((1,1), (50,25)) | 545.37 ns | 3.629 ns | 3.217 ns |
|  BresenhamPrimitivesToEnumerable | ((25,50), (1,1)) | 352.29 ns | 6.229 ns | 6.396 ns |
|                    BresenhamFunc | ((25,50), (1,1)) | 352.77 ns | 3.373 ns | 3.155 ns |
|              BresenhamPrimitives | ((25,50), (1,1)) | 149.76 ns | 1.920 ns | 1.702 ns |
|             BresenhamYieldReturn | ((25,50), (1,1)) | 370.28 ns | 3.717 ns | 3.295 ns |
|        DDAPrimitivesToEnumerable | ((25,50), (1,1)) | 371.97 ns | 2.969 ns | 2.777 ns |
|                    DDAPrimitives | ((25,50), (1,1)) | 151.92 ns | 1.370 ns | 1.214 ns |
|                   DDAYieldReturn | ((25,50), (1,1)) | 393.22 ns | 2.539 ns | 2.250 ns |
| OrthogonalPrimitivesToEnumerable | ((25,50), (1,1)) | 576.28 ns | 5.631 ns | 5.267 ns |
|             OrthogonalPrimitives | ((25,50), (1,1)) | 209.58 ns | 0.871 ns | 0.772 ns |
|            OrthogonalYieldReturn | ((25,50), (1,1)) | 548.43 ns | 2.666 ns | 2.363 ns |
|  BresenhamPrimitivesToEnumerable | ((50,25), (1,1)) | 360.52 ns | 5.138 ns | 4.554 ns |
|                    BresenhamFunc | ((50,25), (1,1)) | 349.13 ns | 0.980 ns | 0.916 ns |
|              BresenhamPrimitives | ((50,25), (1,1)) | 146.45 ns | 0.677 ns | 0.566 ns |
|             BresenhamYieldReturn | ((50,25), (1,1)) | 369.24 ns | 3.165 ns | 2.961 ns |
|        DDAPrimitivesToEnumerable | ((50,25), (1,1)) | 370.01 ns | 1.876 ns | 1.663 ns |
|                    DDAPrimitives | ((50,25), (1,1)) | 150.55 ns | 0.766 ns | 0.598 ns |
|                   DDAYieldReturn | ((50,25), (1,1)) | 377.68 ns | 2.037 ns | 1.701 ns |
| OrthogonalPrimitivesToEnumerable | ((50,25), (1,1)) | 574.76 ns | 1.891 ns | 1.768 ns |
|             OrthogonalPrimitives | ((50,25), (1,1)) | 220.74 ns | 0.918 ns | 0.814 ns |
|            OrthogonalYieldReturn | ((50,25), (1,1)) | 547.96 ns | 4.388 ns | 3.890 ns |

Previously, the `ToEnumerable` versions were roughly on par (slightly slower than) the `YieldReturn` versions.  You can see the `ToEnumerable()` versions are slightly faster than the `YieldReturn` versions now; and none of the code tested uses the deprecated `ToEnumerable()` function.  The custom iterator is automatically used when the result is used in a foreach loop, and won't be boxed unless you need an `IEnumerable`, in which case there is still slightly less overhead than the yield return version.

The `Primitives` versions have not changed and are still roughly twice as fast as the enumerable versions.

## Shapes
### Circle
|                 Method | Radius |        Mean |     Error |    StdDev |
|----------------------- |------- |------------:|----------:|----------:|
|             Primitives |      5 |    87.81 ns |  0.993 ns |  0.929 ns |
| PrimitivesToEnumerable |      5 |   191.43 ns |  1.478 ns |  1.234 ns |
|                   Plot |      5 |   172.35 ns |  0.550 ns |  0.459 ns |
|            YieldReturn |      5 |   194.67 ns |  2.294 ns |  1.915 ns |
|             Primitives |     10 |   170.62 ns |  0.785 ns |  0.656 ns |
| PrimitivesToEnumerable |     10 |   380.34 ns |  3.029 ns |  2.833 ns |
|                   Plot |     10 |   332.47 ns |  0.452 ns |  0.377 ns |
|            YieldReturn |     10 |   377.59 ns |  2.758 ns |  2.445 ns |
|             Primitives |     25 |   466.57 ns |  5.170 ns |  4.583 ns |
| PrimitivesToEnumerable |     25 |   933.92 ns |  3.009 ns |  2.667 ns |
|                   Plot |     25 |   811.71 ns |  1.264 ns |  1.055 ns |
|            YieldReturn |     25 |   914.46 ns |  2.651 ns |  2.214 ns |
|             Primitives |     50 | 1,011.72 ns |  2.823 ns |  2.640 ns |
| PrimitivesToEnumerable |     50 | 1,841.78 ns |  4.512 ns |  3.768 ns |
|                   Plot |     50 | 1,634.31 ns |  3.989 ns |  3.731 ns |
|            YieldReturn |     50 | 1,870.51 ns | 13.561 ns | 12.022 ns |

These results have the same characteristics as Lines above; no change in Primitives, no change (or a tiny bit faster) in `ToEnumerable`; but the code all just uses foreach loops normally.

### Ellipse
|                 Method |          Ellipse |     Mean |   Error |   StdDev |
|----------------------- |----------------- |---------:|--------:|---------:|
|             Primitives |  ((1,1), (1,25)) | 162.7 ns | 1.57 ns |  1.39 ns |
| PrimitivesToEnumerable |  ((1,1), (1,25)) | 348.3 ns | 6.85 ns |  8.15 ns |
|            YieldReturn |  ((1,1), (1,25)) | 354.0 ns | 3.89 ns |  3.45 ns |
|             Primitives | ((1,1), (25,50)) | 424.4 ns | 8.35 ns | 24.09 ns |
| PrimitivesToEnumerable | ((1,1), (25,50)) | 717.4 ns | 5.28 ns |  4.68 ns |
|            YieldReturn | ((1,1), (25,50)) | 753.3 ns | 2.98 ns |  2.49 ns |
|             Primitives |  ((1,1), (50,1)) | 318.0 ns | 2.73 ns |  2.13 ns |
| PrimitivesToEnumerable |  ((1,1), (50,1)) | 593.4 ns | 5.49 ns |  4.29 ns |
|            YieldReturn |  ((1,1), (50,1)) | 666.6 ns | 3.53 ns |  3.13 ns |
|             Primitives | ((25,50), (1,1)) | 388.7 ns | 3.34 ns |  2.61 ns |
| PrimitivesToEnumerable | ((25,50), (1,1)) | 730.4 ns | 3.72 ns |  3.11 ns |
|            YieldReturn | ((25,50), (1,1)) | 761.6 ns | 5.50 ns |  4.88 ns |

These tests and results are basically the same in terms of characteristics as for circle above.