### PR TITLE
Update deps version bump

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+**/*.key
+nuget/archive/

--- a/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
+++ b/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
+++ b/TheSadRogue.Primitives.MonoGame.UnitTests/TheSadRogue.Primitives.MonoGame.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" PrivateAssets="All" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -3,24 +3,22 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <!-- ReSharper disable once UnknownProperty -->
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Chris3606;Thraka</Authors>
     <Company>TheSadRogue</Company>
-    <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+    <Copyright>Copyright © 2025 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
     <Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with MonoGame's equivalents.</Description>
 
     <!-- More nuget package settings-->
     <PackageId>TheSadRogue.Primitives.MonoGame</PackageId>
     <PackageReleaseNotes>
-      - Changed MonoGame dependency to use the PrivateAssets tag.
-        - MonoGame is no longer implicitly installed when this NuGet package is.
-        - However, you can select the DX or OpenGL versions of MonoGame.
+      - Updated primitives library version targeted
     </PackageReleaseNotes>
     <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -44,7 +42,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" PrivateAssets="All" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0-rc3" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
+++ b/TheSadRogue.Primitives.MonoGame/TheSadRogue.Primitives.MonoGame.csproj
@@ -41,10 +41,10 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" PrivateAssets="All" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0-rc3" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
+++ b/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
+++ b/TheSadRogue.Primitives.PerformanceTests/TheSadRogue.Primitives.PerformanceTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
-    <PackageReference Include="ShaiRandom" Version="0.0.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
+    <PackageReference Include="ShaiRandom" Version="0.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
+++ b/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-    <PackageReference Include="xunit" Version="2.4.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
+++ b/TheSadRogue.Primitives.SFML.UnitTests/TheSadRogue.Primitives.SFML.UnitTests.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>8</LangVersion>
     <RootNamespace>SadRogue.Primitives.SFML.UnitTests</RootNamespace>
+    <!--
+    SFML 2.x is broken on .NET 8+; this is the best we can do. As long as nobody tries to build for unsupported
+    targets this shouldn't affect anything.
+    -->
+    <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -30,6 +30,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- 
+    SFML 2.x is broken on .NET 8+; this is the best we can do. As long as nobody tries to build for unsupported
+    targets this shouldn't affect anything.
+    -->
+    <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -3,22 +3,21 @@
 
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Chris3606;Thraka</Authors>
     <Company>TheSadRogue</Company>
-    <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+    <Copyright>Copyright © 2025 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
     <Description>A collection of extension methods that allow TheSadRogue.Primitives types to easily interface with SFML's equivalents.</Description>
 
     <!-- More nuget package settings-->
     <PackageId>TheSadRogue.Primitives.SFML</PackageId>
     <PackageReleaseNotes>
-      - IntRect Extensions
-        - Conversions to and from IntRect now assign the correct values for Width/Height
+      - Updated primitives library version targeted
     </PackageReleaseNotes>
     <RepositoryUrl>https://github.com/thesadrogue/TheSadRogue.Primitives</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -42,7 +41,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="SFML.Graphics" Version="2.6.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0-rc3" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -39,10 +39,10 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SFML.Graphics" Version="2.5.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="SFML.Graphics" Version="2.6.0" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0-rc3" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
+++ b/TheSadRogue.Primitives.SFML/TheSadRogue.Primitives.SFML.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="SFML.Graphics" Version="2.6.0" />
-    <PackageReference Include="TheSadRogue.Primitives" Version="1.6.0" />
+    <PackageReference Include="TheSadRogue.Primitives" Version="1.*" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
+++ b/TheSadRogue.Primitives.UnitTests.NonThreadSafe/TheSadRogue.Primitives.UnitTests.NonThreadSafe.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-    <PackageReference Include="xunit" Version="2.4.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
+++ b/TheSadRogue.Primitives.UnitTests.Shared/TestUtils.cs
@@ -11,7 +11,7 @@ namespace SadRogue.Primitives.UnitTests
     /// </summary>
     public static class TestUtils
     {
-        public static void Fail(string message) => Assert.True(false, message);
+        public static void Fail(string message) => Assert.Fail(message);
 
         public static IEnumerable<T> Yield<T>(this T obj)
         {

--- a/TheSadRogue.Primitives.UnitTests/AreaTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/AreaTests.cs
@@ -356,7 +356,7 @@ namespace SadRogue.Primitives.UnitTests
             var area = new Area(s_pointsToAdd);
             var notEquivalentArea = new Area(null, s_pointsToAdd[0], s_pointsToAdd[2], (2, 3));
             // Required for test case to be valid
-            Assert.DoesNotContain((2, 3), s_pointsToAdd);
+            Assert.DoesNotContain(new Point(2, 3), s_pointsToAdd);
 
             // Ensure this is a valid test case
             Assert.Equal(area.Count, notEquivalentArea.Count);

--- a/TheSadRogue.Primitives.UnitTests/ColorTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/ColorTests.cs
@@ -428,10 +428,10 @@ namespace SadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(NotEqualColors))]
         public void TestEqualityInequalityRelationship(Color testColor)
         {
-            Assert.Single(NotEqualColors.Where(i => i.Equals(testColor)));
-            Assert.Single(NotEqualColors.Where(i => i.Equals((object)testColor)));
-            Assert.Single(NotEqualColors.Where(i => i.Matches(testColor)));
-            Assert.Single(NotEqualColors.Where(i => i == testColor));
+            Assert.Single(NotEqualColors, i => i.Equals(testColor));
+            Assert.Single(NotEqualColors, i => i.Equals((object)testColor));
+            Assert.Single(NotEqualColors, i => i.Matches(testColor));
+            Assert.Single(NotEqualColors, i => i == testColor);
         }
 
         [Theory]

--- a/TheSadRogue.Primitives.UnitTests/GradientTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GradientTests.cs
@@ -53,10 +53,10 @@ namespace SadRogue.Primitives.UnitTests
         [MemberDataEnumerable(nameof(SampleStops))]
         public void TestEqualityInequalityRelationship(GradientStop testStop)
         {
-            Assert.Single(SampleStops.Where(i => i.Equals(testStop)));
-            Assert.Single(SampleStops.Where(i => i.Matches(testStop)));
-            Assert.Single(SampleStops.Where(i => i.Equals((object)testStop)));
-            Assert.Single(SampleStops.Where(i => i == testStop));
+            Assert.Single(SampleStops, i => i.Equals(testStop));
+            Assert.Single(SampleStops, i => i.Matches(testStop));
+            Assert.Single(SampleStops, i => i.Equals((object)testStop));
+            Assert.Single(SampleStops, i => i == testStop);
             foreach (var other in SampleStops)
             {
                 Assert.Equal(!(testStop == other), testStop != other);

--- a/TheSadRogue.Primitives.UnitTests/GridViews/DiffAwareGridViewTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/GridViews/DiffAwareGridViewTests.cs
@@ -448,7 +448,9 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             view[1, 0] = 2;
             view[1, 0] = 1;
             view.RevertToPreviousDiff();
+#pragma warning disable xUnit2013
             Assert.Equal(1, view.Diffs.Count);
+#pragma warning restore xUnit2013
         }
 
         [Fact]
@@ -466,7 +468,9 @@ namespace SadRogue.Primitives.UnitTests.GridViews
             view[1, 0] = 2;
             view[1, 0] = 1;
             view.FinalizeCurrentDiff();
+#pragma warning disable xUnit2013
             Assert.Equal(1, view.Diffs.Count);
+#pragma warning restore xUnit2013
             foreach (var pos in arrayView.Positions())
                 Assert.Equal(arrayView[pos], view[pos]);
         }

--- a/TheSadRogue.Primitives.UnitTests/PolarCoordinateTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/PolarCoordinateTests.cs
@@ -131,13 +131,13 @@ namespace SadRogue.Primitives.UnitTests
         {
             (double radius, double delta) tuple = (s_equalPolar.Radius, s_equalPolar.Theta);
 
-            Assert.Single(TestCoordinates.Where(i => i.Equals(testCoordinate)));
-            Assert.Single(TestCoordinates.Where(i => i.Matches(testCoordinate)));
-            Assert.Single(TestCoordinates.Where(i => i.Equals((object)testCoordinate)));
-            Assert.Single(TestCoordinates.Where(i => i == testCoordinate));
-            Assert.Single(TestCoordinates.Where(i => i.Equals(tuple)));
-            Assert.Single(TestCoordinates.Where(i => i.Matches(tuple)));
-            Assert.Single(TestCoordinates.Where(i => i == tuple));
+            Assert.Single(TestCoordinates, i => i.Equals(testCoordinate));
+            Assert.Single(TestCoordinates, i => i.Matches(testCoordinate));
+            Assert.Single(TestCoordinates, i => i.Equals((object)testCoordinate));
+            Assert.Single(TestCoordinates, i => i == testCoordinate);
+            Assert.Single(TestCoordinates, i => i.Equals(tuple));
+            Assert.Single(TestCoordinates, i => i.Matches(tuple));
+            Assert.Single(TestCoordinates, i => i == tuple);
 
             // Test equality and inequality relationship, also across operators (lhs and rhs types)
             foreach (var other in TestCoordinates)

--- a/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
+++ b/TheSadRogue.Primitives.UnitTests/RectangleTests.cs
@@ -324,8 +324,8 @@ namespace SadRogue.Primitives.UnitTests
                 yLocations.Add(actual.MaxExtentY);
             }
 
-            Assert.Empty(xLocations.Where(location => location < dividend.MinExtentX || location > dividend.MaxExtentX ));
-            Assert.Empty(yLocations.Where(location => location < dividend.MinExtentY || location > dividend.MaxExtentY ));
+            Assert.DoesNotContain(xLocations, location => location < dividend.MinExtentX || location > dividend.MaxExtentX);
+            Assert.DoesNotContain(yLocations, location => location < dividend.MinExtentY || location > dividend.MaxExtentY);
         }
 
         [Fact]

--- a/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
+++ b/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
+++ b/TheSadRogue.Primitives.UnitTests/TheSadRogue.Primitives.UnitTests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -36,10 +36,10 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1">
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Basic package info -->
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
+++ b/TheSadRogue.Primitives/TheSadRogue.Primitives.csproj
@@ -5,11 +5,11 @@
     <RootNamespace>SadRogue.Primitives</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.6.0-rc3</Version>
+    <Version>1.6.0</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Chris3606;Thraka</Authors>
     <Company>TheSadRogue</Company>
-    <Copyright>Copyright © 2023 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
+    <Copyright>Copyright © 2025 [Christopher Ridley (Chris3606) and TheSadRogue Steve De George JR (Thraka)]</Copyright>
     <Description>A collection of primitive data structures for working with a 2-dimensional grid.</Description>
 
     <!-- More nuget package settings-->

--- a/nuget/build.ps1
+++ b/nuget/build.ps1
@@ -1,0 +1,87 @@
+# Configuration
+$scriptDir = $PSScriptRoot
+$rootDir = Join-Path $scriptDir ".."
+$archive = Join-Path $scriptDir archive
+$corePackage = "TheSadRogue.Primitives"
+$dependentPackages = @("TheSadRogue.Primitives.MonoGame", "TheSadRogue.Primitives.SFML")
+$nugetKeyPath = Join-Path $scriptDir "nuget.key"
+
+# Delete any NuGet packages not moved to archive
+Write-Output "Removing old nupkg files"
+Remove-Item "$scriptDir\*.nupkg","$scriptDir\*.snupkg" -Force
+
+# Make sure archive directory exists
+if(!(Test-Path $archive))
+{
+    New-Item -Path $archive -ItemType Directory -Force | Out-Null
+}
+
+# Build core package
+Write-Output "Building $corePackage Debug and Release"
+$output = Invoke-Expression "dotnet build $rootDir\$corePackage\$corePackage.csproj -c Debug --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+$output = Invoke-Expression "dotnet build $rootDir\$corePackage\$corePackage.csproj -c Release --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+
+# Find the version we're using
+$version = (Get-Content $rootDir\$corePackage\$corePackage.csproj | Select-String "<Version>(.*)<").Matches[0].Groups[1].Value
+$nugetKey = Get-Content $nugetKeyPath
+Write-Output "Target $coreProjectVersion version is $version"
+
+# Push packages to nuget
+Write-Output "Pushing $corePackage packages"
+$corePackages = Get-ChildItem "$corePackage.*.nupkg" | Select-Object -ExpandProperty Name
+
+foreach ($package in $corePackages) {
+    $output = Invoke-Expression "dotnet nuget push `"$package`" -s nuget.org -k $nugetKey --skip-duplicate"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+}
+
+Write-Output "Query NuGet for 10 minutes to find the new package"
+
+$timeout = New-TimeSpan -Minutes 10
+$timer = [Diagnostics.StopWatch]::StartNew()
+[Boolean]$foundPackage = $false
+
+# Loop searching for the new SadConsole package
+while ($timer.elapsed -lt $timeout){
+
+    $existingVersions = (Invoke-WebRequest "https://api-v2v3search-0.nuget.org/query?q=PackageId:$corePackage&prerelease=true").Content | ConvertFrom-Json
+
+    if ($existingVersions.totalHits -eq 0) {
+        throw "Unable to get any results from NuGet"
+    }
+
+    if ($null -eq ($existingVersions.data.versions | Where-Object version -eq $version)) {
+        Write-Output "Waiting 30 seconds to retry..."
+        Start-Sleep -Seconds 30
+		
+    }
+    else {
+        Write-Output "Found package. Waiting 1 extra minute to let things settle"
+        $foundPackage = $true
+        Start-Sleep -Seconds 60
+        break
+    }
+}
+
+# Found the core package, start building and pushing the other packages
+if ($foundPackage){
+
+    foreach ($project in $dependentPackages) {
+        # Build package
+        Write-Output "Building $project Debug and Release"
+        $output = Invoke-Expression "dotnet build $rootDir\$project\$project.csproj -c Debug -p:UseProjectReferences=false --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+        $output = Invoke-Expression "dotnet build $rootDir\$project\$project.csproj -c Release -p:UseProjectReferences=false --no-cache"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+
+        # Push packages to nuget
+        Write-Output "Pushing $project packages"
+        $packages = Get-ChildItem "$project*.nupkg" | Select-Object -ExpandProperty Name
+
+        foreach ($package in $packages) {
+            $output = Invoke-Expression "dotnet nuget push `"$package`" -s nuget.org -k $nugetKey --skip-duplicate"; if ($LASTEXITCODE -ne 0) { Write-Error "Failed"; Write-Output $output; throw }
+        }
+    }
+
+    # Archive the packages
+    Move-Item "$scriptDir\*.nupkg","$scriptDir\*.snupkg" $archive -force
+} else {
+    Write-Error "$corePackage didn't appear on NuGet within 10 minutes."
+}

--- a/nuget/push.bat
+++ b/nuget/push.bat
@@ -1,2 +1,0 @@
-nuget push TheSadRogue.Primitives.%1-debug.nupkg -Source https://api.nuget.org/v3/index.json
-nuget push TheSadRogue.Primitives.%1.nupkg -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
- Updated dependencies
- Updated copyright
- Prep for 1.6.0 release

I changed the version numbers of the primitives library package referenced in the MonoGame and SFML package, so it won't build as-is until after deployment.