### PR TITLE
Implemented Auto-Syncing Spatial Maps

### DIFF
--- a/TheSadRogue.Primitives.PerformanceTests/PropertyChangedEventHelperTests.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PropertyChangedEventHelperTests.cs
@@ -20,7 +20,7 @@ public class EventTestClass
         get => _changingValue;
         set => this.SafelySetProperty(ref _changingValue, value, ChangingValueChanging, ChangingValueChanged);
     }
-    public event EventHandler<ValueChangingEventArgs<int>>? ChangingValueChanging;
+    public event EventHandler<ValueChangedEventArgs<int>>? ChangingValueChanging;
     public event EventHandler<ValueChangedEventArgs<int>>? ChangingValueChanged;
 }
 

--- a/TheSadRogue.Primitives.PerformanceTests/PropertyChangedEventHelperTests.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/PropertyChangedEventHelperTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+
+namespace TheSadRogue.Primitives.PerformanceTests;
+
+public class EventTestClass
+{
+    private int _changedValue;
+    public int ChangedValue
+    {
+        get => _changedValue;
+        set => this.SafelySetProperty(ref _changedValue, value, ChangedValueChanged);
+    }
+    public event EventHandler<ValueChangedEventArgs<int>>? ChangedValueChanged;
+
+    private int _changingValue;
+    public int ChangingValue
+    {
+        get => _changingValue;
+        set => this.SafelySetProperty(ref _changingValue, value, ChangingValueChanging, ChangingValueChanged);
+    }
+    public event EventHandler<ValueChangingEventArgs<int>>? ChangingValueChanging;
+    public event EventHandler<ValueChangedEventArgs<int>>? ChangingValueChanged;
+}
+
+public class PropertyChangedEventHelperTests
+{
+    private EventTestClass _eventTest = null!;
+    private int _counter1;
+    private int _counter2;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _eventTest = new EventTestClass();
+        _counter1 = _counter2 = 1;
+        _eventTest.ChangedValueChanged += (_, _) => _counter1++;
+        _eventTest.ChangingValueChanging += (_, _) => _counter2++;
+
+        _eventTest.ChangingValueChanged += (_, _) => _counter2++;
+    }
+
+    [Benchmark]
+    public EventTestClass ChangedBasic()
+    {
+        _eventTest.ChangedValue = _counter1;
+        return _eventTest;
+    }
+
+    [Benchmark]
+    public EventTestClass ChangingAndChangedBasic()
+    {
+        _eventTest.ChangingValue = _counter2;
+        return _eventTest;
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/IDObject.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/IDObject.cs
@@ -1,4 +1,5 @@
-﻿using SadRogue.Primitives;
+﻿using System;
+using SadRogue.Primitives;
 
 namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps
 {
@@ -7,6 +8,29 @@ namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps
         private static readonly IDGenerator s_idGenerator = new IDGenerator();
 
         public IDObject()
+        {
+            ID = s_idGenerator.UseID();
+        }
+
+        public uint ID { get; }
+    }
+
+    public class IDPositionObject : IHasID, IPositionable
+    {
+        private static readonly IDGenerator s_idGenerator = new IDGenerator();
+
+        private Point _position;
+
+        public Point Position
+        {
+            get => _position;
+            set => this.SafelySetProperty(ref _position, value, PositionChanging, PositionChanged);
+        }
+
+        public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanging;
+        public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanged;
+
+        public IDPositionObject()
         {
             ID = s_idGenerator.UseID();
         }

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/IDObject.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/IDObject.cs
@@ -15,7 +15,22 @@ namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps
         public uint ID { get; }
     }
 
-    public class IDPositionObject : IHasID, IPositionable
+    public class IDLayerObject : IHasID, IHasLayer
+    {
+        private static readonly IDGenerator s_idGenerator = new IDGenerator();
+
+        public IDLayerObject(int layer)
+        {
+            ID = s_idGenerator.UseID();
+            Layer = layer;
+        }
+
+        public uint ID { get; }
+
+        public int Layer { get; }
+    }
+
+    public class IDPositionLayerObject : IHasID, IPositionable, IHasLayer
     {
         private static readonly IDGenerator s_idGenerator = new IDGenerator();
 
@@ -30,26 +45,14 @@ namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps
         public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanging;
         public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanged;
 
-        public IDPositionObject()
-        {
-            ID = s_idGenerator.UseID();
-        }
+        public int Layer { get; }
 
-        public uint ID { get; }
-    }
-
-    public class IDLayerObject : IHasID, IHasLayer
-    {
-        private static readonly IDGenerator s_idGenerator = new IDGenerator();
-
-        public IDLayerObject(int layer)
+        public IDPositionLayerObject(int layer = 0)
         {
             ID = s_idGenerator.UseID();
             Layer = layer;
         }
 
         public uint ID { get; }
-
-        public int Layer { get; }
     }
 }

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/LayerMaskerOperations.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/LayerMaskerOperations.cs
@@ -1,5 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using JetBrains.Annotations;
 using SadRogue.Primitives.SpatialMaps;
 
 namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps;

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/LayeredSpatialMapAutoSync.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/LayeredSpatialMapAutoSync.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+using SadRogue.Primitives.SpatialMaps;
+
+namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps;
+
+public class LayeredSpatialMapAutoSync
+{
+    private readonly Point _initialPosition = (0, 1);
+        private readonly Point _moveToPosition = (5, 6);
+        private readonly IDPositionLayerObject _trackedObject = new(0);
+        private readonly int _width = 10;
+        private AutoSyncLayeredSpatialMap<IDPositionLayerObject> _testMap = null!;
+
+        [Params(1, 10, 50, 100)]
+        public int NumEntities;
+
+        [Params(1, 2, 3)]
+        public int NumLayers;
+
+        [GlobalSetup(Targets = new[] { nameof(MoveTwice), nameof(MoveTwiceUsingPositionField)})]
+        public void GlobalSetupObjectsAtMoveToLocation()
+        {
+            _testMap = new AutoSyncLayeredSpatialMap<IDPositionLayerObject>(NumLayers, layersSupportingMultipleItems: uint.MaxValue) { { _trackedObject, _initialPosition } };
+
+            // Put other entities on the map (on each layer)
+            for (int i = 0; i < NumLayers; i++)
+            {
+                int idx = -1;
+                var layer = _testMap.GetLayer(i);
+                while (layer.Count < NumEntities)
+                {
+                    idx += 1;
+                    _testMap.Add(new IDPositionLayerObject(i){Position = Point.FromIndex(idx, _width)});
+                }
+            }
+
+        }
+
+        [GlobalSetup(Targets = new[] { nameof(MoveAllTwice)})]
+        public void GlobalSetupNoObjectsAtMoveToLocation()
+        {
+            _testMap = new AutoSyncLayeredSpatialMap<IDPositionLayerObject>(NumLayers, layersSupportingMultipleItems: uint.MaxValue) { { _trackedObject, _initialPosition } };
+
+            // Put other entities on the map, avoiding the starting point (on each layer)
+            for (int i = 0; i < NumLayers; i++)
+            {
+                int idx = -1;
+                var layer = _testMap.GetLayer(i);
+                while (layer.Count < NumEntities)
+                {
+                    idx += 1;
+                    var point = Point.FromIndex(idx, _width);
+                    if (point != _moveToPosition)
+                        _testMap.Add(new IDPositionLayerObject(i){Position = Point.FromIndex(idx, _width)});
+                }
+            }
+        }
+
+        [Benchmark]
+        public int MoveTwice()
+        {
+            _testMap.Move(_trackedObject, _moveToPosition);
+            _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
+            return _testMap.Count; // Ensure nothing is optimized out
+        }
+
+        [Benchmark]
+        public int MoveTwiceUsingPositionField()
+        {
+            _trackedObject.Position = _moveToPosition;
+            _trackedObject.Position = _initialPosition; // Move it back to not spoil next benchmark
+            return _testMap.Count; // Ensure nothing is optimized out
+        }
+
+        [Benchmark]
+        public int MoveAllTwice()
+        {
+            _testMap.MoveAll(_initialPosition, _moveToPosition);
+            // Move it back to not spoil next benchmark.  Valid since the GlobalSetup function used for this benchmark
+            // doesn't put anything at _moveToPosition in the initial state.
+            _testMap.MoveAll(_moveToPosition, _initialPosition);
+            return _testMap.Count; // Ensure nothing is optimized out
+        }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapAutoSync.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapAutoSync.cs
@@ -9,11 +9,11 @@ public class MultiSpatialMapAutoSync
     private readonly Point _initialPosition = (0, 1);
     private readonly Point _moveToPosition = (5, 6);
 
-    private readonly IDPositionObject _trackedObject = new();
+    private readonly IDPositionLayerObject _trackedLayerObject = new();
 
     private readonly int _width = 10;
 
-    private AutoSyncMultiSpatialMap<IDPositionObject> _testMap = null!;
+    private AutoSyncMultiSpatialMap<IDPositionLayerObject> _testMap = null!;
 
     [Params(1, 10, 50, 100)]
     public int NumEntities;
@@ -21,15 +21,15 @@ public class MultiSpatialMapAutoSync
     [GlobalSetup(Targets = new[] { nameof(MoveTwice), nameof(MoveTwiceUsingPositionField)})]
     public void GlobalSetupObjectsAtMoveToLocation()
     {
-        _trackedObject.Position = _initialPosition;
-        _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> {  _trackedObject  };
+        _trackedLayerObject.Position = _initialPosition;
+        _testMap = new AutoSyncMultiSpatialMap<IDPositionLayerObject> {  _trackedLayerObject  };
 
         // Put other entities on the map
         int idx = -1;
         while (_testMap.Count < NumEntities)
         {
             idx += 1;
-            var obj = new IDPositionObject { Position = Point.FromIndex(idx, _width) };
+            var obj = new IDPositionLayerObject { Position = Point.FromIndex(idx, _width) };
             _testMap.Add(obj);
         }
     }
@@ -37,8 +37,8 @@ public class MultiSpatialMapAutoSync
     [GlobalSetup(Targets = new[] { nameof(MoveAllTwice)})]
     public void GlobalSetupNoObjectsAtMoveToLocation()
     {
-        _trackedObject.Position = _initialPosition;
-        _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> { _trackedObject };
+        _trackedLayerObject.Position = _initialPosition;
+        _testMap = new AutoSyncMultiSpatialMap<IDPositionLayerObject> { _trackedLayerObject };
 
         // Put other entities on the map, avoiding the starting point
         int idx = -1;
@@ -47,23 +47,23 @@ public class MultiSpatialMapAutoSync
             idx += 1;
             var point = Point.FromIndex(idx, _width);
             if (point != _moveToPosition)
-                _testMap.Add(new IDPositionObject {Position = point});
+                _testMap.Add(new IDPositionLayerObject {Position = point});
         }
     }
 
     [Benchmark]
     public int MoveTwice()
     {
-        _testMap.Move(_trackedObject, _moveToPosition);
-        _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
+        _testMap.Move(_trackedLayerObject, _moveToPosition);
+        _testMap.Move(_trackedLayerObject, _initialPosition); // Move it back to not spoil next benchmark
         return _testMap.Count; // Ensure nothing is optimized out
     }
 
     [Benchmark]
     public int MoveTwiceUsingPositionField()
     {
-        _trackedObject.Position = _moveToPosition;
-        _trackedObject.Position = _initialPosition; // Move it back to not spoil next benchmark
+        _trackedLayerObject.Position = _moveToPosition;
+        _trackedLayerObject.Position = _initialPosition; // Move it back to not spoil next benchmark
         return _testMap.Count; // Ensure nothing is optimized out
     }
 

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapAutoSync.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapAutoSync.cs
@@ -1,0 +1,80 @@
+﻿using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+using SadRogue.Primitives.SpatialMaps;
+
+namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps;
+
+public class MultiSpatialMapAutoSync
+{
+    private readonly Point _initialPosition = (0, 1);
+    private readonly Point _moveToPosition = (5, 6);
+
+    //private readonly IDPositionObject _addedObject = new IDPositionObject();
+    private readonly IDPositionObject _trackedObject = new IDPositionObject();
+
+    private readonly int _width = 10;
+
+    private AutoSyncMultiSpatialMap<IDPositionObject> _testMap = null!;
+
+    [Params(1, 10, 50, 100)]
+    public int NumEntities;
+
+    [GlobalSetup(Targets = new[] { /*nameof(MoveTwice),*/ nameof(MoveTwiceUsingPositionField)})]
+    public void GlobalSetupObjectsAtMoveToLocation()
+    {
+        _trackedObject.Position = _initialPosition;
+        _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> { { _trackedObject, _initialPosition } };
+
+        // Put other entities on the map
+        int idx = -1;
+        while (_testMap.Count < NumEntities)
+        {
+            idx += 1;
+            var obj = new IDPositionObject { Position = Point.FromIndex(idx, _width) };
+            _testMap.Add(obj);
+        }
+    }
+
+    // [GlobalSetup(Targets = new[] { nameof(MoveAllTwice)})]
+    // public void GlobalSetupNoObjectsAtMoveToLocation()
+    // {
+    //     _trackedObject.Position = _initialPosition;
+    //     _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> { { _trackedObject, _initialPosition } };
+    //
+    //     // Put other entities on the map, avoiding the starting point
+    //     int idx = -1;
+    //     while (_testMap.Count < NumEntities)
+    //     {
+    //         idx += 1;
+    //         var point = Point.FromIndex(idx, _width);
+    //         if (point != _moveToPosition)
+    //             _testMap.Add(new IDPositionObject {Position = point});
+    //     }
+    // }
+
+    // [Benchmark]
+    // public int MoveTwice()
+    // {
+    //     _testMap.Move(_trackedObject, _moveToPosition);
+    //     _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
+    //     return _testMap.Count; // Ensure nothing is optimized out
+    // }
+
+    [Benchmark]
+    public int MoveTwiceUsingPositionField()
+    {
+        _trackedObject.Position = _moveToPosition;
+        _trackedObject.Position = _initialPosition; // Move it back to not spoil next benchmark
+        return _testMap.Count; // Ensure nothing is optimized out
+    }
+
+    // [Benchmark]
+    // public int MoveAllTwice()
+    // {
+    //     _testMap.MoveAll(_initialPosition, _moveToPosition);
+    //     // Move it back to not spoil next benchmark.  Valid since the GlobalSetup function used for this benchmark
+    //     // doesn't put anything at _moveToPosition in the initial state.
+    //     _testMap.MoveAll(_moveToPosition, _initialPosition);
+    //     return _testMap.Count; // Ensure nothing is optimized out
+    // }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapAutoSync.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapAutoSync.cs
@@ -9,8 +9,7 @@ public class MultiSpatialMapAutoSync
     private readonly Point _initialPosition = (0, 1);
     private readonly Point _moveToPosition = (5, 6);
 
-    //private readonly IDPositionObject _addedObject = new IDPositionObject();
-    private readonly IDPositionObject _trackedObject = new IDPositionObject();
+    private readonly IDPositionObject _trackedObject = new();
 
     private readonly int _width = 10;
 
@@ -19,11 +18,11 @@ public class MultiSpatialMapAutoSync
     [Params(1, 10, 50, 100)]
     public int NumEntities;
 
-    [GlobalSetup(Targets = new[] { /*nameof(MoveTwice),*/ nameof(MoveTwiceUsingPositionField)})]
+    [GlobalSetup(Targets = new[] { nameof(MoveTwice), nameof(MoveTwiceUsingPositionField)})]
     public void GlobalSetupObjectsAtMoveToLocation()
     {
         _trackedObject.Position = _initialPosition;
-        _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> { { _trackedObject, _initialPosition } };
+        _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> {  _trackedObject  };
 
         // Put other entities on the map
         int idx = -1;
@@ -35,30 +34,30 @@ public class MultiSpatialMapAutoSync
         }
     }
 
-    // [GlobalSetup(Targets = new[] { nameof(MoveAllTwice)})]
-    // public void GlobalSetupNoObjectsAtMoveToLocation()
-    // {
-    //     _trackedObject.Position = _initialPosition;
-    //     _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> { { _trackedObject, _initialPosition } };
-    //
-    //     // Put other entities on the map, avoiding the starting point
-    //     int idx = -1;
-    //     while (_testMap.Count < NumEntities)
-    //     {
-    //         idx += 1;
-    //         var point = Point.FromIndex(idx, _width);
-    //         if (point != _moveToPosition)
-    //             _testMap.Add(new IDPositionObject {Position = point});
-    //     }
-    // }
+    [GlobalSetup(Targets = new[] { nameof(MoveAllTwice)})]
+    public void GlobalSetupNoObjectsAtMoveToLocation()
+    {
+        _trackedObject.Position = _initialPosition;
+        _testMap = new AutoSyncMultiSpatialMap<IDPositionObject> { _trackedObject };
 
-    // [Benchmark]
-    // public int MoveTwice()
-    // {
-    //     _testMap.Move(_trackedObject, _moveToPosition);
-    //     _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
-    //     return _testMap.Count; // Ensure nothing is optimized out
-    // }
+        // Put other entities on the map, avoiding the starting point
+        int idx = -1;
+        while (_testMap.Count < NumEntities)
+        {
+            idx += 1;
+            var point = Point.FromIndex(idx, _width);
+            if (point != _moveToPosition)
+                _testMap.Add(new IDPositionObject {Position = point});
+        }
+    }
+
+    [Benchmark]
+    public int MoveTwice()
+    {
+        _testMap.Move(_trackedObject, _moveToPosition);
+        _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
+        return _testMap.Count; // Ensure nothing is optimized out
+    }
 
     [Benchmark]
     public int MoveTwiceUsingPositionField()
@@ -68,13 +67,13 @@ public class MultiSpatialMapAutoSync
         return _testMap.Count; // Ensure nothing is optimized out
     }
 
-    // [Benchmark]
-    // public int MoveAllTwice()
-    // {
-    //     _testMap.MoveAll(_initialPosition, _moveToPosition);
-    //     // Move it back to not spoil next benchmark.  Valid since the GlobalSetup function used for this benchmark
-    //     // doesn't put anything at _moveToPosition in the initial state.
-    //     _testMap.MoveAll(_moveToPosition, _initialPosition);
-    //     return _testMap.Count; // Ensure nothing is optimized out
-    // }
+    [Benchmark]
+    public int MoveAllTwice()
+    {
+        _testMap.MoveAll(_initialPosition, _moveToPosition);
+        // Move it back to not spoil next benchmark.  Valid since the GlobalSetup function used for this benchmark
+        // doesn't put anything at _moveToPosition in the initial state.
+        _testMap.MoveAll(_moveToPosition, _initialPosition);
+        return _testMap.Count; // Ensure nothing is optimized out
+    }
 }

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapOperations.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapOperations.cs
@@ -18,7 +18,7 @@ namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps
         [Params(1, 10, 50, 100)]
         public int NumEntities;
 
-        [GlobalSetup(Targets = new[] { nameof(MoveTwice), nameof(TryMoveTwiceOriginal), nameof(TryMoveTwice), nameof(AddAndRemove), nameof(TryAddAndRemoveOriginal), nameof(TryAddAndRemove), nameof(GetItemsAt) })]
+        [GlobalSetup(Targets = new[] { nameof(MoveTwice),nameof(MoveToSame), nameof(TryMoveTwiceOriginal), nameof(TryMoveTwice), nameof(AddAndRemove), nameof(TryAddAndRemoveOriginal), nameof(TryAddAndRemove), nameof(GetItemsAt) })]
         public void GlobalSetupObjectsAtMoveToLocation()
         {
             _testMap = new MultiSpatialMap<IDObject> { { _trackedObject, _initialPosition } };
@@ -54,6 +54,13 @@ namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps
             _testMap.Move(_trackedObject, _moveToPosition);
             _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
             return _testMap.Count; // Ensure nothing is optimized out
+        }
+
+        [Benchmark]
+        public int MoveToSame()
+        {
+            _testMap.Move(_trackedObject, _initialPosition);
+            return _testMap.Count;
         }
 
         [Benchmark]

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapOperations.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/MultiSpatialMapOperations.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
-using JetBrains.Annotations;
 using SadRogue.Primitives;
 using SadRogue.Primitives.SpatialMaps;
 

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/SpatialMapAutoSync.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/SpatialMapAutoSync.cs
@@ -1,0 +1,64 @@
+﻿using BenchmarkDotNet.Attributes;
+using SadRogue.Primitives;
+using SadRogue.Primitives.SpatialMaps;
+
+namespace TheSadRogue.Primitives.PerformanceTests.SpatialMaps;
+
+public class SpatialMapAutoSync
+{
+    private readonly Point _initialPosition = (0, 1);
+    private readonly Point _moveToPosition = (5, 6);
+    private readonly Point _addPosition = (1, 1);
+    private readonly IDPositionObject _trackedObject = new();
+    private readonly int _width = 10;
+    private AutoSyncSpatialMap<IDPositionObject> _testMap = null!;
+
+    [Params(1, 10, 50, 100)]
+    public int NumEntities;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _testMap = new AutoSyncSpatialMap<IDPositionObject> { { _trackedObject, _initialPosition } };
+
+        // Put other entities on the map, steering clear of the three points we need to remain clear to support
+        // benchmarked adds/removes.
+        int idx = -1;
+        while (_testMap.Count < NumEntities)
+        {
+            idx += 1;
+
+            if (idx == _initialPosition.ToIndex(_width) || idx == _moveToPosition.ToIndex(_width) || idx == _addPosition.ToIndex(_width)) continue;
+
+            var obj = new IDPositionObject { Position = Point.FromIndex(idx, _width) };
+            _testMap.Add(obj);
+        }
+    }
+
+    [Benchmark]
+    public int MoveTwice()
+    {
+        _testMap.Move(_trackedObject, _moveToPosition);
+        _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
+        return _testMap.Count; // Ensure nothing is optimized out
+    }
+
+    [Benchmark]
+    public int MoveTwiceUsingPositionField()
+    {
+        _trackedObject.Position = _moveToPosition;
+        _trackedObject.Position = _initialPosition; // Move it back to not spoil next benchmark
+
+        return _testMap.Count; // Ensure nothing is optimized out
+    }
+
+    [Benchmark]
+    public int MoveAllTwice()
+    {
+        _testMap.MoveAll(_initialPosition, _moveToPosition);
+        // Move it back to not spoil next benchmark.  Valid since the GlobalSetup function used for this benchmark
+        // doesn't put anything at _moveToPosition in the initial state.
+        _testMap.MoveAll(_moveToPosition, _initialPosition);
+        return _testMap.Count; // Ensure nothing is optimized out
+    }
+}

--- a/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/SpatialMapAutoSync.cs
+++ b/TheSadRogue.Primitives.PerformanceTests/SpatialMaps/SpatialMapAutoSync.cs
@@ -9,9 +9,9 @@ public class SpatialMapAutoSync
     private readonly Point _initialPosition = (0, 1);
     private readonly Point _moveToPosition = (5, 6);
     private readonly Point _addPosition = (1, 1);
-    private readonly IDPositionObject _trackedObject = new();
+    private readonly IDPositionLayerObject _trackedLayerObject = new();
     private readonly int _width = 10;
-    private AutoSyncSpatialMap<IDPositionObject> _testMap = null!;
+    private AutoSyncSpatialMap<IDPositionLayerObject> _testMap = null!;
 
     [Params(1, 10, 50, 100)]
     public int NumEntities;
@@ -19,7 +19,7 @@ public class SpatialMapAutoSync
     [GlobalSetup]
     public void GlobalSetup()
     {
-        _testMap = new AutoSyncSpatialMap<IDPositionObject> { { _trackedObject, _initialPosition } };
+        _testMap = new AutoSyncSpatialMap<IDPositionLayerObject> { { _trackedLayerObject, _initialPosition } };
 
         // Put other entities on the map, steering clear of the three points we need to remain clear to support
         // benchmarked adds/removes.
@@ -30,7 +30,7 @@ public class SpatialMapAutoSync
 
             if (idx == _initialPosition.ToIndex(_width) || idx == _moveToPosition.ToIndex(_width) || idx == _addPosition.ToIndex(_width)) continue;
 
-            var obj = new IDPositionObject { Position = Point.FromIndex(idx, _width) };
+            var obj = new IDPositionLayerObject { Position = Point.FromIndex(idx, _width) };
             _testMap.Add(obj);
         }
     }
@@ -38,16 +38,16 @@ public class SpatialMapAutoSync
     [Benchmark]
     public int MoveTwice()
     {
-        _testMap.Move(_trackedObject, _moveToPosition);
-        _testMap.Move(_trackedObject, _initialPosition); // Move it back to not spoil next benchmark
+        _testMap.Move(_trackedLayerObject, _moveToPosition);
+        _testMap.Move(_trackedLayerObject, _initialPosition); // Move it back to not spoil next benchmark
         return _testMap.Count; // Ensure nothing is optimized out
     }
 
     [Benchmark]
     public int MoveTwiceUsingPositionField()
     {
-        _trackedObject.Position = _moveToPosition;
-        _trackedObject.Position = _initialPosition; // Move it back to not spoil next benchmark
+        _trackedLayerObject.Position = _moveToPosition;
+        _trackedLayerObject.Position = _initialPosition; // Move it back to not spoil next benchmark
 
         return _testMap.Count; // Ensure nothing is optimized out
     }

--- a/TheSadRogue.Primitives.UnitTests/IDGeneratorTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/IDGeneratorTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using Xunit;
 using XUnit.ValueTuples;
 

--- a/TheSadRogue.Primitives.UnitTests/Mocks/MockPositionableSpatialMapItem.cs
+++ b/TheSadRogue.Primitives.UnitTests/Mocks/MockPositionableSpatialMapItem.cs
@@ -23,10 +23,11 @@ namespace SadRogue.Primitives.UnitTests.Mocks
             get => _position;
             set
             {
-                this.SafelySetProperty(ref _position, value, PositionChanged);
+                this.SafelySetProperty(ref _position, value, PositionChanging, PositionChanged);
             }
         }
 
+        public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanging;
         public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanged;
 
         public override string ToString() => $"[{ID}, {Layer}]";

--- a/TheSadRogue.Primitives.UnitTests/Mocks/MockPositionableSpatialMapItem.cs
+++ b/TheSadRogue.Primitives.UnitTests/Mocks/MockPositionableSpatialMapItem.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace SadRogue.Primitives.UnitTests.Mocks
+{
+    public class MockPositionableSpatialMapItem : IHasID, IHasLayer, IPositionable
+    {
+        private static readonly IDGenerator _idGen = new IDGenerator();
+
+        public MockPositionableSpatialMapItem(int layer, Point position)
+        {
+            ID = _idGen.UseID();
+            Layer = layer;
+            _position = position;
+        }
+
+        public uint ID { get; }
+        public int Layer { get; }
+
+        private Point _position;
+
+        public Point Position
+        {
+            get => _position;
+            set
+            {
+                this.SafelySetProperty(ref _position, value, PositionChanged);
+            }
+        }
+
+        public event EventHandler<ValueChangedEventArgs<Point>>? PositionChanged;
+
+        public override string ToString() => $"[{ID}, {Layer}]";
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/PropertyChangedEventHelperTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/PropertyChangedEventHelperTests.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using XUnit.ValueTuples;
+
+namespace SadRogue.Primitives.UnitTests
+{
+    public class ValueChangeEventsMock
+    {
+        private readonly bool _fireChanging;
+        private readonly bool _supportsHandled;
+        private readonly bool _supportsCanceled;
+
+        private int _value;
+
+        public int Value
+        {
+            get => _value;
+            set
+            {
+                if (_fireChanging)
+                    this.SafelySetProperty(ref _value, value, ValueChanging, ValueChanged, _supportsCanceled,
+                        _supportsHandled);
+                else
+                    this.SafelySetProperty(ref _value, value, ValueChanged, _supportsHandled);
+            }
+        }
+
+        public event EventHandler<ValueChangingEventArgs<int>>? ValueChanging;
+        public event EventHandler<ValueChangedEventArgs<int>>? ValueChanged;
+
+        public ValueChangeEventsMock(bool fireChanging, bool supportsCanceled, bool supportsHandled)
+        {
+            _fireChanging = fireChanging;
+            _supportsCanceled = supportsCanceled;
+            _supportsHandled = supportsHandled;
+        }
+    }
+
+    public class PropertyChangedEventHelperTests
+    {
+        #region Test Data
+        private static readonly bool[] s_booleans = { true, false };
+
+        public static IEnumerable<(bool fireChanging, bool supportsCanceled, bool supportsHandled)> ChangedTestData =
+            s_booleans.Combinate(s_booleans).Combinate(s_booleans);
+
+        public static IEnumerable<(bool supportsCanceled, bool supportsHandled)> ChangingTestData =
+            s_booleans.Combinate(s_booleans);
+
+        public static IEnumerable<bool> BooleanValues => s_booleans;
+
+        public static IEnumerable<(bool fireChanging, bool supportsCancel)> ValidChangingStates =
+            new[] { (true, true), (true, false), (false, false) };
+
+        #endregion
+
+
+        [Theory]
+        [MemberDataTuple(nameof(ChangedTestData))]
+        public void ChangedFires(bool fireChanging, bool supportsCanceled, bool supportsHandled)
+        {
+            var obj = new ValueChangeEventsMock(fireChanging, supportsCanceled, supportsHandled);
+            int changedCounter = 0;
+            obj.ValueChanged += (s, e) =>
+            {
+                Assert.Same(obj, s);
+                Assert.Equal(0, e.OldValue);
+                Assert.Equal(1, e.NewValue);
+                Assert.Equal(e.NewValue, obj.Value);
+                changedCounter++;
+            };
+
+            obj.Value = 1;
+
+            Assert.Equal(1, changedCounter);
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(ChangingTestData))]
+        public void ChangingFires(bool supportsCanceled, bool supportsHandled)
+        {
+            var obj = new ValueChangeEventsMock(true, supportsCanceled, supportsHandled);
+            int changingCounter = 0;
+            int changedCounter = 0;
+            obj.ValueChanging += (s, e) =>
+            {
+                Assert.Equal(0, changingCounter);
+                Assert.Equal(0, changedCounter);
+                Assert.Same(obj, s);
+                Assert.Equal(0, e.OldValue);
+                Assert.Equal(1, e.NewValue);
+                Assert.Equal(e.OldValue, obj.Value);
+                changingCounter++;
+            };
+            obj.ValueChanged += (s, e) =>
+            {
+                Assert.Equal(1, changingCounter);
+                Assert.Equal(0, changedCounter);
+                Assert.Same(obj, s);
+                Assert.Equal(0, e.OldValue);
+                Assert.Equal(1, e.NewValue);
+                Assert.Equal(e.NewValue, obj.Value);
+                changedCounter++;
+            };
+
+            obj.Value = 1;
+
+            Assert.Equal(1, changingCounter);
+            Assert.Equal(1, changedCounter);
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(BooleanValues))]
+        public void TestCancelled(bool supportsHandled)
+        {
+            var obj = new ValueChangeEventsMock(true, true, supportsHandled);
+
+            int changingCounter = 0;
+            obj.ValueChanging += (s, e) =>
+            {
+                changingCounter += 1;
+            };
+            obj.ValueChanging += (s, e) =>
+            {
+                changingCounter += 2;
+                e.IsCancelled = true;
+            };
+            // Should never execute due to cancellation
+            obj.ValueChanging += (s, e) =>
+            {
+                changingCounter = 5;
+            };
+
+            obj.ValueChanged += (s, e)
+                => Assert.Fail("Changed event should not be executed when event is cancelled during changing event.");
+
+            obj.Value = 1;
+
+            Assert.Equal(3, changingCounter);
+            Assert.Equal(0, obj.Value);
+        }
+
+        [Theory]
+        [MemberDataEnumerable(nameof(BooleanValues))]
+        public void CancelledUnsupported(bool supportsHandled)
+        {
+            var obj = new ValueChangeEventsMock(true, false, supportsHandled);
+
+            int changingCounter = 0;
+            obj.ValueChanging += (s, e) =>
+            {
+                changingCounter += 1;
+            };
+            obj.ValueChanging += (s, e) =>
+            {
+                changingCounter += 2;
+                e.IsCancelled = true; // Should do nothing since cancellation isn't supported
+            };
+            obj.ValueChanging += (s, e) =>
+            {
+                changingCounter = 5;
+            };
+
+            int changedCounter = 0;
+            obj.ValueChanged += (s, e)
+                => changedCounter++;
+
+            obj.Value = 1;
+
+            Assert.Equal(5, changingCounter);
+            Assert.Equal(1, changedCounter);
+            Assert.Equal(1, obj.Value);
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(ValidChangingStates))]
+        public void TestHandled(bool fireChanging, bool supportsCanceled)
+        {
+            var obj = new ValueChangeEventsMock(fireChanging, supportsCanceled, true);
+
+            int changedCounter = 0;
+            obj.ValueChanged += (s, e) =>
+            {
+                changedCounter += 1;
+            };
+            obj.ValueChanged += (s, e) =>
+            {
+                changedCounter += 2;
+                e.IsHandled = true;
+            };
+            // Should never execute due to the previous handler marking IsHandled
+            obj.ValueChanged += (s, e) =>
+            {
+                changedCounter = 5;
+            };
+
+            obj.Value = 1;
+
+            Assert.Equal(3, changedCounter);
+            Assert.Equal(1, obj.Value);
+        }
+
+        [Theory]
+        [MemberDataTuple(nameof(ValidChangingStates))]
+        public void HandledUnsupported(bool fireChanging, bool supportsCanceled)
+        {
+            var obj = new ValueChangeEventsMock(fireChanging, supportsCanceled, false);
+
+            int changedCounter = 0;
+            obj.ValueChanged += (s, e) =>
+            {
+                changedCounter += 1;
+            };
+            obj.ValueChanged += (s, e) =>
+            {
+                changedCounter += 2;
+                e.IsHandled = true;  // Should do nothing since handling isn't supported
+            };
+            obj.ValueChanged += (s, e) =>
+            {
+                changedCounter = 5;
+            };
+
+            obj.Value = 1;
+
+            Assert.Equal(5, changedCounter);
+            Assert.Equal(1, obj.Value);
+        }
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncLayeredSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncLayeredSpatialMapTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Linq;
+using SadRogue.Primitives.SpatialMaps;
+using SadRogue.Primitives.UnitTests.Mocks;
+using Xunit;
+
+namespace SadRogue.Primitives.UnitTests.SpatialMaps
+{
+    public class AutoSyncLayeredSpatialMapTests
+    {
+        [Fact]
+        public void SettingPositionAutoSyncsSpatialMap()
+        {
+            var map = new AutoSyncLayeredSpatialMap<MockPositionableSpatialMapItem>(1, startingLayer: 1, layersSupportingMultipleItems: uint.MaxValue);
+            var item = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item);
+
+            Assert.Equal(1, map.Count);
+            Assert.Single(map.GetItemsAt(item.Position));
+
+            item.Position = (3, 4);
+
+            Assert.Equal(1, map.Count);
+            Assert.Empty(map.GetItemsAt((1, 2)));
+            Assert.Single(map.GetItemsAt(item.Position));
+
+            var item2 = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item2);
+            item.Position = item2.Position;
+            Assert.Equal(2, map.Count);
+            Assert.Equal(2, map.GetItemsAt((1, 2)).Count());
+
+            map.Remove(item);
+            item.Position = (5, 6); // Validate event handler is unregistered
+            Assert.Equal(1, map.Count);
+        }
+
+        [Fact]
+        public void UsingMoveFunctionsAutoSyncsPosition()
+        {
+            var map = new AutoSyncLayeredSpatialMap<MockPositionableSpatialMapItem>(1,  startingLayer: 1, layersSupportingMultipleItems: uint.MaxValue);
+            var item = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item);
+
+            Assert.Equal(1, map.Count);
+            Assert.Single(map.GetItemsAt(item.Position));
+
+            map.Move(item, (3, 4));
+
+            Assert.Equal(1, map.Count);
+            Assert.Empty(map.GetItemsAt((1, 2)));
+            Assert.Single(map.GetItemsAt(item.Position));
+            Assert.Equal(new Point(3, 4), item.Position);
+
+            var item2 = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item2);
+            map.Move(item, item2.Position);
+            Assert.Equal(2, map.Count);
+            Assert.Equal(2, map.GetItemsAt((1, 2)).Count());
+            Assert.Equal(item2.Position, item.Position);
+
+            map.Remove(item);
+            item.Position = (5, 6); // Attempt to validate handlers are unregistered (move would crash with an object not in the map)
+            Assert.Equal(1, map.Count);
+        }
+
+        [Fact]
+        public void MapIsSyncedWhenPositionChangedTriggers()
+        {
+            var map = new AutoSyncLayeredSpatialMap<MockPositionableSpatialMapItem>(1,  startingLayer: 1, layersSupportingMultipleItems: uint.MaxValue);
+            var item = new MockPositionableSpatialMapItem(1, (1, 2));
+            item.PositionChanged += (s, e)
+                => Assert.Equal(e.NewValue, map.GetPositionOf((MockPositionableSpatialMapItem)s!));
+            map.Add(item);
+
+            item.Position = (3, 4);
+            map.Move(item, (2, 3));
+        }
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
@@ -75,7 +75,5 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             item.Position = (3, 4);
             map.Move(item, (2, 3));
         }
-
-
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace SadRogue.Primitives.UnitTests.SpatialMaps
 {
-    public class AutoSyncSpatialMapTests
+    public class AutoSyncMultiSpatialMapTests
     {
         [Fact]
         public void MovementAutoSyncs()

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
@@ -65,6 +65,19 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             Assert.Equal(1, map.Count);
         }
 
+        [Fact]
+        public void MapIsSyncedWhenPositionChangedTriggers()
+        {
+            var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
+            var item = new MockPositionableSpatialMapItem(1, (1, 2));
+            item.PositionChanged += (s, e)
+                => Assert.Equal(e.NewValue, map.GetPositionOf((MockPositionableSpatialMapItem)s!));
+            map.Add(item);
+
+            item.Position = (3, 4);
+            map.Move(item, (2, 3));
+        }
+
 
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncMultiSpatialMapTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using SadRogue.Primitives.SpatialMaps;
 using SadRogue.Primitives.UnitTests.Mocks;
 using Xunit;
@@ -9,7 +10,7 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
     public class AutoSyncMultiSpatialMapTests
     {
         [Fact]
-        public void MovementAutoSyncs()
+        public void SettingPositionAutoSyncsSpatialMap()
         {
             var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
             var item = new MockPositionableSpatialMapItem(1, (1, 2));
@@ -34,6 +35,36 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             item.Position = (5, 6); // Validate event handler is unregistered
             Assert.Equal(1, map.Count);
         }
+
+        [Fact]
+        public void UsingMoveFunctionsAutoSyncsPosition()
+        {
+            var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
+            var item = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item);
+
+            Assert.Equal(1, map.Count);
+            Assert.Single(map.GetItemsAt(item.Position));
+
+            map.Move(item, (3, 4));
+
+            Assert.Equal(1, map.Count);
+            Assert.Empty(map.GetItemsAt((1, 2)));
+            Assert.Single(map.GetItemsAt(item.Position));
+            Assert.Equal(new Point(3, 4), item.Position);
+
+            var item2 = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item2);
+            map.Move(item, item2.Position);
+            Assert.Equal(2, map.Count);
+            Assert.Equal(2, map.GetItemsAt((1, 2)).Count());
+            Assert.Equal(item2.Position, item.Position);
+
+            map.Remove(item);
+            item.Position = (5, 6); // Attempt to validate handlers are unregistered (move would crash with an object not in the map)
+            Assert.Equal(1, map.Count);
+        }
+
 
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncSpatialMapTests.cs
@@ -1,16 +1,15 @@
-﻿using System.Linq;
-using SadRogue.Primitives.SpatialMaps;
+﻿using SadRogue.Primitives.SpatialMaps;
 using SadRogue.Primitives.UnitTests.Mocks;
 using Xunit;
 
 namespace SadRogue.Primitives.UnitTests.SpatialMaps
 {
-    public class AutoSyncMultiSpatialMapTests
+    public class AutoSyncSpatialMapTests
     {
         [Fact]
         public void SettingPositionAutoSyncsSpatialMap()
         {
-            var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
+            var map = new AutoSyncSpatialMap<MockPositionableSpatialMapItem>();
             var item = new MockPositionableSpatialMapItem(1, (1, 2));
             map.Add(item);
 
@@ -23,21 +22,15 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             Assert.Empty(map.GetItemsAt((1, 2)));
             Assert.Single(map.GetItemsAt(item.Position));
 
-            var item2 = new MockPositionableSpatialMapItem(1, (1, 2));
-            map.Add(item2);
-            item.Position = item2.Position;
-            Assert.Equal(2, map.Count);
-            Assert.Equal(2, map.GetItemsAt((1, 2)).Count());
-
             map.Remove(item);
             item.Position = (5, 6); // Validate event handler is unregistered
-            Assert.Equal(1, map.Count);
+            Assert.Equal(0, map.Count);
         }
 
         [Fact]
         public void UsingMoveFunctionsAutoSyncsPosition()
         {
-            var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
+            var map = new AutoSyncSpatialMap<MockPositionableSpatialMapItem>();
             var item = new MockPositionableSpatialMapItem(1, (1, 2));
             map.Add(item);
 
@@ -51,22 +44,15 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             Assert.Single(map.GetItemsAt(item.Position));
             Assert.Equal(new Point(3, 4), item.Position);
 
-            var item2 = new MockPositionableSpatialMapItem(1, (1, 2));
-            map.Add(item2);
-            map.Move(item, item2.Position);
-            Assert.Equal(2, map.Count);
-            Assert.Equal(2, map.GetItemsAt((1, 2)).Count());
-            Assert.Equal(item2.Position, item.Position);
-
             map.Remove(item);
             item.Position = (5, 6); // Attempt to validate handlers are unregistered (move would crash with an object not in the map)
-            Assert.Equal(1, map.Count);
+            Assert.Equal(0, map.Count);
         }
 
         [Fact]
         public void MapIsSyncedWhenPositionChangedTriggers()
         {
-            var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
+            var map = new AutoSyncSpatialMap<MockPositionableSpatialMapItem>();
             var item = new MockPositionableSpatialMapItem(1, (1, 2));
             item.PositionChanged += (s, e)
                 => Assert.Equal(e.NewValue, map.GetPositionOf((MockPositionableSpatialMapItem)s!));
@@ -75,7 +61,5 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             item.Position = (3, 4);
             map.Move(item, (2, 3));
         }
-
-
     }
 }

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/AutoSyncSpatialMapTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using SadRogue.Primitives.SpatialMaps;
+using SadRogue.Primitives.UnitTests.Mocks;
+using Xunit;
+
+namespace SadRogue.Primitives.UnitTests.SpatialMaps
+{
+    public class AutoSyncSpatialMapTests
+    {
+        [Fact]
+        public void MovementAutoSyncs()
+        {
+            var map = new AutoSyncMultiSpatialMap<MockPositionableSpatialMapItem>();
+            var item = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item);
+
+            Assert.Equal(1, map.Count);
+            Assert.Single(map.GetItemsAt(item.Position));
+
+            item.Position = (3, 4);
+
+            Assert.Equal(1, map.Count);
+            Assert.Empty(map.GetItemsAt((1, 2)));
+            Assert.Single(map.GetItemsAt(item.Position));
+
+            var item2 = new MockPositionableSpatialMapItem(1, (1, 2));
+            map.Add(item2);
+            item.Position = item2.Position;
+            Assert.Equal(2, map.Count);
+            Assert.Equal(2, map.GetItemsAt((1, 2)).Count());
+
+            map.Remove(item);
+            item.Position = (5, 6); // Validate event handler is unregistered
+            Assert.Equal(1, map.Count);
+        }
+
+    }
+}

--- a/TheSadRogue.Primitives.UnitTests/SpatialMaps/LayeredSpatialMapTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/SpatialMaps/LayeredSpatialMapTests.cs
@@ -271,12 +271,12 @@ namespace SadRogue.Primitives.UnitTests.SpatialMaps
             _spatialMap.Add(lastItem, _newItemsPos);
             Assert.Equal(_initialItems.Count + 1, _spatialMap.Count);
 
-            // Most of the objects can move; 1 is blocked by lastItem
+            // Most of the objects can move; 1 is blocked by lastItem, so none move
             var val = _spatialMap.TryMoveAll(_initialItemsPos, _newItemsPos, mask);
             Assert.False(val);
             Assert.Equal(2, layersInMask - 1);
-            Assert.Equal(_initialItems.Count - 2, _spatialMap.GetItemsAt(_initialItemsPos).Count());
-            Assert.Equal(2 + 1, _spatialMap.GetItemsAt(_newItemsPos).Count());
+            Assert.Equal(_initialItems.Count, _spatialMap.GetItemsAt(_initialItemsPos).Count());
+            Assert.Single(_spatialMap.GetItemsAt(_newItemsPos));
         }
 
         [Fact]

--- a/TheSadRogue.Primitives/IPositionable.cs
+++ b/TheSadRogue.Primitives/IPositionable.cs
@@ -20,6 +20,11 @@ namespace SadRogue.Primitives
         Point Position { get; set; }
 
         /// <summary>
+        /// Event which should be fired right before the object's position changes.
+        /// </summary>
+        event EventHandler<ValueChangedEventArgs<Point>>? PositionChanging;
+
+        /// <summary>
         /// Event which should be fired when the object's position changes.
         /// </summary>
         event EventHandler<ValueChangedEventArgs<Point>>? PositionChanged;

--- a/TheSadRogue.Primitives/IPositionable.cs
+++ b/TheSadRogue.Primitives/IPositionable.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using SadRogue.Primitives.SpatialMaps;
+
+namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// An interface describing an object which has a position on a grid and may be able to move around.
+    /// </summary>
+    /// <remarks>
+    /// Objects which have a position can implement this interface, which can be useful to make such objects easily
+    /// compatible with automatically syncing spatial map classes like <see cref="AutoSyncMultiSpatialMap{T}"/>.
+    ///
+    /// Other algorithms may be able to make use of this interface as well if all they need is an object with a position.
+    /// </remarks>
+    public interface IPositionable
+    {
+        /// <summary>
+        /// The position of the object.
+        /// </summary>
+        Point Position { get; }
+
+        /// <summary>
+        /// Event which should be fired when the object's position changes.
+        /// </summary>
+        event EventHandler<ObjectPropertyChanged<Point>>? PositionChanged;
+    }
+}

--- a/TheSadRogue.Primitives/IPositionable.cs
+++ b/TheSadRogue.Primitives/IPositionable.cs
@@ -4,7 +4,7 @@ using SadRogue.Primitives.SpatialMaps;
 namespace SadRogue.Primitives
 {
     /// <summary>
-    /// An interface describing an object which has a position on a grid and may be able to move around.
+    /// An interface describing an object which has a position on a grid and can move around.
     /// </summary>
     /// <remarks>
     /// Objects which have a position can implement this interface, which can be useful to make such objects easily
@@ -17,7 +17,7 @@ namespace SadRogue.Primitives
         /// <summary>
         /// The position of the object.
         /// </summary>
-        Point Position { get; }
+        Point Position { get; set; }
 
         /// <summary>
         /// Event which should be fired when the object's position changes.

--- a/TheSadRogue.Primitives/IPositionable.cs
+++ b/TheSadRogue.Primitives/IPositionable.cs
@@ -22,6 +22,6 @@ namespace SadRogue.Primitives
         /// <summary>
         /// Event which should be fired when the object's position changes.
         /// </summary>
-        event EventHandler<ObjectPropertyChanged<Point>>? PositionChanged;
+        event EventHandler<ValueChangedEventArgs<Point>>? PositionChanged;
     }
 }

--- a/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
+++ b/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
@@ -226,20 +226,21 @@ namespace SadRogue.Primitives
             var changingArgs = new ValueChangingEventArgs<TProperty>(propertyField, newValue, changingSupportsCancel);
 
             // Fire "pre-change" event
-            if (changingEvent == null) return;
-
-            if (changingSupportsCancel)
+            if (changingEvent != null)
             {
-                foreach (var del in changingEvent.GetInvocationList())
+                if (changingSupportsCancel)
                 {
-                    var handler = (EventHandler<ValueChangingEventArgs<TProperty>>)del;
-                    handler(self, changingArgs);
-                    if (changingArgs.IsCancelled)
-                        return;
+                    foreach (var del in changingEvent.GetInvocationList())
+                    {
+                        var handler = (EventHandler<ValueChangingEventArgs<TProperty>>)del;
+                        handler(self, changingArgs);
+                        if (changingArgs.IsCancelled)
+                            return;
+                    }
                 }
+                else // This is faster than the foreach loop above, so we should have a special case for this
+                    changingEvent.Invoke(self, changingArgs);
             }
-            else // This is faster than the foreach loop above, so we should have a special case for this
-                changingEvent.Invoke(self, changingArgs);
 
             // Set new value and fire event
             var oldValue = propertyField;

--- a/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
+++ b/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
@@ -4,7 +4,7 @@ namespace SadRogue.Primitives
 {
     /// <summary>
     /// Event arguments for an event fired when an object's properties are changed.  Often used with
-    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ValueChangedEventArgs{TProperty}}?,bool)"/>
+    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ValueChangedEventArgs{TProperty}}?)"/>
     /// and other overloads of that function.
     /// </summary>
     /// <remarks>
@@ -30,78 +30,20 @@ namespace SadRogue.Primitives
         public readonly TProperty NewValue;
 
         /// <summary>
-        /// When <see langword="true"/>, indicates this value change can be flagged as handled and stop further event handlers; otherwise <see langword="false"/>.
-        /// </summary>
-        public readonly bool SupportsHandled;
-
-        /// <summary>
-        /// When <see cref="SupportsHandled"/> is <see langword="true"/>, setting this property to <see langword="true"/> flags this change as handled and to stop processing further event handlers.
-        /// </summary>
-        public bool IsHandled { get; set; }
-
-        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="oldValue">Previous value of property.</param>
         /// <param name="newValue">New value of property.</param>
-        /// <param name="supportsHandled">When <see langword="true"/>, indicates this value change can be flagged as handled and stop further event handlers.</param>
-        public ValueChangedEventArgs(TProperty oldValue, TProperty newValue, bool supportsHandled = false) =>
-            (OldValue, NewValue, SupportsHandled) = (oldValue, newValue, supportsHandled);
-    }
-
-    /// <summary>
-    /// Event arguments for an event fired when an object's properties are changed.  Often used with
-    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ValueChangingEventArgs{TProperty}}?,System.EventHandler{SadRogue.Primitives.ValueChangedEventArgs{TProperty}}?,bool,bool)"/>.
-    /// </summary>
-    /// <remarks>
-    /// It is fairly common to have an event that is fired when a property is changed and/or about to change; a common use case relative to
-    /// This class encapsulates a generic event argument for such occurrences.
-    ///
-    /// In addition to implementing basic functionality for handling value changes, it also has the appropriate flags for
-    /// implementing the concept of "canceling" event during the pre-change event, which if supported by the event, allows the event
-    /// handler to stop the change from occuring and prevent other handlers from running.
-    ///
-    /// It also supports the concept of "handling" an event during the "changed" event, which, if supported by the event,
-    /// allows one event handler to mark the event as "handled" and stop other event handlers from being run.
-    /// </remarks>
-    /// <typeparam name="TProperty">Type of the property changed.</typeparam>
-    public class ValueChangingEventArgs<TProperty> : EventArgs
-    {
-        /// <summary>
-        /// Previous value of property.
-        /// </summary>
-        public readonly TProperty OldValue;
-
-        /// <summary>
-        /// New value of property.
-        /// </summary>
-        public readonly TProperty NewValue;
-
-        /// <summary>
-        /// When <see langword="true"/>, indicates this value change can be cancelled; otherwise <see langword="false"/>.
-        /// </summary>
-        public readonly bool SupportsCancel;
-
-        /// <summary>
-        /// When <see cref="SupportsCancel"/> is <see langword="true"/>, setting this property to <see langword="true"/>
-        /// causes the value change to be cancelled and to stop processing further event handlers for this change.
-        /// </summary>
-        public bool IsCancelled { get; set; }
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="oldValue">Previous value of property.</param>
-        /// <param name="newValue">New value of property.</param>
-        /// <param name="supportsCancel">When <see langword="true"/>, indicates this value change can be cancelled; otherwise <see langword="false"/>.</param>
-        public ValueChangingEventArgs(TProperty oldValue, TProperty newValue, bool supportsCancel = false) =>
-            (OldValue, NewValue, SupportsCancel) = (oldValue, newValue, supportsCancel);
+        public ValueChangedEventArgs(TProperty oldValue, TProperty newValue)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
     }
 
 
     /// <summary>
-    /// Helper functions useful for implementing events using <see cref="ValueChangedEventArgs{TProperty}"/>
-    /// or <see cref="ValueChangingEventArgs{TProperty}"/> as their parameter.
+    /// Helper functions useful for implementing events using <see cref="ValueChangedEventArgs{TProperty}"/> as their parameter.
     /// </summary>
     public static class PropertyChangedEventHelpers
     {
@@ -134,7 +76,7 @@ namespace SadRogue.Primitives
         ///         get => _myProperty;
         ///         set => this.SafelySetProperty(ref _myProperty, value, MyPropertyChanged);
         ///     }
-        ///     public event EventHandler&lt;ObjectPropertyChanged&lt;int&gt;&gt;? MyPropertyChanged;
+        ///     public event EventHandler&lt;ValueChangedEventArgs&lt;int&gt;&gt;? MyPropertyChanged;
         /// }
         /// </code>
         ///</example>
@@ -143,12 +85,10 @@ namespace SadRogue.Primitives
         /// <param name="propertyField">Field to set.</param>
         /// <param name="newValue">New value to set to given field.</param>
         /// <param name="changedEvent">Event to fire when change occurs.</param>
-        /// <param name="supportsHandled">When <see langword="true"/>, indicates this value change can be flagged as handled and stop further event handlers; otherwise <see langword="false"/>.</param>
         /// <typeparam name="TObject">Type of the object the property resides on.</typeparam>
         /// <typeparam name="TProperty">Type of the property.</typeparam>
         public static void SafelySetProperty<TObject, TProperty>(this TObject self, ref TProperty propertyField, TProperty newValue,
-                                                EventHandler<ValueChangedEventArgs<TProperty>>? changedEvent,
-                                                bool supportsHandled = false)
+                                                EventHandler<ValueChangedEventArgs<TProperty>>? changedEvent)
             where TObject : notnull
         {
             // Nothing to do; the value hasn't changed
@@ -163,23 +103,7 @@ namespace SadRogue.Primitives
             propertyField = newValue;
             try
             {
-                if (changedEvent != null)
-                {
-                    var args = new ValueChangedEventArgs<TProperty>(oldValue, newValue, supportsHandled);
-                    if (supportsHandled)
-                    {
-                        foreach (var del in changedEvent.GetInvocationList())
-                        {
-                            var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
-                            handler(self, args);
-                            if (args.IsHandled)
-                                return;
-                        }
-                    }
-                    else // This is faster than the foreach loop above, so we should have a special case for this
-                        changedEvent.Invoke(self, args);
-                }
-
+                changedEvent?.Invoke(self, new ValueChangedEventArgs<TProperty>(oldValue, newValue));
             }
             catch (InvalidOperationException)
             {
@@ -191,30 +115,19 @@ namespace SadRogue.Primitives
 
         /// <summary>
         /// Sets the given field to the new value, and fires the corresponding events.  The value will be properly
-        /// reverted to the old value if the Changed event handler throws InvalidOperationException or if the "changing"
-        /// event supports cancellation and is cancelled.  The "changing" event will be fired just _before_ the value actually changes;
-        /// the "changed" event will be fired just after.
+        /// reverted to the old value if the Changed event handler throws InvalidOperationException.  The "changing"
+        /// event will be fired just _before_ the value actually changes; the "changed" event will be fired just after.
         /// </summary>
         /// <param name="self" />
         /// <param name="propertyField">Field to set.</param>
         /// <param name="newValue">New value to set to given field.</param>
         /// <param name="changingEvent">Event to fire when change is about to occur.</param>
         /// <param name="changedEvent">Event to fire after change occurs.</param>
-        /// <param name="changingSupportsCancel">
-        /// When <see langword="true"/>, indicates that, during the <paramref name="changingEvent"/> event, this value
-        /// change can be cancelled, which stops future changing handlers and prevents the <paramref name="changedEvent"/>
-        /// from firing; otherwise <see langword="false"/>.
-        /// </param>
-        /// <param name="changedSupportsHandled">
-        /// When <see langword="true"/>, indicates that, during the <paramref name="changedEvent"/> event, this value change
-        /// can be flagged as handled and stop further event handlers; otherwise <see langword="false"/>.
-        /// </param>
         /// <typeparam name="TObject">Type of the object the property resides on.</typeparam>
         /// <typeparam name="TProperty">Type of the property.</typeparam>
         public static void SafelySetProperty<TObject, TProperty>(this TObject self, ref TProperty propertyField, TProperty newValue,
-                                                                 EventHandler<ValueChangingEventArgs<TProperty>>? changingEvent,
-                                                                 EventHandler<ValueChangedEventArgs<TProperty>>? changedEvent,
-                                                                 bool changingSupportsCancel = false, bool changedSupportsHandled = false)
+                                                                 EventHandler<ValueChangedEventArgs<TProperty>>? changingEvent,
+                                                                 EventHandler<ValueChangedEventArgs<TProperty>>? changedEvent)
             where TObject : notnull
         {
             // Nothing to do; the value hasn't changed
@@ -225,47 +138,17 @@ namespace SadRogue.Primitives
             else if (propertyField.Equals(newValue)) return;
 
             // Create event arguments
-            var changingArgs = new ValueChangingEventArgs<TProperty>(propertyField, newValue, changingSupportsCancel);
+            var args = new ValueChangedEventArgs<TProperty>(propertyField, newValue);
 
             // Fire "pre-change" event
-            if (changingEvent != null)
-            {
-                if (changingSupportsCancel)
-                {
-                    foreach (var del in changingEvent.GetInvocationList())
-                    {
-                        var handler = (EventHandler<ValueChangingEventArgs<TProperty>>)del;
-                        handler(self, changingArgs);
-                        if (changingArgs.IsCancelled)
-                            return;
-                    }
-                }
-                else // This is faster than the foreach loop above, so we should have a special case for this
-                    changingEvent.Invoke(self, changingArgs);
-            }
+            changingEvent?.Invoke(self, args);
 
             // Set new value and fire event
             var oldValue = propertyField;
             propertyField = newValue;
             try
             {
-                if (changedEvent != null)
-                {
-                    var changedArgs = new ValueChangedEventArgs<TProperty>(oldValue, newValue, changedSupportsHandled);
-                    if (changedSupportsHandled)
-                    {
-                        foreach (var del in changedEvent.GetInvocationList())
-                        {
-                            var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
-                            handler(self, changedArgs);
-                            if (changedArgs.IsHandled)
-                                return;
-                        }
-                    }
-                    else // This is faster than the foreach loop above, so we should have a special case for this
-                        changedEvent.Invoke(self, changedArgs);
-                }
-
+                changedEvent?.Invoke(self, args);
             }
             catch (InvalidOperationException)
             {

--- a/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
+++ b/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
@@ -1,0 +1,157 @@
+﻿using System;
+
+namespace SadRogue.Primitives
+{
+    /// <summary>
+    /// Event arguments for an event fired when an object's properties are changed.  Often used with
+    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ObjectPropertyChanged{TProperty}}?)"/>
+    /// and other overloads of that function.
+    /// </summary>
+    /// <remarks>
+    /// It is fairly common to have an event that is fired when a property is changed; a common use case relative to
+    /// 2D grids is objects that have a position and fire an event when that position changes. This class encapsulates a
+    /// generic event argument for such occurrences.
+    /// </remarks>
+    /// <typeparam name="TProperty">Type of the property changed.</typeparam>
+    public class ObjectPropertyChanged<TProperty> : EventArgs
+    {
+        /// <summary>
+        /// Previous value of property.
+        /// </summary>
+        public readonly TProperty OldValue;
+
+        /// <summary>
+        /// New value of property.
+        /// </summary>
+        public readonly TProperty NewValue;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="oldValue">Previous value of property.</param>
+        /// <param name="newValue">New value of property.</param>
+        public ObjectPropertyChanged(TProperty oldValue, TProperty newValue)
+        {
+            OldValue = oldValue;
+            NewValue = newValue;
+        }
+    }
+
+    /// <summary>
+    /// Helper functions useful for implementing events using <see cref="ObjectPropertyChanged{TProperty}"/> as
+    /// their parameter.
+    /// </summary>
+    public static class PropertyChangedEventHelpers
+    {
+        /// <summary>
+        /// Sets the given field to the new value, and fires the corresponding event just after the value has been changed.
+        /// The value will be properly reverted to the old value if the event handler throws InvalidOperationException.
+        /// </summary>
+        /// <remarks>
+        /// It is fairly common to have an object with a property, such that when the property changes, an event is fired.
+        /// <see cref="IPositionable"/> represents one such interface that is common when dealing with a 2D grid.
+        ///
+        /// Although the implementation of such a property is relatively trivial, there are a few subtle issues that
+        /// can occur:
+        /// - The event might be fired even if the property was set to the same value it is currently
+        /// - If a handler throws something like InvalidOperationException, the value may not be reverted properly.
+        ///
+        /// This function represents a convenient way to implement such a property.  An implementation using this property
+        /// might look like the example below.
+        ///
+        /// Note that this function can work for properties of any type; you could just as easily implement <see cref="IPositionable"/>
+        /// via this interface, for example.
+        ///
+        /// <example>
+        /// <code>
+        /// class MyClass
+        /// {
+        ///     private int _myProperty;
+        ///     public int MyProperty
+        ///     {
+        ///         get => _myProperty;
+        ///         set => this.SafelySetProperty(ref _myProperty, value, MyPropertyChanged);
+        ///     }
+        ///     public event EventHandler&lt;ObjectPropertyChanged&lt;int&gt;&gt;? MyPropertyChanged;
+        /// }
+        /// </code>
+        ///</example>
+        /// </remarks>
+        /// <param name="self" />
+        /// <param name="propertyField">Field to set.</param>
+        /// <param name="newValue">New value to set to given field.</param>
+        /// <param name="changedEvent">Event to fire when change occurs.</param>
+        /// <typeparam name="TObject">Type of the object the property resides on.</typeparam>
+        /// <typeparam name="TProperty">Type of the property.</typeparam>
+        public static void SafelySetProperty<TObject, TProperty>(this TObject self, ref TProperty propertyField, TProperty newValue,
+                                                EventHandler<ObjectPropertyChanged<TProperty>>? changedEvent)
+            where TObject : notnull
+        {
+            // Nothing to do; the value hasn't changed
+            if (propertyField is null)
+            {
+                if (newValue is null) return;
+            }
+            else if (propertyField.Equals(newValue)) return;
+
+            // Set new value and fire event
+            var oldValue = propertyField;
+            propertyField = newValue;
+            try
+            {
+                changedEvent?.Invoke(self, new ObjectPropertyChanged<TProperty>(oldValue, newValue));
+            }
+            catch (InvalidOperationException)
+            {
+                // If exception, preserve old value for future
+                propertyField = oldValue;
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Sets the given field to the new value, and fires the corresponding events.  The value will be properly
+        /// reverted to the old value if the Changed event handler throws InvalidOperationException.  The "changing"
+        /// event will be fired just _before_ the value actually changes; the "changed" event will be fired just after.
+        /// </summary>
+        /// <param name="self" />
+        /// <param name="propertyField">Field to set.</param>
+        /// <param name="newValue">New value to set to given field.</param>
+        /// <param name="changingEvent">Event to fire when change is about to occur.</param>
+        /// <param name="changedEvent">Event to fire after change occurs.</param>
+        /// <typeparam name="TObject">Type of the object the property resides on.</typeparam>
+        /// <typeparam name="TProperty">Type of the property.</typeparam>
+        public static void SafelySetProperty<TObject, TProperty>(this TObject self, ref TProperty propertyField, TProperty newValue,
+                                                                 EventHandler<ObjectPropertyChanged<TProperty>>? changingEvent,
+                                                                 EventHandler<ObjectPropertyChanged<TProperty>>? changedEvent)
+            where TObject : notnull
+        {
+            // Nothing to do; the value hasn't changed
+            if (propertyField is null)
+            {
+                if (newValue is null) return;
+            }
+            else if (propertyField.Equals(newValue)) return;
+
+            // Create event arguments
+            var eventArguments = new ObjectPropertyChanged<TProperty>(propertyField, newValue);
+
+            // Fire "pre-change" event
+            changingEvent?.Invoke(self, eventArguments);
+
+            // Set new value and fire event
+            var oldValue = propertyField;
+            propertyField = newValue;
+            try
+            {
+                changedEvent?.Invoke(self, eventArguments);
+            }
+            catch (InvalidOperationException)
+            {
+                // If exception, preserve old value for future
+                propertyField = oldValue;
+                throw;
+            }
+        }
+    }
+}

--- a/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
+++ b/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
@@ -163,21 +163,23 @@ namespace SadRogue.Primitives
             propertyField = newValue;
             try
             {
-                var args = new ValueChangedEventArgs<TProperty>(oldValue, newValue, supportsHandled);
-                if (changedEvent == null) return;
-
-                if (supportsHandled)
+                if (changedEvent != null)
                 {
-                    foreach (var del in changedEvent.GetInvocationList())
+                    var args = new ValueChangedEventArgs<TProperty>(oldValue, newValue, supportsHandled);
+                    if (supportsHandled)
                     {
-                        var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
-                        handler(self, args);
-                        if (args.IsHandled)
-                            return;
+                        foreach (var del in changedEvent.GetInvocationList())
+                        {
+                            var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
+                            handler(self, args);
+                            if (args.IsHandled)
+                                return;
+                        }
                     }
+                    else // This is faster than the foreach loop above, so we should have a special case for this
+                        changedEvent.Invoke(self, args);
                 }
-                else // This is faster than the foreach loop above, so we should have a special case for this
-                    changedEvent.Invoke(self, args);
+
             }
             catch (InvalidOperationException)
             {
@@ -247,21 +249,23 @@ namespace SadRogue.Primitives
             propertyField = newValue;
             try
             {
-                var changedArgs = new ValueChangedEventArgs<TProperty>(oldValue, newValue, changedSupportsHandled);
-                if (changedEvent == null) return;
-
-                if (changedSupportsHandled)
+                if (changedEvent != null)
                 {
-                    foreach (var del in changedEvent.GetInvocationList())
+                    var changedArgs = new ValueChangedEventArgs<TProperty>(oldValue, newValue, changedSupportsHandled);
+                    if (changedSupportsHandled)
                     {
-                        var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
-                        handler(self, changedArgs);
-                        if (changedArgs.IsHandled)
-                            return;
+                        foreach (var del in changedEvent.GetInvocationList())
+                        {
+                            var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
+                            handler(self, changedArgs);
+                            if (changedArgs.IsHandled)
+                                return;
+                        }
                     }
+                    else // This is faster than the foreach loop above, so we should have a special case for this
+                        changedEvent.Invoke(self, changedArgs);
                 }
-                else // This is faster than the foreach loop above, so we should have a special case for this
-                    changedEvent.Invoke(self, changedArgs);
+
             }
             catch (InvalidOperationException)
             {

--- a/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
+++ b/TheSadRogue.Primitives/PropertyChangedEventHelpers.cs
@@ -4,16 +4,20 @@ namespace SadRogue.Primitives
 {
     /// <summary>
     /// Event arguments for an event fired when an object's properties are changed.  Often used with
-    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ObjectPropertyChanged{TProperty}}?)"/>
+    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ValueChangedEventArgs{TProperty}}?,bool)"/>
     /// and other overloads of that function.
     /// </summary>
     /// <remarks>
     /// It is fairly common to have an event that is fired when a property is changed; a common use case relative to
     /// 2D grids is objects that have a position and fire an event when that position changes. This class encapsulates a
     /// generic event argument for such occurrences.
+    ///
+    /// In addition to implementing basic functionality for handling value changes, it also has the appropriate flags for
+    /// implementing the concept of "handling" an event; if supported by the event, this allows one event handler to
+    /// mark the event as "handled" and stop other event handlers from being run.
     /// </remarks>
     /// <typeparam name="TProperty">Type of the property changed.</typeparam>
-    public class ObjectPropertyChanged<TProperty> : EventArgs
+    public class ValueChangedEventArgs<TProperty> : EventArgs
     {
         /// <summary>
         /// Previous value of property.
@@ -26,20 +30,78 @@ namespace SadRogue.Primitives
         public readonly TProperty NewValue;
 
         /// <summary>
+        /// When <see langword="true"/>, indicates this value change can be flagged as handled and stop further event handlers; otherwise <see langword="false"/>.
+        /// </summary>
+        public readonly bool SupportsHandled;
+
+        /// <summary>
+        /// When <see cref="SupportsHandled"/> is <see langword="true"/>, setting this property to <see langword="true"/> flags this change as handled and to stop processing further event handlers.
+        /// </summary>
+        public bool IsHandled { get; set; }
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="oldValue">Previous value of property.</param>
         /// <param name="newValue">New value of property.</param>
-        public ObjectPropertyChanged(TProperty oldValue, TProperty newValue)
-        {
-            OldValue = oldValue;
-            NewValue = newValue;
-        }
+        /// <param name="supportsHandled">When <see langword="true"/>, indicates this value change can be flagged as handled and stop further event handlers.</param>
+        public ValueChangedEventArgs(TProperty oldValue, TProperty newValue, bool supportsHandled = false) =>
+            (OldValue, NewValue, SupportsHandled) = (oldValue, newValue, supportsHandled);
     }
 
     /// <summary>
-    /// Helper functions useful for implementing events using <see cref="ObjectPropertyChanged{TProperty}"/> as
-    /// their parameter.
+    /// Event arguments for an event fired when an object's properties are changed.  Often used with
+    /// <see cref="PropertyChangedEventHelpers.SafelySetProperty{TObject,TProperty}(TObject,ref TProperty,TProperty,System.EventHandler{SadRogue.Primitives.ValueChangingEventArgs{TProperty}}?,System.EventHandler{SadRogue.Primitives.ValueChangedEventArgs{TProperty}}?,bool,bool)"/>.
+    /// </summary>
+    /// <remarks>
+    /// It is fairly common to have an event that is fired when a property is changed and/or about to change; a common use case relative to
+    /// This class encapsulates a generic event argument for such occurrences.
+    ///
+    /// In addition to implementing basic functionality for handling value changes, it also has the appropriate flags for
+    /// implementing the concept of "canceling" event during the pre-change event, which if supported by the event, allows the event
+    /// handler to stop the change from occuring and prevent other handlers from running.
+    ///
+    /// It also supports the concept of "handling" an event during the "changed" event, which, if supported by the event,
+    /// allows one event handler to mark the event as "handled" and stop other event handlers from being run.
+    /// </remarks>
+    /// <typeparam name="TProperty">Type of the property changed.</typeparam>
+    public class ValueChangingEventArgs<TProperty> : EventArgs
+    {
+        /// <summary>
+        /// Previous value of property.
+        /// </summary>
+        public readonly TProperty OldValue;
+
+        /// <summary>
+        /// New value of property.
+        /// </summary>
+        public readonly TProperty NewValue;
+
+        /// <summary>
+        /// When <see langword="true"/>, indicates this value change can be cancelled; otherwise <see langword="false"/>.
+        /// </summary>
+        public readonly bool SupportsCancel;
+
+        /// <summary>
+        /// When <see cref="SupportsCancel"/> is <see langword="true"/>, setting this property to <see langword="true"/>
+        /// causes the value change to be cancelled and to stop processing further event handlers for this change.
+        /// </summary>
+        public bool IsCancelled { get; set; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="oldValue">Previous value of property.</param>
+        /// <param name="newValue">New value of property.</param>
+        /// <param name="supportsCancel">When <see langword="true"/>, indicates this value change can be cancelled; otherwise <see langword="false"/>.</param>
+        public ValueChangingEventArgs(TProperty oldValue, TProperty newValue, bool supportsCancel = false) =>
+            (OldValue, NewValue, SupportsCancel) = (oldValue, newValue, supportsCancel);
+    }
+
+
+    /// <summary>
+    /// Helper functions useful for implementing events using <see cref="ValueChangedEventArgs{TProperty}"/>
+    /// or <see cref="ValueChangingEventArgs{TProperty}"/> as their parameter.
     /// </summary>
     public static class PropertyChangedEventHelpers
     {
@@ -81,10 +143,12 @@ namespace SadRogue.Primitives
         /// <param name="propertyField">Field to set.</param>
         /// <param name="newValue">New value to set to given field.</param>
         /// <param name="changedEvent">Event to fire when change occurs.</param>
+        /// <param name="supportsHandled">When <see langword="true"/>, indicates this value change can be flagged as handled and stop further event handlers; otherwise <see langword="false"/>.</param>
         /// <typeparam name="TObject">Type of the object the property resides on.</typeparam>
         /// <typeparam name="TProperty">Type of the property.</typeparam>
         public static void SafelySetProperty<TObject, TProperty>(this TObject self, ref TProperty propertyField, TProperty newValue,
-                                                EventHandler<ObjectPropertyChanged<TProperty>>? changedEvent)
+                                                EventHandler<ValueChangedEventArgs<TProperty>>? changedEvent,
+                                                bool supportsHandled = false)
             where TObject : notnull
         {
             // Nothing to do; the value hasn't changed
@@ -99,7 +163,21 @@ namespace SadRogue.Primitives
             propertyField = newValue;
             try
             {
-                changedEvent?.Invoke(self, new ObjectPropertyChanged<TProperty>(oldValue, newValue));
+                var args = new ValueChangedEventArgs<TProperty>(oldValue, newValue, supportsHandled);
+                if (changedEvent == null) return;
+
+                if (supportsHandled)
+                {
+                    foreach (var del in changedEvent.GetInvocationList())
+                    {
+                        var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
+                        handler(self, args);
+                        if (args.IsHandled)
+                            return;
+                    }
+                }
+                else // This is faster than the foreach loop above, so we should have a special case for this
+                    changedEvent.Invoke(self, args);
             }
             catch (InvalidOperationException)
             {
@@ -111,19 +189,30 @@ namespace SadRogue.Primitives
 
         /// <summary>
         /// Sets the given field to the new value, and fires the corresponding events.  The value will be properly
-        /// reverted to the old value if the Changed event handler throws InvalidOperationException.  The "changing"
-        /// event will be fired just _before_ the value actually changes; the "changed" event will be fired just after.
+        /// reverted to the old value if the Changed event handler throws InvalidOperationException or if the "changing"
+        /// event supports cancellation and is cancelled.  The "changing" event will be fired just _before_ the value actually changes;
+        /// the "changed" event will be fired just after.
         /// </summary>
         /// <param name="self" />
         /// <param name="propertyField">Field to set.</param>
         /// <param name="newValue">New value to set to given field.</param>
         /// <param name="changingEvent">Event to fire when change is about to occur.</param>
         /// <param name="changedEvent">Event to fire after change occurs.</param>
+        /// <param name="changingSupportsCancel">
+        /// When <see langword="true"/>, indicates that, during the <paramref name="changingEvent"/> event, this value
+        /// change can be cancelled, which stops future changing handlers and prevents the <paramref name="changedEvent"/>
+        /// from firing; otherwise <see langword="false"/>.
+        /// </param>
+        /// <param name="changedSupportsHandled">
+        /// When <see langword="true"/>, indicates that, during the <paramref name="changedEvent"/> event, this value change
+        /// can be flagged as handled and stop further event handlers; otherwise <see langword="false"/>.
+        /// </param>
         /// <typeparam name="TObject">Type of the object the property resides on.</typeparam>
         /// <typeparam name="TProperty">Type of the property.</typeparam>
         public static void SafelySetProperty<TObject, TProperty>(this TObject self, ref TProperty propertyField, TProperty newValue,
-                                                                 EventHandler<ObjectPropertyChanged<TProperty>>? changingEvent,
-                                                                 EventHandler<ObjectPropertyChanged<TProperty>>? changedEvent)
+                                                                 EventHandler<ValueChangingEventArgs<TProperty>>? changingEvent,
+                                                                 EventHandler<ValueChangedEventArgs<TProperty>>? changedEvent,
+                                                                 bool changingSupportsCancel = false, bool changedSupportsHandled = false)
             where TObject : notnull
         {
             // Nothing to do; the value hasn't changed
@@ -134,17 +223,44 @@ namespace SadRogue.Primitives
             else if (propertyField.Equals(newValue)) return;
 
             // Create event arguments
-            var eventArguments = new ObjectPropertyChanged<TProperty>(propertyField, newValue);
+            var changingArgs = new ValueChangingEventArgs<TProperty>(propertyField, newValue, changingSupportsCancel);
 
             // Fire "pre-change" event
-            changingEvent?.Invoke(self, eventArguments);
+            if (changingEvent == null) return;
+
+            if (changingSupportsCancel)
+            {
+                foreach (var del in changingEvent.GetInvocationList())
+                {
+                    var handler = (EventHandler<ValueChangingEventArgs<TProperty>>)del;
+                    handler(self, changingArgs);
+                    if (changingArgs.IsCancelled)
+                        return;
+                }
+            }
+            else // This is faster than the foreach loop above, so we should have a special case for this
+                changingEvent.Invoke(self, changingArgs);
 
             // Set new value and fire event
             var oldValue = propertyField;
             propertyField = newValue;
             try
             {
-                changedEvent?.Invoke(self, eventArguments);
+                var changedArgs = new ValueChangedEventArgs<TProperty>(oldValue, newValue, changedSupportsHandled);
+                if (changedEvent == null) return;
+
+                if (changedSupportsHandled)
+                {
+                    foreach (var del in changedEvent.GetInvocationList())
+                    {
+                        var handler = (EventHandler<ValueChangedEventArgs<TProperty>>)del;
+                        handler(self, changedArgs);
+                        if (changedArgs.IsHandled)
+                            return;
+                    }
+                }
+                else // This is faster than the foreach loop above, so we should have a special case for this
+                    changedEvent.Invoke(self, changedArgs);
             }
             catch (InvalidOperationException)
             {

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncLayeredSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncLayeredSpatialMap.cs
@@ -1,0 +1,690 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using SadRogue.Primitives.Pooling;
+
+namespace SadRogue.Primitives.SpatialMaps
+{
+    /// <summary>
+    /// A version of <see cref="AdvancedLayeredSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
+    /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
+    /// in the spatial map when they move and that the position fields are updated if the spatial map's move functions
+    /// are used.
+    /// </summary>
+    /// <remarks>
+    /// This class automatically keeps the spatial map position of each object synced up with their
+    /// <see cref="IPositionable.Position"/> property; you may either use the Move functions of the spatial map,
+    /// in which case the Position fields of the objects are updated as appropriate, or you may change the Position
+    /// field, in which case the spatial map position is updated to match.
+    ///
+    /// If you want to manually control the positions of items in the spatial map, you should use
+    /// <see cref="AdvancedLayeredSpatialMap{T}"/> instead.
+    /// </remarks>
+    /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
+    public class AutoSyncAdvancedLayeredSpatialMap<T> : ISpatialMap<T>, IReadOnlyLayeredSpatialMap<T>
+        where T : class, IHasLayer, IPositionable
+    {
+        private readonly AdvancedLayeredSpatialMap<T> _layeredSpatialMap;
+
+        /// <inheritdoc />
+        public int Count => _layeredSpatialMap.Count;
+
+        /// <inheritdoc />
+        public IEnumerable<T> Items => _layeredSpatialMap.Items;
+
+        /// <inheritdoc />
+        public IEnumerable<Point> Positions => _layeredSpatialMap.Positions;
+
+        /// <inheritdoc />
+        public event EventHandler<ItemEventArgs<T>>? ItemAdded
+        {
+            add => _layeredSpatialMap.ItemAdded += value;
+            remove => _layeredSpatialMap.ItemAdded -= value;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<ItemMovedEventArgs<T>>? ItemMoved
+        {
+            add => _layeredSpatialMap.ItemMoved += value;
+            remove => _layeredSpatialMap.ItemMoved -= value;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<ItemEventArgs<T>>? ItemRemoved
+        {
+            add => _layeredSpatialMap.ItemRemoved += value;
+            remove => _layeredSpatialMap.ItemRemoved -= value;
+        }
+
+        /// <inheritdoc />
+        public LayerMasker LayerMasker => _layeredSpatialMap.LayerMasker;
+
+        /// <inheritdoc />
+        public IEnumerable<IReadOnlySpatialMap<T>> Layers => _layeredSpatialMap.Layers;
+
+        /// <inheritdoc />
+        public int NumberOfLayers => _layeredSpatialMap.NumberOfLayers;
+
+        /// <inheritdoc />
+        public int StartingLayer => _layeredSpatialMap.StartingLayer;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="itemComparer">
+        /// Equality comparer to use for comparison and hashing of type T. Be especially mindful of the
+        /// efficiency of its GetHashCode function, as it will determine the efficiency of
+        /// many AdvancedLayeredSpatialMap functions.
+        /// </param>
+        /// <param name="numberOfLayers">Number of layers to include.</param>
+        /// <param name="customListPoolCreator">
+        /// A function used to determine the list pool implementation used for the spatial maps which support multiple
+        /// items in a location (if any).  The function takes the layer it is creating the pool for as a parameter.
+        /// If no custom creator is specified, a ListPool is used.
+        /// </param>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many AdvancedLayeredSpatialMap functions.  Defaults to the default equality
+        /// comparer for Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="startingLayer">Index to use for the first layer.</param>
+        /// <param name="layersSupportingMultipleItems">
+        /// A layer mask indicating which layers should support multiple items residing at the same
+        /// location on that layer. Defaults to no layers.
+        /// </param>
+        public AutoSyncAdvancedLayeredSpatialMap(IEqualityComparer<T> itemComparer,
+                                         int numberOfLayers, Func<int, IListPool<T>>? customListPoolCreator = null,
+                                         IEqualityComparer<Point>? pointComparer = null, int startingLayer = 0,
+                                         uint layersSupportingMultipleItems = 0)
+        {
+            _layeredSpatialMap = new AdvancedLayeredSpatialMap<T>(itemComparer, numberOfLayers, customListPoolCreator,
+                pointComparer, startingLayer, layersSupportingMultipleItems);
+
+            _layeredSpatialMap.ItemAdded += OnItemAdded;
+            _layeredSpatialMap.ItemRemoved += OnItemRemoved;
+        }
+
+        #region Enumeration
+        /// <summary>
+        /// Used by foreach loop, so that the class will give ISpatialTuple objects when used in a
+        /// foreach loop. Generally should never be called explicitly.
+        /// </summary>
+        /// <returns>An enumerator for the spatial map</returns>
+        public IEnumerator<ItemPositionPair<T>> GetEnumerator() => _layeredSpatialMap.GetEnumerator();
+
+        /// <summary>
+        /// Generic iterator used internally by foreach loops.
+        /// </summary>
+        /// <returns>Enumerator to ISpatialTuple instances.</returns>
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_layeredSpatialMap).GetEnumerator();
+        #endregion
+
+        /// <inheritdoc />
+        public IReadOnlyLayeredSpatialMap<T> AsReadOnly() => _layeredSpatialMap.AsReadOnly();
+
+        IReadOnlySpatialMap<T> IReadOnlySpatialMap<T>.AsReadOnly() => _layeredSpatialMap.AsReadOnly();
+
+        #region Add
+
+        /// <summary>
+        /// Returns true if the given item can be added at its current position, eg. it is on a layer in the spatial map and its
+        /// layer will accept it; false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <returns>True if the item can be successfully added at its current position; false otherwise.</returns>
+        public bool CanAdd(T newItem) => _layeredSpatialMap.CanAdd(newItem, newItem.Position);
+
+        /// <summary>
+        /// Returns true if the given item can be added at the given position, eg. it is on a layer in the spatial map and its
+        /// layer will accept it; false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <param name="position">Position to add item to.</param>
+        /// <returns>True if the item can be successfully added at the position given; false otherwise.</returns>
+        public bool CanAdd(T newItem, Point position) => _layeredSpatialMap.CanAdd(newItem, position);
+
+        /// <summary>
+        /// Returns true if the given item can be added at the given position, eg. it is on a layer in the spatial map and its
+        /// layer will accept it; false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <param name="x">X-value of the position to add item to.</param>
+        /// <param name="y">Y-value of the position to add item to.</param>
+        /// <returns>True if the item can be successfully added at the position given; false otherwise.</returns>
+        public bool CanAdd(T newItem, int x, int y) => _layeredSpatialMap.CanAdd(newItem, x, y);
+
+        /// <summary>
+        /// Adds the given item at its position on the correct layer.  ArgumentException is thrown if the layer is
+        /// invalid or the item otherwise cannot be added to its layer.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        public void Add(T item) => _layeredSpatialMap.Add(item, item.Position);
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map on the
+        /// correct layer.  ArgumentException is thrown if the layer is invalid or the item otherwise cannot be added to
+        /// its layer.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="position">Position to add item at.</param>
+        public void Add(T item, Point position)
+        {
+            item.Position = position;
+            _layeredSpatialMap.Add(item, position);
+        }
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map on the
+        /// correct layer.  ArgumentException is thrown if the layer is invalid or the item otherwise cannot be added to
+        /// its layer.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="x">X-value of position to add item at.</param>
+        /// <param name="y">Y-value of position to add item at.</param>
+        public void Add(T item, int x, int y) => Add(item, new Point(x, y));
+
+        /// <summary>
+        /// Adds the given item at its position on the correct layer.  Returns false if the layer is
+        /// invalid or the item otherwise cannot be added to its layer.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        public bool TryAdd(T item) => _layeredSpatialMap.TryAdd(item, item.Position);
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map on the
+        /// correct layer.  If the layer is invalid or the item otherwise cannot be added to its layer, does nothing and
+        /// returns false.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="position">Position to add item at.</param>
+        /// <returns>True if the item was added, false otherwise.</returns>
+        public bool TryAdd(T item, Point position)
+        {
+            if (!_layeredSpatialMap.TryAdd(item, position))
+                return false;
+
+            item.Position = position;
+            return true;
+        }
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map on the
+        /// correct layer.  If the layer is invalid or the item otherwise cannot be added to its layer, does nothing and
+        /// returns false.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="x">X-value of position to add item at.</param>
+        /// <param name="y">Y-value of position to add item at.</param>
+        /// <returns>True if the item was added, false otherwise.</returns>
+        public bool TryAdd(T item, int x, int y) => TryAdd(item, new Point(x, y));
+        #endregion
+
+        #region Move
+        /// <summary>
+        /// Returns true if the given item can be moved from its current location to the specified one, eg. it is in the spatial
+        /// map and its layer will accept it at the new position; false otherwise.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="target">Location to move item to.</param>
+        /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
+        public bool CanMove(T item, Point target) => _layeredSpatialMap.CanMove(item, target);
+
+        /// <summary>
+        /// Returns true if the given item can be moved from its current location to the specified one, eg. it is in the spatial
+        /// map and its layer will
+        /// accept it at the new position; false otherwise.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="targetX">X-value of the location to move item to.</param>
+        /// <param name="targetY">Y-value of the location to move item to.</param>
+        /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
+        public bool CanMove(T item, int targetX, int targetY) => _layeredSpatialMap.CanMove(item, targetX, targetY);
+
+        /// <inheritdoc />
+        public bool CanMoveAll(Point current, Point target, uint layerMask = uint.MaxValue) => _layeredSpatialMap.CanMoveAll(current, target, layerMask);
+
+        /// <inheritdoc />
+        public bool CanMoveAll(int currentX, int currentY, int targetX, int targetY, uint layerMask = uint.MaxValue) => _layeredSpatialMap.CanMoveAll(currentX, currentY, targetX, targetY, layerMask);
+
+        /// <inheritdoc />
+        bool IReadOnlySpatialMap<T>.CanMoveAll(Point current, Point target) => _layeredSpatialMap.CanMoveAll(current, target);
+
+        /// <inheritdoc />
+        bool IReadOnlySpatialMap<T>.CanMoveAll(int currentX, int currentY, int targetX, int targetY) => _layeredSpatialMap.CanMoveAll(currentX, currentY, targetX, targetY);
+
+        /// <summary>
+        /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
+        /// accordingly. Throws ArgumentException if either the item given
+        /// isn't in the spatial map, or if the layer that the item resides on is configured to allow only one item per
+        /// location at any given time and there is already an item at <paramref name="target" />.
+        /// </summary>
+        /// <param name="item">The item to move.</param>
+        /// <param name="target">Position to move the given item to.</param>
+        public void Move(T item, Point target)
+        {
+            item.Position = target;
+        }
+
+        /// <summary>
+        /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
+        /// accordingly. Throws ArgumentException if either the item given
+        /// isn't in the spatial map, or if the layer that the item resides on is configured to allow only one item per
+        /// location at any given time and there is already an item at the target position.
+        /// </summary>
+        /// <param name="item">The item to move.</param>
+        /// <param name="targetX">X-value of position to move the given item to.</param>
+        /// <param name="targetY">Y-value of position to move the given item to.</param>
+        public void Move(T item, int targetX, int targetY)
+        {
+            item.Position = new Point(targetX, targetY);
+        }
+
+        /// <inheritdoc />
+        public bool TryMove(T item, Point target)
+        {
+            if (!_layeredSpatialMap.TryMove(item, target))
+                return false;
+
+            item.Position = target;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public bool TryMove(T item, int targetX, int targetY) => TryMove(item, new Point(targetX, targetY));
+
+        /// <summary>
+        /// Moves all items that are on layers in <paramref name="layerMask" /> at the specified source location to the target
+        /// location, updating their <see cref="IPositionable.Position"/> fields accordingly.  Throws ArgumentException
+        /// if one or more items cannot be moved or there are no items to be moved.
+        /// </summary>
+        /// <param name="current">Location to move items from.</param>
+        /// <param name="target">Location to move items to.</param>
+        /// <param name="layerMask">The layer mask to use to find items.</param>
+        public void MoveAll(Point current, Point target, uint layerMask = uint.MaxValue)
+        {
+            var moved = _layeredSpatialMap.GetItemsAt(current, layerMask).ToArray();
+
+            // It will be better to call MoveAll/MoveValid, rather than depend on the position updates, since this can save
+            // an entire list's worth of allocation if the underlying map being moved is a MultiSpatialMap.
+            //
+            // Since MoveAll is not generally considered to be a function you should call if the possibility of failure
+            // is expected, we'll get a list of the things we're going to move first and use the MoveAll implementation
+            // of LayeredSpatialMap which avoids the allocation of something like MoveValid.
+            _layeredSpatialMap.MoveAll(current, target, layerMask);
+
+            foreach (var item in moved)
+                item.Position = target;
+        }
+
+        /// <summary>
+        /// Moves all items that are on layers in <paramref name="layerMask" /> at the specified source location to the target
+        /// location, updating their <see cref="IPositionable.Position"/> fields accordingly.  Throws ArgumentException
+        /// if one or more items cannot be moved or there are no items to be moved.
+        /// </summary>
+        /// <param name="currentX">X-value of the location to move items from.</param>
+        /// <param name="currentY">Y-value of the location to move items from.</param>
+        /// <param name="targetX">X-value of the location to move items to.</param>
+        /// <param name="targetY">Y-value of the location to move items to.</param>
+        /// <param name="layerMask">The layer mask to use to find items.</param>
+        public void MoveAll(int currentX, int currentY, int targetX, int targetY, uint layerMask = uint.MaxValue)
+            => MoveAll(new Point(currentX, currentY), new Point(targetX, targetY), layerMask);
+
+        /// <inheritdoc />
+        void ISpatialMap<T>.MoveAll(Point current, Point target) => MoveAll(current, target);
+
+        /// <inheritdoc />
+        void ISpatialMap<T>.MoveAll(int currentX, int currentY, int targetX, int targetY)
+            => MoveAll(new Point(currentX, currentY), new Point(targetX, targetY));
+
+        /// <summary>
+        /// Moves all items that are on layers in <paramref name="layerMask" /> at the specified source location to the
+        /// target location, updating their Position fields accordingly.  Returns false and moves nothing if one or more
+        /// items cannot be moved or there are no items to be moved.
+        /// </summary>
+        /// <param name="current">Location to move items from.</param>
+        /// <param name="target">Location to move items to.</param>
+        /// <param name="layerMask">The layer mask to use to find items.</param>
+        /// <returns>
+        /// True if all items at <paramref name="current"/> on layers within the mask given were moved to
+        /// <paramref name="target"/>; false otherwise.
+        /// </returns>
+        public bool TryMoveAll(Point current, Point target, uint layerMask = uint.MaxValue)
+        {
+            // It will be better to call MoveValid, rather than depend on the position updates, since this can save
+            // an entire list's worth of allocation if the underlying map being moved is a MultiSpatialMap.
+            //
+            // LayeredSpatialMap implements MoveAll by checking if all items can move first, then moving them.
+            // In order to save some enumeration, we'll replicate that functionality here but use MoveValid once we
+            // know all items to can move, as an efficient way of generating the list of things we moved.
+            //
+            // This is also consistent with TryMoveAll being a function you call if failure is a potentially expected
+            // outcome; by checking first, we delay allocation of any arrays or lists until we're sure we need to allocate
+            // them.
+            if (!_layeredSpatialMap.CanMoveAll(current, target, layerMask))
+                return false;
+
+            var moved = _layeredSpatialMap.MoveValid(current, target, layerMask);
+
+            foreach (var item in moved)
+                item.Position = target;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Moves all items that are on layers in <paramref name="layerMask" /> at the specified source location to the
+        /// target location, updating their Position fields accordingly.  Returns false and moves nothing if one or more
+        /// items cannot be moved or there are no items to be moved.
+        /// </summary>
+        /// <param name="currentX">X-value of the location to move items from.</param>
+        /// <param name="currentY">Y-value of the location to move items from.</param>
+        /// <param name="targetX">X-value of the location to move items to.</param>
+        /// <param name="targetY">Y-value of the location to move items to.</param>
+        /// <param name="layerMask">The layer mask to use to find items.</param>
+        /// <returns>
+        /// True if all items at the current position on layers within the mask given were moved to
+        /// the target position; false otherwise.
+        /// </returns>
+        public bool TryMoveAll(int currentX, int currentY, int targetX, int targetY, uint layerMask = uint.MaxValue)
+            => TryMoveAll(new Point(currentX, currentY), new Point(targetX, targetY), layerMask);
+
+        /// <inheritdoc />
+        bool ISpatialMap<T>.TryMoveAll(Point current, Point target) => TryMoveAll(current, target);
+
+        /// <inheritdoc />
+        bool ISpatialMap<T>.TryMoveAll(int currentX, int currentY, int targetX, int targetY)
+            => TryMoveAll(new Point(currentX, currentY), new Point(targetX, targetY));
+
+        /// <summary>
+        /// Moves all items that can be moved, that are at the given position and on any layer specified by the given layer
+        /// mask, to the new position, updating their Position fields accordingly. If no layer mask is specified,
+        /// defaults to all layers.
+        /// </summary>
+        /// <param name="current">Position to move all items from.</param>
+        /// <param name="target">Position to move all items to.</param>
+        /// <param name="layerMask">
+        /// Layer mask specifying which layers to search for items on. Defaults to all layers.
+        /// </param>
+        /// <returns>All items moved.</returns>
+        public List<T> MoveValid(Point current, Point target, uint layerMask = uint.MaxValue)
+        {
+            var list = _layeredSpatialMap.MoveValid(current, target, layerMask);
+            foreach (var obj in list)
+                obj.Position = target;
+
+            return list;
+        }
+
+        /// <summary>
+        /// Moves all items that can be moved, that are at the given position and on any layer specified by the given layer
+        /// mask, to the new position, updating their Position fields accordingly. If no layer mask is specified,
+        /// defaults to all layers.
+        /// </summary>
+        /// <param name="currentX">X-value of the position to move items from.</param>
+        /// <param name="currentY">Y-value of the position to move items from.</param>
+        /// <param name="targetX">X-value of the position to move items to.</param>
+        /// <param name="targetY">Y-value of the position to move items from.</param>
+        /// <param name="layerMask">
+        /// Layer mask specifying which layers to search for items on. Defaults to all layers.
+        /// </param>
+        /// <returns>All items moved.</returns>
+        public List<T> MoveValid(int currentX, int currentY, int targetX, int targetY, uint layerMask = uint.MaxValue)
+            => MoveValid(new Point(currentX, currentY), new Point(targetX, targetY), layerMask);
+
+        /// <summary>
+        /// Moves all items that can be moved, that are at the given position and on any layer specified by the given layer
+        /// mask, to the new position, updating their Position fields accordingly. If no layer mask is specified,
+        /// defaults to all layers.
+        /// </summary>
+        /// <param name="current">Position to move items from.</param>
+        /// <param name="target">Position to move items to.</param>
+        /// <param name="itemsMovedOutput">List in which to place all moved items.</param>
+        /// <param name="layerMask">
+        /// Layer mask specifying which layers to search for items on. Defaults to all layers.
+        /// </param>
+        public void MoveValid(Point current, Point target, List<T> itemsMovedOutput, uint layerMask = uint.MaxValue)
+        {
+            int idx = itemsMovedOutput.Count;
+            _layeredSpatialMap.MoveValid(current, target, itemsMovedOutput, layerMask);
+
+            int count = itemsMovedOutput.Count;
+            for (int i = idx; i < count; i++)
+                itemsMovedOutput[i].Position = target;
+        }
+
+        /// <summary>
+        /// Moves all items that can be moved, that are at the given position and on any layer specified by the given layer
+        /// mask, to the new position, updating their Position fields accordingly. If no layer mask is specified,
+        /// defaults to all layers.
+        /// </summary>
+        /// <param name="currentX">X-value of the position to move items from.</param>
+        /// <param name="currentY">Y-value of the position to move items from.</param>
+        /// <param name="targetX">X-value of the position to move items to.</param>
+        /// <param name="targetY">Y-value of the position to move items from.</param>
+        /// <param name="itemsMovedOutput">List in which to place all moved items.</param>
+        /// <param name="layerMask">
+        /// Layer mask specifying which layers to search for items on. Defaults to all layers.
+        /// </param>
+        public void MoveValid(int currentX, int currentY, int targetX, int targetY, List<T> itemsMovedOutput,
+                              uint layerMask = uint.MaxValue)
+            => MoveValid(new Point(currentX, currentY), new Point(targetX, targetY), itemsMovedOutput, layerMask);
+
+        List<T> ISpatialMap<T>.MoveValid(Point current, Point target)
+            => MoveValid(current, target);
+
+        void ISpatialMap<T>.MoveValid(Point current, Point target, List<T> itemsMovedOutput)
+            => MoveValid(current, target, itemsMovedOutput);
+
+        List<T> ISpatialMap<T>.MoveValid(int currentX, int currentY, int targetX, int targetY)
+            => MoveValid(new Point(currentX, currentY), new Point(targetX, targetY));
+
+        void ISpatialMap<T>.MoveValid(int currentX, int currentY, int targetX, int targetY, List<T> itemsMovedOutput)
+            => MoveValid(new Point(currentX, currentY), new Point(targetX, targetY), itemsMovedOutput);
+        #endregion
+
+        #region Contains
+        /// <inheritdoc />
+        public bool Contains(T item) => _layeredSpatialMap.Contains(item);
+
+        /// <inheritdoc />
+        bool IReadOnlySpatialMap<T>.Contains(Point position) => _layeredSpatialMap.Contains(position);
+
+        bool IReadOnlySpatialMap<T>.Contains(int x, int y) => _layeredSpatialMap.Contains(x, y);
+
+        /// <inheritdoc />
+        public bool Contains(Point position, uint layerMask = uint.MaxValue) => _layeredSpatialMap.Contains(position, layerMask);
+
+        /// <inheritdoc />
+        public bool Contains(int x, int y, uint layerMask = uint.MaxValue) => _layeredSpatialMap.Contains(x, y, layerMask);
+        #endregion
+
+        #region Get Items/Positions/Layers
+        /// <inheritdoc />
+        IEnumerable<T> IReadOnlySpatialMap<T>.GetItemsAt(Point position) => _layeredSpatialMap.GetItemsAt(position);
+
+        /// <inheritdoc />
+        IEnumerable<T> IReadOnlySpatialMap<T>.GetItemsAt(int x, int y) => _layeredSpatialMap.GetItemsAt(x, y);
+
+        /// <inheritdoc />
+        public IEnumerable<T> GetItemsAt(Point position, uint layerMask = uint.MaxValue) => _layeredSpatialMap.GetItemsAt(position, layerMask);
+
+        /// <inheritdoc />
+        public IEnumerable<T> GetItemsAt(int x, int y, uint layerMask = uint.MaxValue) => _layeredSpatialMap.GetItemsAt(x, y, layerMask);
+
+        /// <inheritdoc />
+        public Point? GetPositionOfOrNull(T item) => _layeredSpatialMap.GetPositionOfOrNull(item);
+
+        /// <inheritdoc />
+        public bool TryGetPositionOf(T item, out Point position) => _layeredSpatialMap.TryGetPositionOf(item, out position);
+
+        /// <inheritdoc />
+        public Point GetPositionOf(T item) => _layeredSpatialMap.GetPositionOf(item);
+
+        /// <inheritdoc />
+        public IReadOnlySpatialMap<T> GetLayer(int layer) => _layeredSpatialMap.GetLayer(layer);
+
+        /// <inheritdoc />
+        public IEnumerable<IReadOnlySpatialMap<T>> GetLayersInMask(uint layerMask = uint.MaxValue)
+            => _layeredSpatialMap.GetLayersInMask(layerMask);
+        #endregion
+
+        /// <summary>
+        /// Returns a string representation of the spatial map.
+        /// </summary>
+        /// <returns>A string representation of the spatial map.</returns>
+        public override string ToString() => _layeredSpatialMap.ToString();
+
+        /// <summary>
+        /// Returns a string representation of each item in the spatial map, with elements
+        /// displayed in the specified way.
+        /// </summary>
+        /// <param name="elementStringifier">
+        /// A function that takes an element of type T and produces the string that should
+        /// represent it in the output.
+        /// </param>
+        /// <returns>A string representing each layer in the spatial map, with each element displayed in the specified way.</returns>
+        public string ToString(Func<T, string> elementStringifier) => _layeredSpatialMap.ToString(elementStringifier);
+
+        #region Clear/Remove
+
+        /// <inheritdoc />
+        public void Clear() => _layeredSpatialMap.Clear();
+
+        /// <inheritdoc />
+        public void Remove(T item) => _layeredSpatialMap.Remove(item);
+
+        List<T> ISpatialMap<T>.Remove(Point position) => _layeredSpatialMap.Remove(position);
+
+        List<T> ISpatialMap<T>.Remove(int x, int y) => _layeredSpatialMap.Remove(x, y);
+
+        /// <inheritdoc />
+        public bool TryRemove(T item) => _layeredSpatialMap.TryRemove(item);
+        bool ISpatialMap<T>.TryRemove(Point position) => _layeredSpatialMap.TryRemove(position);
+
+        bool ISpatialMap<T>.TryRemove(int x, int y) => _layeredSpatialMap.TryRemove(x, y);
+
+        /// <summary>
+        /// Removes all items at the specified location that are on any layer included in the given
+        /// layer mask from the spatial map. Returns any items that were removed. Defaults to searching
+        /// for items on all layers.
+        /// </summary>
+        /// <param name="position">Position to remove items from.</param>
+        /// <param name="layerMask">
+        /// The layer mask indicating which layers to search for items. Defaults to all layers.
+        /// </param>
+        /// <returns>Any items that were removed, or nothing if no items were removed.</returns>
+        public List<T> Remove(Point position, uint layerMask = uint.MaxValue)
+            => _layeredSpatialMap.Remove(position, layerMask);
+
+        /// <summary>
+        /// Removes all items at the specified location that are on any layer included in the given
+        /// layer mask from the spatial map. Returns any items that were removed. Defaults to searching
+        /// for items on all layers.
+        /// </summary>
+        /// <param name="x">X-value of the position to remove items from.</param>
+        /// <param name="y">Y-value of the position to remove items from.</param>
+        /// <param name="layerMask">
+        /// The layer mask indicating which layers to search for items. Defaults to all layers.
+        /// </param>
+        /// <returns>Any items that were removed, or nothing if no items were removed.</returns>
+        public List<T> Remove(int x, int y, uint layerMask = uint.MaxValue)
+            => _layeredSpatialMap.Remove(x, y, layerMask);
+
+        /// <summary>
+        /// Attempts to remove all items at the specified location that are on any layer included in the given
+        /// layer mask from the spatial map. Returns true if the items were successfully removed; false if one or more
+        /// failed.
+        /// </summary>
+        /// <param name="position">Position to remove items from.</param>
+        /// <param name="layerMask">
+        /// The layer mask indicating which layers to search for items. Defaults to all layers.
+        /// </param>
+        /// <returns>True if the items were successfully removed; false otherwise</returns>
+        public bool TryRemove(Point position, uint layerMask = uint.MaxValue)
+            => _layeredSpatialMap.TryRemove(position, layerMask);
+
+        /// <summary>
+        /// Attempts to remove all items at the specified location that are on any layer included in the given
+        /// layer mask from the spatial map. Returns true if the items were successfully removed; false if one or more
+        /// failed.
+        /// </summary>
+        /// <param name="x">X-value of the position to remove items from.</param>
+        /// <param name="y">Y-value of the position to remove items from.</param>
+        /// <param name="layerMask">
+        /// The layer mask indicating which layers to search for items. Defaults to all layers.
+        /// </param>
+        /// <returns>True if the items were successfully removed; false otherwise</returns>
+        public bool TryRemove(int x, int y, uint layerMask = uint.MaxValue)
+            => _layeredSpatialMap.TryRemove(x, y, layerMask);
+        #endregion
+
+        #region Item Handlers
+        private void OnItemAdded(object? sender, ItemEventArgs<T> e)
+        {
+            e.Item.PositionChanging += ItemOnPositionChanging;
+        }
+
+        private void ItemOnPositionChanging(object? sender, ValueChangedEventArgs<Point> e)
+        {
+            if (sender != null)
+                _layeredSpatialMap.Move((T)sender, e.NewValue);
+        }
+
+        private void OnItemRemoved(object? sender, ItemEventArgs<T> e)
+        {
+            e.Item.PositionChanging -= ItemOnPositionChanging;
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// A version of <see cref="LayeredSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
+    /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
+    /// in the spatial map when they move and that the position fields are updated if the spatial map's move functions
+    /// are used.
+    /// </summary>
+    /// <remarks>
+    /// This class automatically keeps the spatial map position of each object synced up with their
+    /// <see cref="IPositionable.Position"/> property; you may either use the Move functions of the spatial map,
+    /// in which case the Position fields of the objects are updated as appropriate, or you may change the Position
+    /// field, in which case the spatial map position is updated to match.
+    ///
+    /// If you want to manually control the positions of items in the spatial map, you should use
+    /// <see cref="LayeredSpatialMap{T}"/> instead.
+    /// </remarks>
+    /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
+    public sealed class AutoSyncLayeredSpatialMap<T> : AutoSyncAdvancedLayeredSpatialMap<T>
+        where T : class, IHasID, IPositionable, IHasLayer
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="numberOfLayers">Number of layers to include.</param>
+        /// <param name="customListPoolCreator">
+        /// A function used to determine the list pool implementation used for the spatial maps which support multiple
+        /// items in a location (if any).  The function takes the layer it is creating the pool for as a parameter.
+        /// If no custom creator is specified, a ListPool is used.
+        /// </param>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many AdvancedLayeredSpatialMap functions.  Defaults to the default equality
+        /// comparer for Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="startingLayer">Index to use for the first layer.</param>
+        /// <param name="layersSupportingMultipleItems">
+        /// A layer mask indicating which layers should support multiple items residing at the same
+        /// location on that layer. Defaults to no layers.
+        /// </param>
+        public AutoSyncLayeredSpatialMap(int numberOfLayers,
+                                         Func<int, IListPool<T>>? customListPoolCreator = null,
+                                         IEqualityComparer<Point>? pointComparer = null, int startingLayer = 0,
+                                         uint layersSupportingMultipleItems = 0)
+            : base(new IDComparer<T>(), numberOfLayers, customListPoolCreator, pointComparer, startingLayer,
+                layersSupportingMultipleItems)
+        { }
+    }
+}

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncLayeredSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncLayeredSpatialMap.cs
@@ -265,6 +265,10 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <param name="target">Position to move the given item to.</param>
         public void Move(T item, Point target)
         {
+            if (!Contains(item)) throw new ArgumentException(
+                $"Tried to move item in {GetType().Name}, but the item does not exist.",
+                nameof(item));
+
             item.Position = target;
         }
 

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -1,0 +1,461 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using SadRogue.Primitives.Pooling;
+
+namespace SadRogue.Primitives.SpatialMaps
+{
+    /// <summary>
+    /// A version of <see cref="AdvancedMultiSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
+    /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
+    /// in the spatial map when they move.
+    /// </summary>
+    /// <remarks>
+    /// You should not call the <see cref="ISpatialMap{T}.Move(T,SadRogue.Primitives.Point)"/> function (or any similar
+    /// functions) on an instance of this class; they will throw an exception.  This class automatically keeps items
+    /// synced up with their <see cref="IPositionable.Position"/> property.  If you need to manually control the
+    /// positions, you should use <see cref="AdvancedMultiSpatialMap{T}"/> instead.
+    /// </remarks>
+    /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
+    public class AutoSyncAdvancedMultiSpatialMap<T> : ISpatialMap<T>
+        where T : IPositionable
+    {
+        private readonly AdvancedMultiSpatialMap<T> _multiSpatialMap;
+
+        /// <inheritdoc />
+        public int Count => _multiSpatialMap.Count;
+
+        /// <inheritdoc />
+        public IEnumerable<T> Items => _multiSpatialMap.Items;
+
+        /// <inheritdoc />
+        public IEnumerable<Point> Positions => _multiSpatialMap.Positions;
+
+        /// <inheritdoc />
+        public event EventHandler<ItemEventArgs<T>>? ItemAdded
+        {
+            add => _multiSpatialMap.ItemAdded += value;
+            remove => _multiSpatialMap.ItemAdded -= value;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<ItemMovedEventArgs<T>>? ItemMoved
+        {
+            add => _multiSpatialMap.ItemMoved += value;
+            remove => _multiSpatialMap.ItemMoved -= value;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<ItemEventArgs<T>>? ItemRemoved
+        {
+            add => _multiSpatialMap.ItemRemoved += value;
+            remove => _multiSpatialMap.ItemRemoved -= value;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="itemComparer">
+        /// Equality comparer to use for comparison and hashing of type T. Be especially mindful of the
+        /// efficiency of its GetHashCode function, as it will determine the efficiency of many AdvancedMultiSpatialMap
+        /// functions.
+        /// </param>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many AdvancedMultiSpatialMap functions.  Defaults to the default equality
+        /// comparer for Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="initialCapacity">
+        /// The initial maximum number of elements the AdvancedMultiSpatialMap can hold before it has to
+        /// internally resize data structures. Defaults to 32.
+        /// </param>
+        public AutoSyncAdvancedMultiSpatialMap(IEqualityComparer<T> itemComparer, IEqualityComparer<Point>? pointComparer = null,
+                                               int initialCapacity = 32)
+            : this(itemComparer, new ListPool<T>(50, 16), pointComparer, initialCapacity)
+        { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="itemComparer">
+        /// Equality comparer to use for comparison and hashing of type T. Be especially mindful of the
+        /// efficiency of its GetHashCode function, as it will determine the efficiency of many AdvancedMultiSpatialMap
+        /// functions.
+        /// </param>
+        /// <param name="listPool">
+        /// The list pool implementation to use.  Specify <see cref="NoPoolingListPool{T}"/> to disable pooling entirely.
+        /// This implementation _may_ be shared with other spatial maps if you wish, however be aware that no thread safety is implemented
+        /// by the default list pool implementations or the spatial map itself.
+        /// </param>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many AdvancedMultiSpatialMap functions.  Defaults to the default equality
+        /// comparer for Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="initialCapacity">
+        /// The initial maximum number of elements the AdvancedMultiSpatialMap can hold before it has to
+        /// internally resize data structures. Defaults to 32.
+        /// </param>
+        public AutoSyncAdvancedMultiSpatialMap(IEqualityComparer<T> itemComparer, IListPool<T> listPool,
+                                               IEqualityComparer<Point>? pointComparer = null,
+                                               int initialCapacity = 32)
+        {
+            _multiSpatialMap = new AdvancedMultiSpatialMap<T>(itemComparer, listPool, pointComparer, initialCapacity);
+
+            _multiSpatialMap.ItemAdded += OnItemAdded;
+            _multiSpatialMap.ItemRemoved += OnItemRemoved;
+        }
+
+        #region Enumeration
+        /// <summary>
+        /// Used by foreach loop, so that the class will give ISpatialTuple objects when used in a
+        /// foreach loop. Generally should never be called explicitly.
+        /// </summary>
+        /// <returns>An enumerator for the spatial map.</returns>
+        public IEnumerator<ItemPositionPair<T>> GetEnumerator() => _multiSpatialMap.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_multiSpatialMap).GetEnumerator();
+        #endregion
+
+        /// <inheritdoc />
+        public IReadOnlySpatialMap<T> AsReadOnly() => _multiSpatialMap.AsReadOnly();
+
+        #region Add
+        /// <summary>
+        /// Returns true if the given item can be added at the given position, eg. if the item is not already in the spatial map;
+        /// false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <param name="position">Position to add item to.</param>
+        /// <returns>True if the item can be successfully added at the position given; false otherwise.</returns>
+        public bool CanAdd(T newItem, Point position) => _multiSpatialMap.CanAdd(newItem, position);
+
+        /// <summary>
+        /// Returns true if the given item can be added at the given position, eg. if the item is not already in the spatial map;
+        /// false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <param name="x">X-value of the position to add item to.</param>
+        /// <param name="y">Y-value of the position to add item to.</param>
+        /// <returns>True if the item can be successfully added at the position given; false otherwise.</returns>
+        public bool CanAdd(T newItem, int x, int y) => _multiSpatialMap.CanAdd(newItem, x, y);
+
+        /// <summary>
+        /// Adds the given item at the given position, provided the item is not already in the
+        /// spatial map. If the item is already added, throws ArgumentException.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="position">The position at which to add the new item.</param>
+        public void Add(T item, Point position) => _multiSpatialMap.Add(item, position);
+
+        /// <summary>
+        /// Adds the given item at the given position, provided the item is not already in the
+        /// spatial map. If the item is already added, throws ArgumentException.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="x">x-value of the position to add item to.</param>
+        /// <param name="y">y-value of the position to add item to.</param>
+        public void Add(T item, int x, int y) => _multiSpatialMap.Add(item, x, y);
+
+        /// <summary>
+        /// Adds the given item at the given position, provided the item is not already in the
+        /// spatial map. If the item is already added, returns false.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="position">The position at which to add the new item.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        public bool TryAdd(T item, Point position) => _multiSpatialMap.TryAdd(item, position);
+
+        /// <summary>
+        /// Adds the given item at the given position, provided the item is not already in the
+        /// spatial map. If the item is already added, returns false.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="x">x-value of the position to add item to.</param>
+        /// <param name="y">y-value of the position to add item to.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        public bool TryAdd(T item, int x, int y) => _multiSpatialMap.TryAdd(item, x, y);
+        #endregion
+
+        #region Move
+        /// <summary>
+        /// Returns true if the given item can be moved from its current location to the specified one,
+        /// eg. the item is contained within the spatial map; false otherwise.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="target">Location to move item to.</param>
+        /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
+        public bool CanMove(T item, Point target)
+            => _multiSpatialMap.CanMove(item, target);
+
+        /// <summary>
+        /// Returns true if the given item can be moved from its current location to the specified one,
+        /// eg. the item is contained within the spatial map; false otherwise.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="targetX">X-value of the location to move item to.</param>
+        /// <param name="targetY">Y-value of the location to move item to.</param>
+        /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
+        public bool CanMove(T item, int targetX, int targetY)
+            => _multiSpatialMap.CanMove(item, targetX, targetY);
+
+        /// <inheritdoc />
+        public bool CanMoveAll(Point current, Point target)
+            => _multiSpatialMap.CanMoveAll(current, target);
+
+        /// <inheritdoc />
+        public bool CanMoveAll(int currentX, int currentY, int targetX, int targetY)
+            => _multiSpatialMap.CanMoveAll(currentX, currentY, targetX, targetY);
+
+        [DoesNotReturn]
+        void ISpatialMap<T>.Move(T item, Point target)
+        {
+            ThrowMoveException();
+        }
+
+        [DoesNotReturn]
+        void ISpatialMap<T>.Move(T item, int targetX, int targetY)
+        {
+            ThrowMoveException();
+        }
+
+        [DoesNotReturn]
+        bool ISpatialMap<T>.TryMove(T item, Point target)
+        {
+            ThrowMoveException();
+            return false;
+        }
+
+        [DoesNotReturn]
+        bool ISpatialMap<T>.TryMove(T item, int targetX, int targetY)
+        {
+            ThrowMoveException();
+            return false;
+        }
+
+        [DoesNotReturn]
+        void ISpatialMap<T>.MoveAll(Point current, Point target)
+        {
+            ThrowMoveException();
+        }
+
+        [DoesNotReturn]
+        bool ISpatialMap<T>.TryMoveAll(Point current, Point target)
+        {
+            ThrowMoveException();
+            return false;
+        }
+
+        [DoesNotReturn]
+        void ISpatialMap<T>.MoveAll(int currentX, int currentY, int targetX, int targetY)
+        {
+            ThrowMoveException();
+        }
+
+        [DoesNotReturn]
+        bool ISpatialMap<T>.TryMoveAll(int currentX, int currentY, int targetX, int targetY)
+        {
+            ThrowMoveException();
+            return false;
+        }
+
+        [DoesNotReturn]
+        List<T> ISpatialMap<T>.MoveValid(Point current, Point target)
+        {
+            ThrowMoveException();
+            return default;
+        }
+
+        [DoesNotReturn]
+        void ISpatialMap<T>.MoveValid(Point current, Point target, List<T> itemsMovedOutput)
+        {
+            ThrowMoveException();
+        }
+
+        [DoesNotReturn]
+        List<T> ISpatialMap<T>.MoveValid(int currentX, int currentY, int targetX, int targetY)
+        {
+            ThrowMoveException();
+            return default;
+        }
+
+        [DoesNotReturn]
+        void ISpatialMap<T>.MoveValid(int currentX, int currentY, int targetX, int targetY, List<T> itemsMovedOutput)
+        {
+            ThrowMoveException();
+        }
+        #endregion
+
+        #region Contains
+        /// <inheritdoc />
+        public bool Contains(T item) => _multiSpatialMap.Contains(item);
+
+        /// <inheritdoc />
+        public bool Contains(Point position) => _multiSpatialMap.Contains(position);
+
+        /// <inheritdoc />
+        public bool Contains(int x, int y) => _multiSpatialMap.Contains(x, y);
+        #endregion
+
+        #region Get Items/Positions
+
+        /// <summary>
+        /// Gets the item(s) at the given position if there are any items, or returns
+        /// nothing if there is nothing at that position.
+        /// </summary>
+        /// <param name="position">The position to return the item(s) for.</param>
+        /// <returns>
+        /// The item(s) at the given position if there are any items, or nothing if there is nothing
+        /// at that position.
+        /// </returns>
+        public ListEnumerator<T> GetItemsAt(Point position) => _multiSpatialMap.GetItemsAt(position);
+
+        IEnumerable<T> IReadOnlySpatialMap<T>.GetItemsAt(Point position) => _multiSpatialMap.GetItemsAt(position);
+
+        /// <summary>
+        /// Gets the item(s) at the given position if there are any items, or returns
+        /// nothing if there is nothing at that position.
+        /// </summary>
+        /// <param name="x">The x-value of the position to return the item(s) for.</param>
+        /// <param name="y">The y-value of the position to return the item(s) for.</param>
+        /// <returns>
+        /// The item(s) at the given position if there are any items, or nothing if there is nothing
+        /// at that position.
+        /// </returns>
+        public ListEnumerator<T> GetItemsAt(int x, int y) => _multiSpatialMap.GetItemsAt(new Point(x, y));
+
+        IEnumerable<T> IReadOnlySpatialMap<T>.GetItemsAt(int x, int y) => _multiSpatialMap.GetItemsAt(x, y);
+
+        /// <inheritdoc />
+        public Point? GetPositionOfOrNull(T item) => _multiSpatialMap.GetPositionOfOrNull(item);
+
+        /// <inheritdoc />
+        public bool TryGetPositionOf(T item, out Point position) => _multiSpatialMap.TryGetPositionOf(item, out position);
+
+        /// <inheritdoc />
+        public Point GetPositionOf(T item) => _multiSpatialMap.GetPositionOf(item);
+        #endregion
+
+
+        /// <summary>
+        /// Returns a string representation of the spatial map, allowing display of the
+        /// spatial map's items in a specified way.
+        /// </summary>
+        /// <param name="itemStringifier">Function that turns an item into a string.</param>
+        /// <returns>A string representation of the spatial map.</returns>
+        public string ToString(Func<T, string> itemStringifier) => _multiSpatialMap.ToString(itemStringifier);
+
+        #region Clear/Remove
+        /// <inheritdoc />
+        public void Clear() => _multiSpatialMap.Clear();
+
+        /// <summary>
+        /// Removes the item specified, if it exists.  Throws ArgumentException if the item is
+        /// not in the spatial map.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        public void Remove(T item) => _multiSpatialMap.Remove(item);
+
+        /// <summary>
+        /// Removes the item specified, if it exists.  If the item is not in the spatial map, returns false.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>True if the item was successfully removed; false otherwise.</returns>
+        public bool TryRemove(T item) => _multiSpatialMap.TryRemove(item);
+
+        /// <inheritdoc />
+        public List<T> Remove(Point position) => _multiSpatialMap.Remove(position);
+
+        /// <inheritdoc/>
+        public bool TryRemove(Point position) => _multiSpatialMap.TryRemove(position);
+
+        /// <inheritdoc />
+        public List<T> Remove(int x, int y) => _multiSpatialMap.Remove(x, y);
+
+        /// <inheritdoc />
+        public bool TryRemove(int x, int y) => _multiSpatialMap.TryRemove(x, y);
+        #endregion
+
+        #region Item Handlers
+        private void OnItemAdded(object? sender, ItemEventArgs<T> e)
+        {
+            e.Item.PositionChanged += ItemOnPositionChanged;
+        }
+
+        private void ItemOnPositionChanged(object? sender, ObjectPropertyChanged<Point> e)
+        {
+            _multiSpatialMap.Move((T)sender!, e.NewValue);
+        }
+
+        private void OnItemRemoved(object? sender, ItemEventArgs<T> e)
+        {
+            e.Item.PositionChanged -= ItemOnPositionChanged;
+        }
+        #endregion
+
+        [DoesNotReturn]
+        private static void ThrowMoveException()
+        {
+            throw new NotSupportedException($"{nameof(AutoSyncAdvancedMultiSpatialMap<T>)} does not allow you " +
+                                            "to move items manually; it will move items automatically when their PositionChanged event is fired.  " +
+                                            "If you would like to move items manually, use the non-auto sync variants instead.");
+        }
+    }
+
+    /// <summary>
+    /// A version of <see cref="MultiSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
+    /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
+    /// in the spatial map when they move.
+    /// </summary>
+    /// <remarks>
+    /// You should not call the <see cref="ISpatialMap{T}.Move(T,SadRogue.Primitives.Point)"/> function (or any similar
+    /// functions) on an instance of this class; they will throw an exception.  This class automatically keeps items
+    /// synced up with their <see cref="IPositionable.Position"/> property.  If you need to manually control the
+    /// positions, you should use <see cref="AdvancedMultiSpatialMap{T}"/> instead.
+    /// </remarks>
+    /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
+    public sealed class AutoSyncMultiSpatialMap<T> : AutoSyncAdvancedMultiSpatialMap<T> where T : class, IHasID, IPositionable
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="listPool">
+        /// The list pool implementation to use.  Specify <see cref="NoPoolingListPool{T}"/> to disable pooling entirely.
+        /// This implementation _may_ be shared with other spatial maps if you wish, however be aware that no thread safety is implemented
+        /// by the default list pool implementations or the spatial map itself.
+        /// </param>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many MultiSpatialMap functions.  Defaults to the default equality
+        /// comparer for Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="initialCapacity">
+        /// The initial maximum number of elements the spatial map can hold before it has to
+        /// internally resize data structures. Defaults to 32.
+        /// </param>
+        public AutoSyncMultiSpatialMap(IListPool<T> listPool, IEqualityComparer<Point>? pointComparer = null, int initialCapacity = 32)
+            : base(new IDComparer<T>(), listPool, pointComparer, initialCapacity)
+        { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many MultiSpatialMap functions.  Defaults to the default equality
+        /// comparer for Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="initialCapacity">
+        /// The initial maximum number of elements the spatial map can hold before it has to
+        /// internally resize data structures. Defaults to 32.
+        /// </param>
+        public AutoSyncMultiSpatialMap(IEqualityComparer<Point>? pointComparer = null, int initialCapacity = 32)
+            : base(new IDComparer<T>(), pointComparer, initialCapacity)
+        { }
+    }
+}

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -424,6 +424,12 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <returns>A string representation of the spatial map.</returns>
         public string ToString(Func<T, string> itemStringifier) => _multiSpatialMap.ToString(itemStringifier);
 
+        /// <summary>
+        /// Returns a string representation of the spatial map.
+        /// </summary>
+        /// <returns>A string representation of the spatial map.</returns>
+        public override string ToString() => _multiSpatialMap.ToString();
+
         #region Clear/Remove
         /// <inheritdoc />
         public void Clear() => _multiSpatialMap.Clear();

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -260,6 +260,10 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <param name="target">The position to move it to.</param>
         public void Move(T item, Point target)
         {
+            if (!Contains(item)) throw new ArgumentException(
+                $"Tried to move item in {GetType().Name}, but the item does not exist.",
+                nameof(item));
+
             item.Position = target;
         }
 
@@ -271,10 +275,7 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <param name="item">The item to move.</param>
         /// <param name="targetX">X-value of the location to move it to.</param>
         /// <param name="targetY">Y-value of the location to move it to.</param>
-        public void Move(T item, int targetX, int targetY)
-        {
-            item.Position = new Point(targetX, targetY);
-        }
+        public void Move(T item, int targetX, int targetY) => Move(item, new Point(targetX, targetY));
 
         /// <inheritdoc />
         public bool TryMove(T item, Point target)

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -128,6 +128,14 @@ namespace SadRogue.Primitives.SpatialMaps
 
         #region Add
         /// <summary>
+        /// Returns true if the given item can be added at its current position, eg. if the item is not already in the spatial map;
+        /// false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <returns>True if the item can be successfully added at its current position; false otherwise.</returns>
+        public bool CanAdd(T newItem) => _multiSpatialMap.CanAdd(newItem, newItem.Position);
+
+        /// <summary>
         /// Returns true if the given item can be added at the given position, eg. if the item is not already in the spatial map;
         /// false otherwise.
         /// </summary>
@@ -246,8 +254,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
-        /// accordingly. If the item does not exist in the spatial map or is already at the target position, the function
-        /// throws ArgumentException.
+        /// accordingly. If the item does not exist in the spatial map, the function throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to move.</param>
         /// <param name="target">The position to move it to.</param>

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -421,7 +421,7 @@ namespace SadRogue.Primitives.SpatialMaps
         #region Item Handlers
         private void OnItemAdded(object? sender, ItemEventArgs<T> e)
         {
-            e.Item.PositionChanged += ItemOnPositionChanged;
+            e.Item.PositionChanging += ItemOnPositionChanging;
             ItemMoved += OnItemMoved;
         }
 
@@ -430,7 +430,7 @@ namespace SadRogue.Primitives.SpatialMaps
             e.Item.Position = e.NewPosition;
         }
 
-        private void ItemOnPositionChanged(object? sender, ValueChangedEventArgs<Point> e)
+        private void ItemOnPositionChanging(object? sender, ValueChangedEventArgs<Point> e)
         {
             if (sender != null)
                 _multiSpatialMap.Move((T)sender, e.NewValue);
@@ -438,7 +438,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         private void OnItemRemoved(object? sender, ItemEventArgs<T> e)
         {
-            e.Item.PositionChanged -= ItemOnPositionChanged;
+            e.Item.PositionChanging -= ItemOnPositionChanging;
             ItemMoved -= OnItemMoved;
         }
         #endregion

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -151,78 +151,64 @@ namespace SadRogue.Primitives.SpatialMaps
         public void Add(T item) => _multiSpatialMap.Add(item, item.Position);
 
         /// <summary>
-        /// Adds the given item at its position, provided the item is not already in the
-        /// spatial map. If the item is already added, or if the items position isn't hte one specified,
-        /// throws ArgumentException.
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map, provided
+        /// the item is not already in the spatial map. If the item is already added, throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="position">The position at which to add the new item.  Must match the item's Position field.</param>
-        void ISpatialMap<T>.Add(T item, Point position)
+        /// <param name="position">The position at which to add the new item.</param>
+        public void Add(T item, Point position)
         {
-            if (item.Position != position)
-                throw new ArgumentException("Item's position did not match the one specified to the function.");
-
+            item.Position = position;
             _multiSpatialMap.Add(item, position);
         }
 
         /// <summary>
-        /// Adds the given item at the given position, provided the item is not already in the
-        /// spatial map. If the item is already added, or if the items position isn't hte one specified,
-        /// throws ArgumentException.
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map, provided
+        /// the item is not already in the spatial map. If the item is already added, throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="x">x-value of the position to add item to.  Must match the item's Position field.</param>
-        /// <param name="y">y-value of the position to add item to.  Must match the item's Position field.</param>
-        void ISpatialMap<T>.Add(T item, int x, int y)
+        /// <param name="x">x-value of the position to add item to.</param>
+        /// <param name="y">y-value of the position to add item to.</param>
+        public void Add(T item, int x, int y)
         {
             var position = new Point(x, y);
-            if (item.Position != position)
-                throw new ArgumentException("Item's position did not match the one specified to the function.");
 
+            item.Position = position;
             _multiSpatialMap.Add(item, position);
         }
 
         /// <summary>
-        /// Adds the given item at the its position, provided the item is not already in the
-        /// spatial map. If the item is already added, returns false.
+        /// Adds the given item at its position, provided the item is not already in the spatial map. If the item is
+        /// already added, returns false.
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <returns>True if the item was successfully added; false otherwise.</returns>
-        public bool Try(T item) => _multiSpatialMap.TryAdd(item, item.Position);
+        public bool TryAdd(T item) => _multiSpatialMap.TryAdd(item, item.Position);
 
         /// <summary>
-        /// Adds the given item at the its position, provided the item is not already in the
-        /// spatial map. If the item is already added, or if the point specified doesn't match the object's position field,
-        /// returns false.
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map, provided
+        /// the item is not already in the spatial map. If the item is already added, nothing is changed and the function returns false.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="position">The position at which to add the new item.  Must match the item's Position field.</param>
+        /// <param name="position">The position at which to add the new item.</param>
         /// <returns>True if the item was successfully added; false otherwise.</returns>
-        bool ISpatialMap<T>.TryAdd(T item, Point position)
+        public bool TryAdd(T item, Point position)
         {
-            if (item.Position != position)
-                return false;
 
-            return _multiSpatialMap.TryAdd(item, position);
+            if (!_multiSpatialMap.TryAdd(item, position)) return false;
+            item.Position = position;
+            return true;
         }
 
         /// <summary>
-        /// Adds the given item at the given position, provided the item is not already in the
-        /// spatial map. If the item is already added, or if the point specified doesn't match the object's position field,
-        /// returns false.
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map, provided
+        /// the item is not already in the spatial map. If the item is already added, nothing is changed and the function returns false.
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <param name="x">x-value of the position to add item to.  Must match the item's Position field.</param>
         /// <param name="y">y-value of the position to add item to.  Must match the item's Position field.</param>
         /// <returns>True if the item was successfully added; false otherwise.</returns>
-        bool ISpatialMap<T>.TryAdd(T item, int x, int y)
-        {
-            var position = new Point(x, y);
-            if (item.Position != position)
-                return false;
-
-            return _multiSpatialMap.TryAdd(item, position);
-        }
+        public bool TryAdd(T item, int x, int y) => TryAdd(item, new Point(x, y));
         #endregion
 
         #region Move

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -144,40 +144,85 @@ namespace SadRogue.Primitives.SpatialMaps
         public bool CanAdd(T newItem, int x, int y) => _multiSpatialMap.CanAdd(newItem, x, y);
 
         /// <summary>
-        /// Adds the given item at the given position, provided the item is not already in the
+        /// Adds the given item at its position, provided the item is not already in the
         /// spatial map. If the item is already added, throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="position">The position at which to add the new item.</param>
-        public void Add(T item, Point position) => _multiSpatialMap.Add(item, position);
+        public void Add(T item) => _multiSpatialMap.Add(item, item.Position);
 
         /// <summary>
-        /// Adds the given item at the given position, provided the item is not already in the
-        /// spatial map. If the item is already added, throws ArgumentException.
+        /// Adds the given item at its position, provided the item is not already in the
+        /// spatial map. If the item is already added, or if the items position isn't hte one specified,
+        /// throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="x">x-value of the position to add item to.</param>
-        /// <param name="y">y-value of the position to add item to.</param>
-        public void Add(T item, int x, int y) => _multiSpatialMap.Add(item, x, y);
+        /// <param name="position">The position at which to add the new item.  Must match the item's Position field.</param>
+        void ISpatialMap<T>.Add(T item, Point position)
+        {
+            if (item.Position != position)
+                throw new ArgumentException("Item's position did not match the one specified to the function.");
+
+            _multiSpatialMap.Add(item, position);
+        }
 
         /// <summary>
         /// Adds the given item at the given position, provided the item is not already in the
+        /// spatial map. If the item is already added, or if the items position isn't hte one specified,
+        /// throws ArgumentException.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="x">x-value of the position to add item to.  Must match the item's Position field.</param>
+        /// <param name="y">y-value of the position to add item to.  Must match the item's Position field.</param>
+        void ISpatialMap<T>.Add(T item, int x, int y)
+        {
+            var position = new Point(x, y);
+            if (item.Position != position)
+                throw new ArgumentException("Item's position did not match the one specified to the function.");
+
+            _multiSpatialMap.Add(item, position);
+        }
+
+        /// <summary>
+        /// Adds the given item at the its position, provided the item is not already in the
         /// spatial map. If the item is already added, returns false.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="position">The position at which to add the new item.</param>
         /// <returns>True if the item was successfully added; false otherwise.</returns>
-        public bool TryAdd(T item, Point position) => _multiSpatialMap.TryAdd(item, position);
+        public bool Try(T item) => _multiSpatialMap.TryAdd(item, item.Position);
+
+        /// <summary>
+        /// Adds the given item at the its position, provided the item is not already in the
+        /// spatial map. If the item is already added, or if the point specified doesn't match the object's position field,
+        /// returns false.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="position">The position at which to add the new item.  Must match the item's Position field.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        bool ISpatialMap<T>.TryAdd(T item, Point position)
+        {
+            if (item.Position != position)
+                return false;
+
+            return _multiSpatialMap.TryAdd(item, position);
+        }
 
         /// <summary>
         /// Adds the given item at the given position, provided the item is not already in the
-        /// spatial map. If the item is already added, returns false.
+        /// spatial map. If the item is already added, or if the point specified doesn't match the object's position field,
+        /// returns false.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        /// <param name="x">x-value of the position to add item to.</param>
-        /// <param name="y">y-value of the position to add item to.</param>
+        /// <param name="x">x-value of the position to add item to.  Must match the item's Position field.</param>
+        /// <param name="y">y-value of the position to add item to.  Must match the item's Position field.</param>
         /// <returns>True if the item was successfully added; false otherwise.</returns>
-        public bool TryAdd(T item, int x, int y) => _multiSpatialMap.TryAdd(item, x, y);
+        bool ISpatialMap<T>.TryAdd(T item, int x, int y)
+        {
+            var position = new Point(x, y);
+            if (item.Position != position)
+                return false;
+
+            return _multiSpatialMap.TryAdd(item, position);
+        }
         #endregion
 
         #region Move

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -385,9 +385,10 @@ namespace SadRogue.Primitives.SpatialMaps
             e.Item.PositionChanged += ItemOnPositionChanged;
         }
 
-        private void ItemOnPositionChanged(object? sender, ObjectPropertyChanged<Point> e)
+        private void ItemOnPositionChanged(object? sender, ValueChangedEventArgs<Point> e)
         {
-            _multiSpatialMap.Move((T)sender!, e.NewValue);
+            if (sender != null)
+                _multiSpatialMap.Move((T)sender, e.NewValue);
         }
 
         private void OnItemRemoved(object? sender, ItemEventArgs<T> e)

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -415,7 +415,9 @@ namespace SadRogue.Primitives.SpatialMaps
         //
         // Unfortunately, since by this definition one event always triggers the other, we need to ensure we avoid
         // infinite looping.  The Position field will never raise its event if the position has not changed; so this
-        // stops a loop in that direction.  In the other direction,
+        // stops a loop in that direction.  In the other direction, the Move function will tolerate the target being
+        // the same as the item's current position in the spatial map by returning early, and this will cost only about
+        // 13 nanoseconds extra time.
         #region Item Handlers
         private void OnItemAdded(object? sender, ItemEventArgs<T> e)
         {

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncMultiSpatialMap.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using SadRogue.Primitives.Pooling;
 
 namespace SadRogue.Primitives.SpatialMaps
@@ -9,17 +8,21 @@ namespace SadRogue.Primitives.SpatialMaps
     /// <summary>
     /// A version of <see cref="AdvancedMultiSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
     /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
-    /// in the spatial map when they move.
+    /// in the spatial map when they move and that the position fields are updated if the spatial map's move functions
+    /// are used.
     /// </summary>
     /// <remarks>
-    /// You should not call the <see cref="ISpatialMap{T}.Move(T,SadRogue.Primitives.Point)"/> function (or any similar
-    /// functions) on an instance of this class; they will throw an exception.  This class automatically keeps items
-    /// synced up with their <see cref="IPositionable.Position"/> property.  If you need to manually control the
-    /// positions, you should use <see cref="AdvancedMultiSpatialMap{T}"/> instead.
+    /// This class automatically keeps the spatial map position of each object synced up with their
+    /// <see cref="IPositionable.Position"/> property; you may either use the Move functions of the spatial map,
+    /// in which case the Position fields of the objects are updated as appropriate, or you may change the Position
+    /// field, in which case the spatial map position is updated to match.
+    ///
+    /// If you want to manually control the positions of items in the spatial map, you should use
+    /// <see cref="AdvancedMultiSpatialMap{T}"/> instead.
     /// </remarks>
     /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
     public class AutoSyncAdvancedMultiSpatialMap<T> : ISpatialMap<T>
-        where T : IPositionable
+        where T : class, IPositionable
     {
         private readonly AdvancedMultiSpatialMap<T> _multiSpatialMap;
 
@@ -241,83 +244,73 @@ namespace SadRogue.Primitives.SpatialMaps
         public bool CanMoveAll(int currentX, int currentY, int targetX, int targetY)
             => _multiSpatialMap.CanMoveAll(currentX, currentY, targetX, targetY);
 
-        [DoesNotReturn]
-        void ISpatialMap<T>.Move(T item, Point target)
-        {
-            ThrowMoveException();
-        }
+        /// <summary>
+        /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
+        /// accordingly. If the item does not exist in the spatial map or is already at the target position, the function
+        /// throws ArgumentException.
+        /// </summary>
+        /// <param name="item">The item to move.</param>
+        /// <param name="target">The position to move it to.</param>
+        public void Move(T item, Point target) => _multiSpatialMap.Move(item, target);
 
-        [DoesNotReturn]
-        void ISpatialMap<T>.Move(T item, int targetX, int targetY)
-        {
-            ThrowMoveException();
-        }
+        /// <summary>
+        /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
+        /// accordingly. If the item does not exist in the spatial map or is already at the target position, the function
+        /// throws ArgumentException.
+        /// </summary>
+        /// <param name="item">The item to move.</param>
+        /// <param name="targetX">X-value of the location to move it to.</param>
+        /// <param name="targetY">Y-value of the location to move it to.</param>
+        public void Move(T item, int targetX, int targetY) => _multiSpatialMap.Move(item, targetX, targetY);
 
-        [DoesNotReturn]
-        bool ISpatialMap<T>.TryMove(T item, Point target)
-        {
-            ThrowMoveException();
-            return false;
-        }
+        /// <inheritdoc />
+        public bool TryMove(T item, Point target) => _multiSpatialMap.TryMove(item, target);
 
-        [DoesNotReturn]
-        bool ISpatialMap<T>.TryMove(T item, int targetX, int targetY)
-        {
-            ThrowMoveException();
-            return false;
-        }
+        /// <inheritdoc />
+        public bool TryMove(T item, int targetX, int targetY) => _multiSpatialMap.TryMove(item, targetX, targetY);
 
-        [DoesNotReturn]
-        void ISpatialMap<T>.MoveAll(Point current, Point target)
-        {
-            ThrowMoveException();
-        }
+        /// <summary>
+        /// Moves all items at the specified source location to the target location, updating their
+        /// <see cref="IPositionable.Position"/> fields accordingly.  Throws ArgumentException if there are
+        /// no items to be moved.
+        /// </summary>
+        /// <param name="current">Location to move items from.</param>
+        /// <param name="target">Location to move items to.</param>
+        public void MoveAll(Point current, Point target) => _multiSpatialMap.MoveAll(current, target);
 
-        [DoesNotReturn]
-        bool ISpatialMap<T>.TryMoveAll(Point current, Point target)
-        {
-            ThrowMoveException();
-            return false;
-        }
+        /// <inheritdoc/>
+        public bool TryMoveAll(Point current, Point target) => _multiSpatialMap.TryMoveAll(current, target);
 
-        [DoesNotReturn]
-        void ISpatialMap<T>.MoveAll(int currentX, int currentY, int targetX, int targetY)
-        {
-            ThrowMoveException();
-        }
+        /// <summary>
+        /// Moves all items at the specified source location to the target location, updating their
+        /// <see cref="IPositionable.Position"/> fields accordingly.  Throws ArgumentException if there are
+        /// no items to be moved.
+        /// </summary>
+        /// <param name="currentX">X-value of the location to move items from.</param>
+        /// <param name="currentY">Y-value of the location to move items from.</param>
+        /// <param name="targetX">X-value of the location to move items to.</param>
+        /// <param name="targetY">Y-value of the location to move items to.</param>
+        public void MoveAll(int currentX, int currentY, int targetX, int targetY)
+            => _multiSpatialMap.MoveAll(currentX, currentY, targetX, targetY);
 
-        [DoesNotReturn]
-        bool ISpatialMap<T>.TryMoveAll(int currentX, int currentY, int targetX, int targetY)
-        {
-            ThrowMoveException();
-            return false;
-        }
+        /// <inheritdoc/>
+        public bool TryMoveAll(int currentX, int currentY, int targetX, int targetY)
+            => _multiSpatialMap.TryMoveAll(currentX, currentY, targetX, targetY);
 
-        [DoesNotReturn]
-        List<T> ISpatialMap<T>.MoveValid(Point current, Point target)
-        {
-            ThrowMoveException();
-            return default;
-        }
+        /// <inheritdoc />
+        public List<T> MoveValid(Point current, Point target) => _multiSpatialMap.MoveValid(current, target);
 
-        [DoesNotReturn]
-        void ISpatialMap<T>.MoveValid(Point current, Point target, List<T> itemsMovedOutput)
-        {
-            ThrowMoveException();
-        }
+        /// <inheritdoc />
+        public void MoveValid(Point current, Point target, List<T> itemsMovedOutput)
+            => _multiSpatialMap.MoveValid(current, target, itemsMovedOutput);
 
-        [DoesNotReturn]
-        List<T> ISpatialMap<T>.MoveValid(int currentX, int currentY, int targetX, int targetY)
-        {
-            ThrowMoveException();
-            return default;
-        }
+        /// <inheritdoc />
+        public List<T> MoveValid(int currentX, int currentY, int targetX, int targetY)
+            => _multiSpatialMap.MoveValid(currentX, currentY, targetX, targetY);
 
-        [DoesNotReturn]
-        void ISpatialMap<T>.MoveValid(int currentX, int currentY, int targetX, int targetY, List<T> itemsMovedOutput)
-        {
-            ThrowMoveException();
-        }
+        /// <inheritdoc />
+        public void MoveValid(int currentX, int currentY, int targetX, int targetY, List<T> itemsMovedOutput)
+            => _multiSpatialMap.MoveValid(currentX, currentY, targetX, targetY, itemsMovedOutput);
         #endregion
 
         #region Contains
@@ -410,10 +403,29 @@ namespace SadRogue.Primitives.SpatialMaps
         public bool TryRemove(int x, int y) => _multiSpatialMap.TryRemove(x, y);
         #endregion
 
+        // There are 2 core handlers that deal with movement-related events below:
+        //    1. OnItemMoved: Called when the _multiSpatialMap's ItemMoved event happens
+        //    2. ItemOnPositionChanged: Called when an item's Position field changes.
+        //
+        // We want to handle both, because movement can happen one of two ways in an auto-synced map:
+        //    1. The user modifies an item's Position field.  This triggers ItemOnPositionChanged, and in this case we
+        //       need to ensure the spatial map stays synced up.
+        //    2. The user calls some sort of Move function on the spatial map.  In this case, the OnItemAdded function
+        //       is triggered, which needs to update the position field.
+        //
+        // Unfortunately, since by this definition one event always triggers the other, we need to ensure we avoid
+        // infinite looping.  The Position field will never raise its event if the position has not changed; so this
+        // stops a loop in that direction.  In the other direction,
         #region Item Handlers
         private void OnItemAdded(object? sender, ItemEventArgs<T> e)
         {
             e.Item.PositionChanged += ItemOnPositionChanged;
+            ItemMoved += OnItemMoved;
+        }
+
+        private void OnItemMoved(object? sender, ItemMovedEventArgs<T> e)
+        {
+            e.Item.Position = e.NewPosition;
         }
 
         private void ItemOnPositionChanged(object? sender, ValueChangedEventArgs<Point> e)
@@ -425,28 +437,25 @@ namespace SadRogue.Primitives.SpatialMaps
         private void OnItemRemoved(object? sender, ItemEventArgs<T> e)
         {
             e.Item.PositionChanged -= ItemOnPositionChanged;
+            ItemMoved -= OnItemMoved;
         }
         #endregion
-
-        [DoesNotReturn]
-        private static void ThrowMoveException()
-        {
-            throw new NotSupportedException($"{nameof(AutoSyncAdvancedMultiSpatialMap<T>)} does not allow you " +
-                                            "to move items manually; it will move items automatically when their PositionChanged event is fired.  " +
-                                            "If you would like to move items manually, use the non-auto sync variants instead.");
-        }
     }
 
     /// <summary>
     /// A version of <see cref="MultiSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
     /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
-    /// in the spatial map when they move.
+    /// in the spatial map when they move and that the position fields are updated if the spatial map's move functions
+    /// are used.
     /// </summary>
     /// <remarks>
-    /// You should not call the <see cref="ISpatialMap{T}.Move(T,SadRogue.Primitives.Point)"/> function (or any similar
-    /// functions) on an instance of this class; they will throw an exception.  This class automatically keeps items
-    /// synced up with their <see cref="IPositionable.Position"/> property.  If you need to manually control the
-    /// positions, you should use <see cref="AdvancedMultiSpatialMap{T}"/> instead.
+    /// This class automatically keeps the spatial map position of each object synced up with their
+    /// <see cref="IPositionable.Position"/> property; you may either use the Move functions of the spatial map,
+    /// in which case the Position fields of the objects are updated as appropriate, or you may change the Position
+    /// field, in which case the spatial map position is updated to match.
+    ///
+    /// If you want to manually control the positions of items in the spatial map, you should use
+    /// <see cref="MultiSpatialMap{T}"/> instead.
     /// </remarks>
     /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
     public sealed class AutoSyncMultiSpatialMap<T> : AutoSyncAdvancedMultiSpatialMap<T> where T : class, IHasID, IPositionable

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncSpatialMap.cs
@@ -252,6 +252,10 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <param name="target">Location to move item to.</param>
         public void Move(T item, Point target)
         {
+            if (!Contains(item)) throw new ArgumentException(
+                $"Tried to move item in {GetType().Name}, but the item does not exist.",
+                nameof(item));
+
             item.Position = target;
         }
 
@@ -263,10 +267,7 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <param name="item">Item to move.</param>
         /// <param name="targetX">X-value of the location to move it to.</param>
         /// <param name="targetY">Y-value of the location to move it to.</param>
-        public void Move(T item, int targetX, int targetY)
-        {
-            item.Position = new Point(targetX, targetY);
-        }
+        public void Move(T item, int targetX, int targetY) => Move(item, new Point(targetX, targetY));
 
         /// <inheritdoc />
         public bool TryMove(T item, Point target)

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncSpatialMap.cs
@@ -1,0 +1,614 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SadRogue.Primitives.SpatialMaps
+{
+    /// <summary>
+    /// A version of <see cref="AdvancedSpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
+    /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
+    /// in the spatial map when they move and that the position fields are updated if the spatial map's move functions
+    /// are used.
+    /// </summary>
+    /// <remarks>
+    /// This class automatically keeps the spatial map position of each object synced up with their
+    /// <see cref="IPositionable.Position"/> property; you may either use the Move functions of the spatial map,
+    /// in which case the Position fields of the objects are updated as appropriate, or you may change the Position
+    /// field, in which case the spatial map position is updated to match.
+    ///
+    /// If you want to manually control the positions of items in the spatial map, you should use
+    /// <see cref="AdvancedSpatialMap{T}"/> instead.
+    /// </remarks>
+    /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
+    public class AutoSyncAdvancedSpatialMap<T> : ISpatialMap<T>
+        where T : class, IPositionable
+    {
+        private readonly AdvancedSpatialMap<T> _spatialMap;
+
+        /// <inheritdoc/>
+        public int Count => _spatialMap.Count;
+
+        /// <inheritdoc/>
+        public IEnumerable<T> Items => _spatialMap.Items;
+
+        /// <inheritdoc/>
+        public IEnumerable<Point> Positions => _spatialMap.Positions;
+
+        /// <inheritdoc/>
+        public event EventHandler<ItemEventArgs<T>>? ItemAdded
+        {
+            add => _spatialMap.ItemAdded += value;
+            remove => _spatialMap.ItemAdded -= value;
+        }
+
+        /// <inheritdoc/>
+        public event EventHandler<ItemMovedEventArgs<T>>? ItemMoved
+        {
+            add => _spatialMap.ItemMoved += value;
+            remove => _spatialMap.ItemMoved -= value;
+        }
+
+        /// <inheritdoc/>
+        public event EventHandler<ItemEventArgs<T>>? ItemRemoved
+        {
+            add => _spatialMap.ItemRemoved += value;
+            remove => _spatialMap.ItemRemoved -= value;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="itemComparer">
+        /// Equality comparer to use for comparison and hashing of type T. Be especially mindful of the
+        /// efficiency of its GetHashCode function, as it will determine the efficiency of many spatial map functions.
+        /// functions.
+        /// </param>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many spatial map functions.  Defaults to the default equality comparer for
+        /// Point, which uses a fairly efficient generalized hashing algorithm.
+        /// </param>
+        /// <param name="initialCapacity">
+        /// The initial maximum number of elements the spatial map can hold before it has to
+        /// internally resize data structures. Defaults to 32.
+        /// </param>
+        public AutoSyncAdvancedSpatialMap(IEqualityComparer<T> itemComparer, IEqualityComparer<Point>? pointComparer = null,
+                                  int initialCapacity = 32)
+        {
+            _spatialMap = new AdvancedSpatialMap<T>(itemComparer, pointComparer, initialCapacity);
+
+            _spatialMap.ItemAdded += OnItemAdded;
+            _spatialMap.ItemRemoved += OnItemRemoved;
+        }
+
+        #region Enumeration
+        /// <summary>
+        /// Used by foreach loop, so that the class will give ISpatialTuple objects when used in a
+        /// foreach loop. Generally should never be called explicitly.
+        /// </summary>
+        /// <returns>An enumerator for the spatial map</returns>
+        public IEnumerator<ItemPositionPair<T>> GetEnumerator() => _spatialMap.GetEnumerator();
+
+        /// <summary>
+        /// Generic iterator used internally by foreach loops.
+        /// </summary>
+        /// <returns>Enumerator to ISpatialTuple instances.</returns>
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_spatialMap).GetEnumerator();
+        #endregion
+
+        /// <inheritdoc />
+        public IReadOnlySpatialMap<T> AsReadOnly() => _spatialMap.AsReadOnly();
+
+        #region Add
+        /// <summary>
+        /// Returns true if the given item can be added at the given position, eg. the item is not already in the
+        /// spatial map and the position is not already filled; false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <param name="position">Position to add item to.</param>
+        /// <returns>True if the item can be successfully added at the position given; false otherwise.</returns>
+        public bool CanAdd(T newItem, Point position) => _spatialMap.CanAdd(newItem, position);
+
+        /// <summary>
+        /// Returns true if the given item can be added at the given position, eg. if the item is not already in the spatial map;
+        /// false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <param name="x">X-value of the position to add item to.</param>
+        /// <param name="y">Y-value of the position to add item to.</param>
+        /// <returns>True if the item can be successfully added at the position given; false otherwise.</returns>
+        public bool CanAdd(T newItem, int x, int y) => _spatialMap.CanAdd(newItem, x, y);
+
+        /// <summary>
+        /// Adds the given item at its position, provided the item is not already in the
+        /// spatial map and the position is not already filled. If either of those are the case,
+        /// throws ArgumentException.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        public void Add(T item) => _spatialMap.Add(item, item.Position);
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map,
+        /// provided the item is not already in the spatial map and the position is not already filled. If either of
+        /// those are the case, throws ArgumentException.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="position">Position to add item to.</param>
+        public void Add(T item, Point position)
+        {
+            item.Position = position;
+            _spatialMap.Add(item, position);
+        }
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and then adds it to the spatial map,
+        /// provided the item is not already in the spatial map and the position is not already filled. If either of
+        /// those are the case, throws ArgumentException.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="x">X-value of the position to add item to.</param>
+        /// <param name="y">Y-value of the position to add item to.</param>
+        public void Add(T item, int x, int y) => Add(item, new Point(x, y));
+
+        /// <summary>
+        /// Tries to add the given item at its position, provided the item is not already in the
+        /// spatial map and the position is not already filled. If either of those are the case,
+        /// returns false.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        public bool TryAdd(T item) => _spatialMap.TryAdd(item, item.Position);
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and tries to add the given item at the given
+        /// position, provided the item is not already in the spatial map and the position is not already filled.
+        /// If either of those are the case, nothing is changed and the function returns false.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="position">Position to add item to.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        public bool TryAdd(T item, Point position)
+        {
+            if (!_spatialMap.TryAdd(item, position)) return false;
+            item.Position = position;
+            return true;
+        }
+
+        /// <summary>
+        /// Changes the position field of the given item to the given value, and tries to add the given item at the given
+        /// position, provided the item is not already in the spatial map and the position is not already filled.
+        /// If either of those are the case, nothing is changed and the function returns false.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="x">X-value of the position to add item to.</param>
+        /// <param name="y">Y-value of the position to add item to.</param>
+        /// <returns>True if the item was successfully added; false otherwise.</returns>
+        public bool TryAdd(T item, int x, int y) => TryAdd(item, new Point(x, y));
+        #endregion
+
+        #region Move
+        /// <summary>
+        /// Returns true if the given item can be moved from its current location to the specified one, eg. if the item
+        /// does exists in the spatial map and if the new position is not already filled by some other item; false otherwise.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="target">Location to move item to.</param>
+        /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
+        public bool CanMove(T item, Point target) => _spatialMap.CanMove(item, target);
+
+        /// <summary>
+        /// Returns true if the given item can be moved from its current location to the specified one, eg. if the item
+        /// exists in the spatial map and if the new position is not already filled by some other item; false otherwise.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="targetX">X-value of the location to move item to.</param>
+        /// <param name="targetY">Y-value of the location to move item to.</param>
+        /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
+        public bool CanMove(T item, int targetX, int targetY) => _spatialMap.CanMove(item, targetX, targetY);
+
+        /// <summary>
+        /// Returns true if the item at the current position specified can be moved to the target position, eg. if an item exists
+        /// at the current
+        /// position and the new position is not already filled by some other item; false otherwise.
+        /// </summary>
+        /// <param name="current">Location to move items from.</param>
+        /// <param name="target">Location to move items to.</param>
+        /// <returns>
+        /// true if all items at the position current can be moved to the position target; false if one or more items
+        /// cannot be moved.
+        /// </returns>
+        public bool CanMoveAll(Point current, Point target) => _spatialMap.CanMoveAll(current, target);
+
+        /// <summary>
+        /// Returns true if the item at the current position specified can be moved to the target position, eg. if an item exists
+        /// at the current
+        /// position and the new position is not already filled by some other item; false otherwise.
+        /// </summary>
+        /// <param name="currentX">X-value of the location to move items from.</param>
+        /// <param name="currentY">Y-value of the location to move items from.</param>
+        /// <param name="targetX">X-value of the location to move items to.</param>
+        /// <param name="targetY">Y-value of the location to move items to.</param>
+        /// <returns>
+        /// true if all items at the position current can be moved to the position target; false if one or more items
+        /// cannot be moved.
+        /// </returns>
+        public bool CanMoveAll(int currentX, int currentY, int targetX, int targetY) => _spatialMap.CanMoveAll(currentX, currentY, targetX, targetY);
+
+        /// <summary>
+        /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
+        /// accordingly. Throws ArgumentException if the item does not exist in the spatial map or if the position is
+        /// already filled by some other item.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="target">Location to move item to.</param>
+        public void Move(T item, Point target)
+        {
+            item.Position = target;
+        }
+
+        /// <summary>
+        /// Moves the item specified to the position specified, updating its <see cref="IPositionable.Position"/> field
+        /// accordingly. Throws ArgumentException if the item does not exist in the spatial map or if the position is
+        /// already filled by some other item.
+        /// </summary>
+        /// <param name="item">Item to move.</param>
+        /// <param name="targetX">X-value of the location to move it to.</param>
+        /// <param name="targetY">Y-value of the location to move it to.</param>
+        public void Move(T item, int targetX, int targetY)
+        {
+            item.Position = new Point(targetX, targetY);
+        }
+
+        /// <inheritdoc />
+        public bool TryMove(T item, Point target)
+        {
+            if (!_spatialMap.TryMove(item, target))
+                return false;
+
+            item.Position = target;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public bool TryMove(T item, int targetX, int targetY) => TryMove(item, new Point(targetX, targetY));
+
+        /// <summary>
+        /// Moves the item at the specified source location to the target location.  Throws ArgumentException if one or
+        /// more items cannot be moved, eg. if no item exists at the current position or the new position is already
+        /// filled by some other item.
+        /// </summary>
+        /// <param name="current">Location to move items from.</param>
+        /// <param name="target">Location to move items to.</param>
+        public void MoveAll(Point current, Point target)
+        {
+            _spatialMap.MoveAll(current, target);
+
+            // SpatialMap enforces that only one entity can be at any position; so if the move succeeded, the one
+            // at the target position has to be the one we moved.
+            _spatialMap.GetItem(target).Position = target;
+        }
+
+        /// <inheritdoc/>
+        public bool TryMoveAll(Point current, Point target)
+        {
+            if (!_spatialMap.TryMoveAll(current, target))
+                return false;
+            // SpatialMap enforces that only one entity can be at any position; so if the move succeeded, the one
+            // at the target position has to be the one we moved.
+            _spatialMap.GetItem(target).Position = target;
+            return true;
+        }
+
+        /// <summary>
+        /// Moves the item at the specified source location to the target location.  Throws ArgumentException if one or
+        /// more items cannot be moved, eg. if no item exists at the current position or the new position is already
+        /// filled by some other item.
+        /// </summary>
+        /// <param name="currentX">X-value of the location to move items from.</param>
+        /// <param name="currentY">Y-value of the location to move items from.</param>
+        /// <param name="targetX">X-value of the location to move items to.</param>
+        /// <param name="targetY">Y-value of the location to move items to.</param>
+        public void MoveAll(int currentX, int currentY, int targetX, int targetY)
+            => MoveAll(new Point(currentX, currentY), new Point(targetX, targetY));
+
+        /// <inheritdoc/>
+        public bool TryMoveAll(int currentX, int currentY, int targetX, int targetY) => _spatialMap.TryMoveAll(currentX, currentY, targetX, targetY);
+
+        /// <summary>
+        /// Moves whatever is at position current, if anything, to the target position, if it is a valid move.
+        /// If something was moved, it returns what was moved. If nothing was moved, eg. either there was nothing at
+        /// <paramref name="current" /> or already something at <paramref name="target" />, returns nothing.
+        /// </summary>
+        /// <remarks>
+        /// Since this implementation of ISpatialMap guarantees that only one item may be at any
+        /// given location at a time, the returned values will either be none, or a single value.
+        /// </remarks>
+        /// <param name="current">The position of the item to move.</param>
+        /// <param name="target">The position to move the item to.</param>
+        /// <returns>
+        /// The item moved as a 1-element list if something was moved, or nothing if no item
+        /// was moved.
+        /// </returns>
+        public List<T> MoveValid(Point current, Point target)
+        {
+            var moved = _spatialMap.MoveValid(current, target);
+            if (moved.Count > 0)
+                moved[0].Position = target;
+
+            return moved;
+        }
+
+        /// <inheritdoc/>
+        public void MoveValid(Point current, Point target, List<T> itemsMovedOutput)
+        {
+            int index = itemsMovedOutput.Count;
+            _spatialMap.MoveValid(current, target, itemsMovedOutput);
+            if (_spatialMap.Count > index)
+                itemsMovedOutput[index].Position = target;
+        }
+
+        /// <summary>
+        /// Moves whatever is at the "current" position specified, if anything, to the "target" position, if
+        /// it is a valid move. If something was moved, it returns what was moved. If nothing was moved, eg.
+        /// either there was nothing at the "current" position given, or already something at the "target" position
+        /// given, it returns nothing.
+        /// </summary>
+        /// <remarks>
+        /// Since this implementation of ISpatialMap guarantees that only one item may be at any
+        /// given location at a time, the returned values will either be none, or a single value.
+        /// </remarks>
+        /// <param name="currentX">X-value of the location to move item from.</param>
+        /// <param name="currentY">Y-value of the location to move item from.</param>
+        /// <param name="targetX">X-value of the location to move item to.</param>
+        /// <param name="targetY">Y-value of the location to move item to.</param>
+        /// <returns>
+        /// The item moved as a 1-element IEnumerable if something was moved, or nothing if no item
+        /// was moved.
+        /// </returns>
+        public List<T> MoveValid(int currentX, int currentY, int targetX, int targetY)
+            => MoveValid(new Point(currentX, currentY), new Point(targetX, targetY));
+
+        /// <inheritdoc/>
+        public void MoveValid(int currentX, int currentY, int targetX, int targetY, List<T> itemsMovedOutput)
+            => MoveValid(new Point(currentX, currentY), new Point(targetX, targetY), itemsMovedOutput);
+        #endregion
+
+        #region Contains
+        /// <inheritdoc />
+        public bool Contains(T item) => _spatialMap.Contains(item);
+
+        /// <inheritdoc />
+        public bool Contains(Point position) => _spatialMap.Contains(position);
+
+        /// <inheritdoc />
+        public bool Contains(int x, int y) => _spatialMap.Contains(x, y);
+        #endregion
+
+        #region Get Items/Positions
+        /// <summary>
+        /// Gets the item at the given position as a 1-element enumerable if there is any item there,
+        /// or nothing if there is nothing at that position.
+        /// </summary>
+        /// <remarks>
+        /// Since this implementation guarantees that only one item can be at any given
+        /// location at once, the return value is guaranteed to be at most one element. You may find it
+        /// more convenient to use the <see cref="GetItem(Point)" /> function when you know you are
+        /// dealing with a SpatialMap/AdvancedSpatialMap instance.
+        /// </remarks>
+        /// <param name="position">The position to return the item for.</param>
+        /// <returns>
+        /// The item at the given position as a 1-element enumerable, if there is an item there, or
+        /// nothing if there is no item there.
+        /// </returns>
+        public IEnumerable<T> GetItemsAt(Point position) => _spatialMap.GetItemsAt(position);
+
+        /// <summary>
+        /// Gets the item at the given position as a 1-element enumerable if there is any item there,
+        /// or nothing if there is nothing at that position.
+        /// </summary>
+        /// <remarks>
+        /// Since this implementation guarantees that only one item can be at any given
+        /// location at once, the return value is guaranteed to be at most one element. You may find it
+        /// more convenient to use the <see cref="GetItem(int, int)" /> function when you know you are
+        /// dealing with a SpatialMap/AdvancedSpatialMap instance.
+        /// </remarks>
+        /// <param name="x">The x-value of the position to return the item(s) for.</param>
+        /// <param name="y">The y-value of the position to return the item(s) for.</param>
+        /// <returns>
+        /// The item at the given position as a 1-element enumerable, if there is an item there, or
+        /// nothing if there is no item there.
+        /// </returns>
+        public IEnumerable<T> GetItemsAt(int x, int y) => _spatialMap.GetItemsAt(x, y);
+
+        /// <inheritdoc />
+        public Point? GetPositionOfOrNull(T item) => _spatialMap.GetPositionOfOrNull(item);
+
+        /// <inheritdoc />
+        public bool TryGetPositionOf(T item, out Point position) => _spatialMap.TryGetPositionOf(item, out position);
+
+        /// <inheritdoc />
+        public Point GetPositionOf(T item) => _spatialMap.GetPositionOf(item);
+
+        /// <summary>
+        /// Gets the item at the given position.  Throws ArgumentException no item exists at the given location.
+        /// </summary>
+        /// <exception cref="ArgumentException">No item is present in the spatial map at the given position.</exception>
+        /// <remarks>
+        /// Intended to be a more convenient function as compared to <see cref="GetItemsAt(Point)" />, since
+        /// this spatial map implementation only allows a single item to at any given location at a time.
+        /// </remarks>
+        /// <param name="position">The position to return the item for.</param>
+        /// <returns>
+        /// The item at the given position.
+        /// </returns>
+        public T GetItem(Point position) => _spatialMap.GetItem(position);
+
+        /// <summary>
+        /// Gets the item at the given position.  Throws ArgumentException no item exists at the given location.
+        /// </summary>
+        /// <exception cref="ArgumentException">No item is present in the spatial map at the given position.</exception>
+        /// <remarks>
+        /// Intended to be a more convenient function as compared to <see cref="GetItemsAt(Point)" />, since
+        /// this spatial map implementation only allows a single item to at any given location at a time.
+        /// </remarks>
+        /// <param name="x">The x-value of the position to return the item for.</param>
+        /// <param name="y">The y-value of the position to return the item for.</param>
+        /// <returns>
+        /// The item at the given position.
+        /// </returns>
+        public T GetItem(int x, int y) => _spatialMap.GetItem(x, y);
+
+        /// <summary>
+        /// Gets the item at the given position, or default(T) if no item exists.
+        /// </summary>
+        /// <remarks>
+        /// Intended to be a more convenient function as compared to <see cref="GetItemsAt(Point)" />, since
+        /// this spatial map implementation only allows a single item to at any given location at a time.
+        /// </remarks>
+        /// <param name="position">The position to return the item for.</param>
+        /// <returns>
+        /// The item at the given position, or default(T) if no item exists at that location.
+        /// </returns>
+        public T? GetItemOrDefault(Point position) => _spatialMap.GetItemOrDefault(position);
+
+        /// <summary>
+        /// Gets the item at the given position, or default(T) if no item exists.
+        /// </summary>
+        /// <remarks>
+        /// Intended to be a more convenient function as compared to <see cref="GetItemsAt(int, int)" />, since
+        /// this spatial map implementation only allows a single item to at any given location at a time.
+        /// </remarks>
+        /// <param name="x">The x-value of the position to return the item for.</param>
+        /// <param name="y">The y-value of the position to return the item for.</param>
+        /// <returns>
+        /// The item at the given position, or default(T) if no item exists at that location.
+        /// </returns>
+        public T? GetItemOrDefault(int x, int y) => _spatialMap.GetItemOrDefault(x, y);
+        #endregion
+
+        /// <summary>
+        /// Returns a string representation of the spatial map, allowing display of the spatial map's
+        /// items in a specified way.
+        /// </summary>
+        /// <param name="itemStringifier">Function that turns an item into a string.</param>
+        /// <returns>A string representation of the spatial map.</returns>
+        public string ToString(Func<T, string> itemStringifier) => _spatialMap.ToString(itemStringifier);
+
+        /// <summary>
+        /// Returns a string representation of the spatial map.
+        /// </summary>
+        /// <returns>A string representation of the spatial map.</returns>
+        public override string ToString() => _spatialMap.ToString();
+
+        #region Clear/Remove
+        /// <inheritdoc />
+        public void Clear() => _spatialMap.Clear();
+
+        /// <summary>
+        /// Removes the item specified. Throws ArgumentException if the item specified was
+        /// not in the spatial map.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        public void Remove(T item) => _spatialMap.Remove(item);
+
+        /// <summary>
+        /// Removes the item specified. If the item specified was not in the spatial map, does nothing and returns false.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>True if the item was removed; false otherwise.</returns>
+        public bool TryRemove(T item) => _spatialMap.TryRemove(item);
+
+        /// <summary>
+        /// Removes whatever is at the given position, if anything, and returns the item removed as a
+        /// 1-element IEnumerable. Returns nothing if no item was at the position specified.
+        /// </summary>
+        /// <remarks>
+        /// Since this implementation of ISpatialMap guarantees that only one item can be at any given
+        /// location at a time, the returned value is guaranteed to be either nothing or a single element.
+        /// </remarks>
+        /// <param name="position">The position of the item to remove.</param>
+        /// <returns>
+        /// The item removed as a 1-element list, if something was removed; an empty list if no item
+        /// was found at that position.
+        /// </returns>
+        public List<T> Remove(Point position) => _spatialMap.Remove(position);
+
+        /// <inheritdoc/>
+        public bool TryRemove(Point position) => _spatialMap.TryRemove(position);
+
+        /// <summary>
+        /// Removes whatever is at the given position, if anything, and returns the item removed as a
+        /// 1-element IEnumerable. Returns nothing if no item was at the position specified.
+        /// </summary>
+        /// <remarks>
+        /// Since this implementation guarantees that only one item can be at any given
+        /// location at a time, the returned value is guaranteed to be either nothing or a single element.
+        /// </remarks>
+        /// <param name="x">X-value of the position to remove item from.</param>
+        /// <param name="y">Y-value of the position to remove item from.</param>
+        /// <returns>
+        /// The item removed as a 1-element IEnumerable, if something was removed; nothing if no item
+        /// was found at that position.
+        /// </returns>
+        public List<T> Remove(int x, int y) => _spatialMap.Remove(x, y);
+
+        /// <inheritdoc/>
+        public bool TryRemove(int x, int y) => _spatialMap.TryRemove(x, y);
+        #endregion
+
+        #region Item Handlers
+        private void OnItemAdded(object? sender, ItemEventArgs<T> e)
+        {
+            e.Item.PositionChanging += ItemOnPositionChanging;
+        }
+
+        private void ItemOnPositionChanging(object? sender, ValueChangedEventArgs<Point> e)
+        {
+            if (sender != null)
+                _spatialMap.Move((T)sender, e.NewValue);
+        }
+
+        private void OnItemRemoved(object? sender, ItemEventArgs<T> e)
+        {
+            e.Item.PositionChanging -= ItemOnPositionChanging;
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// A version of <see cref="SpatialMap{T}"/> which takes items that implement <see cref="IPositionable"/>,
+    /// and uses that interface's properties/events to automatically ensure items are recorded at the proper positions
+    /// in the spatial map when they move and that the position fields are updated if the spatial map's move functions
+    /// are used.
+    /// </summary>
+    /// <remarks>
+    /// This class automatically keeps the spatial map position of each object synced up with their
+    /// <see cref="IPositionable.Position"/> property; you may either use the Move functions of the spatial map,
+    /// in which case the Position fields of the objects are updated as appropriate, or you may change the Position
+    /// field, in which case the spatial map position is updated to match.
+    ///
+    /// If you want to manually control the positions of items in the spatial map, you should use
+    /// <see cref="SpatialMap{T}"/> instead.
+    /// </remarks>
+    /// <typeparam name="T">The type of object that will be contained by this spatial map.</typeparam>
+    public sealed class AutoSyncSpatialMap<T> : AutoSyncAdvancedSpatialMap<T> where T : class, IHasID, IPositionable
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="pointComparer">
+        /// Equality comparer to use for comparison and hashing of points, as object are added to/removed from/moved
+        /// around the spatial map.  Be especially mindful of the efficiency of its GetHashCode function, as it will
+        /// determine the efficiency of many SpatialMap functions.  Defaults to the default equality comparer for
+        /// Point.
+        /// </param>
+        /// <param name="initialCapacity">
+        /// The initial maximum number of elements the SpatialMap can hold before it has to
+        /// internally resize data structures. Defaults to 32.
+        /// </param>
+        public AutoSyncSpatialMap(IEqualityComparer<Point>? pointComparer = null, int initialCapacity = 32)
+            : base(new IDComparer<T>(), pointComparer, initialCapacity)
+        { }
+    }
+}

--- a/TheSadRogue.Primitives/SpatialMaps/AutoSyncSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/AutoSyncSpatialMap.cs
@@ -102,6 +102,14 @@ namespace SadRogue.Primitives.SpatialMaps
 
         #region Add
         /// <summary>
+        /// Returns true if the given item can be added at its current position, eg. the item is not already in the
+        /// spatial map and the position is not already filled; false otherwise.
+        /// </summary>
+        /// <param name="newItem">Item to add.</param>
+        /// <returns>True if the item can be successfully added at its current position; false otherwise.</returns>
+        public bool CanAdd(T newItem) => _spatialMap.CanAdd(newItem, newItem.Position);
+
+        /// <summary>
         /// Returns true if the given item can be added at the given position, eg. the item is not already in the
         /// spatial map and the position is not already filled; false otherwise.
         /// </summary>

--- a/TheSadRogue.Primitives/SpatialMaps/ISpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/ISpatialMap.cs
@@ -120,8 +120,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Moves all items at the specified source location to the target location.  Throws ArgumentException if one or
-        /// more items cannot be moved or there are
-        /// no items to be moved.
+        /// more items cannot be moved or there are no items to be moved.
         /// </summary>
         /// <param name="current">Location to move items from.</param>
         /// <param name="target">Location to move items to.</param>
@@ -138,8 +137,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Moves all items at the specified source location to the target location.  Throws ArgumentException if one or
-        /// more items cannot be moved or there are no items
-        /// to be moved.
+        /// more items cannot be moved or there are no items to be moved.
         /// </summary>
         /// <param name="currentX">X-value of the location to move items from.</param>
         /// <param name="currentY">Y-value of the location to move items from.</param>

--- a/TheSadRogue.Primitives/SpatialMaps/MultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/MultiSpatialMap.cs
@@ -654,7 +654,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <inheritdoc />
         public bool CanMoveAll(Point current, Point target)
-            => _positionMapping.ContainsKey(current) && current != target;
+            => _positionMapping.ContainsKey(current);
 
         /// <inheritdoc />
         public bool CanMoveAll(int currentX, int currentY, int targetX, int targetY)
@@ -668,9 +668,6 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <param name="target">Location to move items to.</param>
         public void MoveAll(Point current, Point target)
         {
-            if (current == target)
-                return;
-
             List<T> currentList;
             try
             {
@@ -682,6 +679,9 @@ namespace SadRogue.Primitives.SpatialMaps
                     $"Tried to move all items from {current} in {GetType().Name}, but there was nothing at that position.",
                     nameof(current));
             }
+
+            if (current == target)
+                return;
 
             // We know the move will succeed, since they don't fail in MultiSpatialMap; so we can go ahead and remove
             // the old position list now.
@@ -722,11 +722,11 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <inheritdoc/>
         public bool TryMoveAll(Point current, Point target)
         {
-            if (current == target)
-                return true;
-
             if (!_positionMapping.TryGetValue(current, out var currentList))
                 return false;
+
+            if (current == target)
+                return true;
 
             // We know the move will succeed, since they don't fail in MultiSpatialMap; so we can go ahead and remove
             // the old position list now.

--- a/TheSadRogue.Primitives/SpatialMaps/MultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/MultiSpatialMap.cs
@@ -288,7 +288,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Moves the item specified to the position specified. If the item does not exist in the
-        /// spatial map or is already at the target position, the function throws ArgumentException.
+        /// spatial map, the function throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to move.</param>
         /// <param name="target">The position to move it to.</param>
@@ -307,9 +307,7 @@ namespace SadRogue.Primitives.SpatialMaps
             }
 
             if (oldPos == target)
-                throw new ArgumentException(
-                    $"Tried to move item in {GetType().Name}, but the item was already at the target position.",
-                    nameof(target));
+                return;
 
             // Key guaranteed to exist due to state invariant of spatial map (oldPos existed in the other map)
             var oldPosList = _positionMapping[oldPos];
@@ -356,7 +354,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Moves the item specified to the position specified. If the item does not exist in the
-        /// spatial map or is already at the target position, the function throws ArgumentException.
+        /// spatial map, the function throws ArgumentException.
         /// </summary>
         /// <param name="item">The item to move.</param>
         /// <param name="targetX">X-value of the location to move it to.</param>
@@ -370,7 +368,7 @@ namespace SadRogue.Primitives.SpatialMaps
                 return false;
 
             if (oldPos == target)
-                return false;
+                return true;
 
             // Key guaranteed to exist due to state invariant of spatial map (oldPos existed in the other map)
             var oldPosList = _positionMapping[oldPos];

--- a/TheSadRogue.Primitives/SpatialMaps/MultiSpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/MultiSpatialMap.cs
@@ -669,9 +669,7 @@ namespace SadRogue.Primitives.SpatialMaps
         public void MoveAll(Point current, Point target)
         {
             if (current == target)
-                throw new ArgumentException(
-                    $"Tried to move all items from {current} in {GetType().Name}, but the current and target positions were the same.",
-                    nameof(target));
+                return;
 
             List<T> currentList;
             try
@@ -725,7 +723,7 @@ namespace SadRogue.Primitives.SpatialMaps
         public bool TryMoveAll(Point current, Point target)
         {
             if (current == target)
-                return false;
+                return true;
 
             if (!_positionMapping.TryGetValue(current, out var currentList))
                 return false;

--- a/TheSadRogue.Primitives/SpatialMaps/SpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/SpatialMap.cs
@@ -541,12 +541,16 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <summary>
         /// Returns true if the given item can be moved from its current location to the specified one, eg. if the item
         /// does exists in the spatial map and if the new position is not already filled by some other item; false otherwise.
+        /// However, if the item is already at the specified position, always returns true.
         /// </summary>
         /// <param name="item">Item to move.</param>
         /// <param name="target">Location to move item to.</param>
         /// <returns>true if the given item can be moved to the given position; false otherwise.</returns>
         public bool CanMove(T item, Point target)
-            => _itemMapping.ContainsKey(item) && !_positionMapping.ContainsKey(target);
+        {
+            if (!_itemMapping.TryGetValue(item, out Point current)) return false;
+            return current == target || !_positionMapping.ContainsKey(target);
+        }
 
         /// <summary>
         /// Returns true if the given item can be moved from its current location to the specified one, eg. if the item
@@ -560,8 +564,7 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Returns true if the item at the current position specified can be moved to the target position, eg. if an item exists
-        /// at the current
-        /// position and the new position is not already filled by some other item; false otherwise.
+        /// at the current position and the new position is not already filled by some other item; false otherwise.
         /// </summary>
         /// <param name="current">Location to move items from.</param>
         /// <param name="target">Location to move items to.</param>
@@ -570,12 +573,11 @@ namespace SadRogue.Primitives.SpatialMaps
         /// cannot be moved.
         /// </returns>
         public bool CanMoveAll(Point current, Point target)
-            => _positionMapping.ContainsKey(current) && !_positionMapping.ContainsKey(target);
+            => _positionMapping.ContainsKey(current) && (current == target || !_positionMapping.ContainsKey(target));
 
         /// <summary>
         /// Returns true if the item at the current position specified can be moved to the target position, eg. if an item exists
-        /// at the current
-        /// position and the new position is not already filled by some other item; false otherwise.
+        /// at the current position and the new position is not already filled by some other item; false otherwise.
         /// </summary>
         /// <param name="currentX">X-value of the location to move items from.</param>
         /// <param name="currentY">Y-value of the location to move items from.</param>
@@ -590,20 +592,20 @@ namespace SadRogue.Primitives.SpatialMaps
 
         /// <summary>
         /// Moves the item at the specified source location to the target location.  Throws ArgumentException if one or
-        /// more items cannot be moved, eg.
-        /// if no item exists at the current position or the new position is already filled by some other item.
+        /// more items cannot be moved, eg. if no item exists at the current position or the new position is
+        /// already filled by some other item.
         /// </summary>
         /// <param name="current">Location to move items from.</param>
         /// <param name="target">Location to move items to.</param>
         public void MoveAll(Point current, Point target)
         {
-            if (current == target)
-                return;
-
             if (!_positionMapping.TryGetValue(current, out var item))
                 throw new ArgumentException(
                     $"Tried to move item from {current} in {GetType().Name}, but there was nothing at the that position.",
                     nameof(current));
+
+            if (current == target)
+                return;
 
             if (_positionMapping.ContainsKey(target))
                 throw new ArgumentException(
@@ -620,11 +622,11 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <inheritdoc/>
         public bool TryMoveAll(Point current, Point target)
         {
-            if (current == target)
-                return false;
-
             if (!_positionMapping.TryGetValue(current, out var item))
                 return false;
+
+            if (current == target)
+                return true;
 
             if (_positionMapping.ContainsKey(target))
                 return false;

--- a/TheSadRogue.Primitives/SpatialMaps/SpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/SpatialMap.cs
@@ -283,6 +283,8 @@ namespace SadRogue.Primitives.SpatialMaps
                     nameof(item));
             }
 
+            if (oldPos == target) return;
+
             try
             {
                 _positionMapping.Add(target, item);
@@ -313,6 +315,9 @@ namespace SadRogue.Primitives.SpatialMaps
         {
             if (!_itemMapping.TryGetValue(item, out Point oldPos))
                 return false;
+
+            if (oldPos == target)
+                return true;
 
             if (!_positionMapping.TryAdd(target, item))
                 return false;

--- a/TheSadRogue.Primitives/SpatialMaps/SpatialMap.cs
+++ b/TheSadRogue.Primitives/SpatialMaps/SpatialMap.cs
@@ -204,7 +204,7 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <remarks>
         /// Since this implementation guarantees that only one item can be at any given
         /// location at once, the return value is guaranteed to be at most one element. You may find it
-        /// more convenient to use the <see cref="GetItemsAt(Point)" /> function when you know you are
+        /// more convenient to use the <see cref="GetItem(Point)" /> function when you know you are
         /// dealing with a SpatialMap/AdvancedSpatialMap instance.
         /// </remarks>
         /// <param name="position">The position to return the item for.</param>
@@ -226,7 +226,7 @@ namespace SadRogue.Primitives.SpatialMaps
         /// <remarks>
         /// Since this implementation guarantees that only one item can be at any given
         /// location at once, the return value is guaranteed to be at most one element. You may find it
-        /// more convenient to use the <see cref="GetItemsAt(int, int)" /> function when you know you are
+        /// more convenient to use the <see cref="GetItem(int, int)" /> function when you know you are
         /// dealing with a SpatialMap/AdvancedSpatialMap instance.
         /// </remarks>
         /// <param name="x">The x-value of the position to return the item(s) for.</param>
@@ -598,9 +598,7 @@ namespace SadRogue.Primitives.SpatialMaps
         public void MoveAll(Point current, Point target)
         {
             if (current == target)
-                throw new ArgumentException(
-                    $"Tried to move all items from {current} in {GetType().Name}, but the current and target positions were the same.",
-                    nameof(target));
+                return;
 
             if (!_positionMapping.TryGetValue(current, out var item))
                 throw new ArgumentException(


### PR DESCRIPTION
# Changes
- Added `PropertyChangedEventHelpers` which contains a set of generic extension functions allowing easy, safe, and efficient implementation of properties which have a value changed and/or changing event.  Specifically:
    - No events are fired if the new value is the same as the old value
    - If `InvalidOperationException` is thrown by any event handler, the change will be reverted so that any handler of the exception will see the original value
- Added `IPositionable` interface, which defines a `Position` field as well as changing and changed events associated with that field.
    - This should be implemented by applicable classes, as implementing this interface enables support for things like auto-syncing spatial maps.
- `ISpatialMap.Move` functions (and other movement-related functions) are now "tolerant"; you may attempt to move an item or items to their own position without exception.
    - This is necessary to support syncing spatial maps and provides a more sensible interface
- Bugfix: `MoveAll` functions are guaranteed to not move items if some item can't move even for layered maps
- Bugfix: `TryMoveAll` for `LayeredSpatialMap` correctly uses layer mask
- Implemented "AutoSync" variations for all spatial maps (closes #116)
    - The type of objects stored in these variants _must_ implement `IPositionable`
    - To move one or more objects, you may either use the spatial map's move functions (any of them), or set the `Position` field of the object directly; in either case, the spatial map will remain in sync.

# Notes
A lot of methods of implementing these features have been discussed; however ultimately the implementation used here is rather simple (though tedious to test).  The basic concept is that an auto-syncing spatial map implements the same interface 
 as its manual counterpart, largely by forwarding to an internal (manually synced) spatial map's functions/properties.  When objects are added, an auto-syncing spatial map will subscribe a handler to those object's `PositionChanging` event which will, when the object moves, update the underlying spatial map, in turn throwing an exception if the underlying spatial map rejects the move.  The `Move` functions of auto-syncing spatial maps, in turn, will set the `Position` field of the objects accordingly.

This provides bidirectional syncing; if an object is moved via a auto-syncing spatial map's move function, its `Position` field is automatically updated, and if an object is moved via its position field, the underlying spatial map is updated as well.

Other ways of syncing spatial maps more exclusively with events, rather than a wrapper class, were attempted; however they proved complex and hard to reason about.  The current method's performance characteristics prioritize making `Move` and the setting of `Position` fields as close to their manual-syncing counterparts in terms of performance as possible, while sacrificing some speed in `MoveAll` (and to some extent `MoveValid`).  This seems to make sense as a general library implementation of synced spatial maps, because `Move` is far more common that `MoveAll` (in fact, `MoveAll` is usually entirely inviable when using spatial maps and manually syncing them, so the comparison there is not fair to begin with).  There is some performance impact, but it seems about what one would expect given the addition of event handlers.

Additionally, some generic extension functions are provided via the `PropertyChangedEventHelpers` class, which can apply to implementing pretty much any value that has "changed" and/or "changing" events.  Again, a relatively simplistic approach is taken to both these helpers and `IPositionable` specifically; no built-in event cancellation, no fancy handled logic, etc.  Again, this is something that I attempted; but trying to bake it into the implementation of events created situations that made assumptions on performance characteristics that simply weren't good for some uses cases; so I thought it best to leave those more complex use cases for the user to implement as needed with their own logic (and this is more efficient than doing it with a delegate directly anyway).

Overall, the goal here is to create a very flexible, very efficient implementation of auto-syncing spatial maps, while keeping `IPositionable` as minimal as possible not taking away any options from the user if they want to do syncing manually.

Testing this implementation is, unfortunately, quite troublesome.  Some basic unit tests have been added, but the test coverage is not ideal currently.   Since many of the function implementations across various auto-syncing variants use similar concepts, in theory there shouldn't be any major issues; but given that it is quite hard to test these in unit tests fully, my thinking is it is better to have a merge request and a release with the new feature, in order to get spatial maps (which are tested fairly comprehensively with GoRogue) into the primitives library.  At the very least, I have fairly high confidence the `IPositionable` interface shouldn't need to change; so it should be beneficial to have that interface merged in.

# Benchmarks
The entire performance benchmark list that pertains to spatial maps is, to say the least, lengthy (about 248 benchmarks and that's only testing the auto-syncing spatial map functions where large differences are likely to be seen).   As such, I won't include the entire list as a table; but it can be viewed [here](https://github.com/thesadrogue/TheSadRogue.Primitives/files/10986169/spatial.map.auto.sync.txt), for reference.

A couple general observations I made looking at the test results:
1. When using an `AutoSync` variant, setting the position via the `Move(T)` spatial map function vs setting the position via the `Position` field is identical in terms of performance.  Both are 30ns or so slower in the test cases compared to the manual-syncing variants (so about 15ns slower per call); while this is measurable, this overhead is trivial for most cases (and some overhead is unavoidable; more operations are being performed).
2. Despite taking advantage of various implementation-specific optimizations, `MoveAll` is 2-3x slower in auto-syncing variants.  This is due to a few constraints:
    - The implementation must keep track of what items it moved so it can update the `Position` field of those objects; this requires returning (and thus allocating) a list
    - Setting the position field of each object generates an event, which in turn generates a call to the underlying spatial map's `Move` function, wherein it must perform one dictionary lookup in order to determine that the object's position has already been updated.
It is possible that this could be more optimized in the future; but particularly since use cases for these types of functions are fairly uncommon with auto-syncing maps, I think the current implementation should be OK for many use cases.  Even in the worst cases, the overhead is a few hundred nanoseconds.
